### PR TITLE
Fix sound pitch degrading to integer steps with small audio buffers

### DIFF
--- a/src/libs/audio.cpp
+++ b/src/libs/audio.cpp
@@ -163,12 +163,17 @@ void AudioEngine::mix(float* out, unsigned int framesPerBuffer, AudioEngine* eng
         unsigned long frames_to_process = framesPerBuffer;
         unsigned long output_index = 0;
         bool still_playing = true;
-        float frame_f = (float)frame;
+        // Track the position as integer frame + fractional remainder. The
+        // fraction must survive across mix() calls, otherwise non-integer
+        // pitches degrade toward trunc(pitch) as the buffer size shrinks
+        // (at buffer_size=1, pitch 0.9 never advances and 1.5 plays at 1.0).
+        double frame_f = (double)frame
+                       + std::atomic_ref<float>(snd.frame_frac).load(std::memory_order_relaxed);
 
         while (frames_to_process > 0 && still_playing) {
             unsigned long src_frame = (unsigned long)frame_f;
             if (src_frame >= snd.frame_count) {
-                if (snd.loop) { frame_f = 0.0f; continue; }
+                if (snd.loop) { frame_f = 0.0; continue; }
                 else { still_playing = false; break; }
             }
 
@@ -196,6 +201,7 @@ void AudioEngine::mix(float* out, unsigned int framesPerBuffer, AudioEngine* eng
         }
         frame = (unsigned int)frame_f;
 
+        std::atomic_ref<float>(snd.frame_frac).store((float)(frame_f - (double)frame), std::memory_order_relaxed);
         aref_frame.store(frame, std::memory_order_relaxed);
         if (!still_playing)
             aref_playing.store(false, std::memory_order_release);
@@ -672,6 +678,7 @@ std::string AudioEngine::load_sound(const fs::path& file_path, const std::string
             snd.volume = 1.0f;
             snd.pan    = 0.5f;
             snd.pitch  = 1.0f;
+            snd.frame_frac = 0.0f;
             if ((double)ff_rate != target_sample_rate) {
                 double ratio = target_sample_rate / (double)ff_rate;
                 long out_frames = (long)(ff_frames * ratio) + 1;
@@ -724,6 +731,7 @@ std::string AudioEngine::load_sound(const fs::path& file_path, const std::string
         snd.volume = 1.0f;
         snd.pan = 0.5f;
         snd.pitch = 1.0f;
+        snd.frame_frac = 0.0f;
 
         if (snd.sample_rate != target_sample_rate) {
             double ratio = target_sample_rate / (double)snd.sample_rate;
@@ -877,6 +885,7 @@ void AudioEngine::play_sound(const std::string& name, VolumePreset volume_preset
         }
 
         std::atomic_ref<unsigned int>(snd.current_frame).store(0, std::memory_order_relaxed);
+        std::atomic_ref<float>(snd.frame_frac).store(0.0f, std::memory_order_relaxed);
         std::atomic_ref<bool>(snd.is_playing).store(true, std::memory_order_release);
     } else {
         //spdlog::warn("Sound {} not found", name);
@@ -889,6 +898,7 @@ void AudioEngine::stop_sound(const std::string& name) {
     if (it != sounds.end()) {
         std::atomic_ref<bool>(it->second.is_playing).store(false, std::memory_order_relaxed);
         std::atomic_ref<unsigned int>(it->second.current_frame).store(0, std::memory_order_relaxed);
+        std::atomic_ref<float>(it->second.frame_frac).store(0.0f, std::memory_order_relaxed);
     } else {
         spdlog::warn("Sound {} not found", name);
     }
@@ -953,6 +963,7 @@ void AudioEngine::seek_sound(const std::string& name, float position) {
         sound& snd = it->second;
         unsigned int frame = static_cast<unsigned int>(std::max(position, 0.0f) * static_cast<float>(target_sample_rate));
         std::atomic_ref<unsigned int>(snd.current_frame).store(std::min(frame, snd.frame_count), std::memory_order_relaxed);
+        std::atomic_ref<float>(snd.frame_frac).store(0.0f, std::memory_order_relaxed);
     } else {
         spdlog::warn("Sound {} not found", name);
     }

--- a/src/libs/audio.h
+++ b/src/libs/audio.h
@@ -64,6 +64,7 @@ struct sound {
 
     bool is_playing;                // Whether the sound is currently playing
     unsigned int current_frame;     // Current playback position in frames
+    float frame_frac;               // Fractional part of playback position (for pitch != 1.0)
     bool loop;                      // Whether to loop the sound
 
     float volume;                   // Volume multiplier (0.0 to 1.0+)


### PR DESCRIPTION
## Problem

Practice mode's song speed control silently misbehaves depending on the configured audio buffer size. With a small `buffer_size` in `config.toml`:

- **0.1x–0.9x**: the song freezes at the current position (playback never advances)
- **1.1x–1.9x**: plays at exactly 1.0x even though the displayed multiplier changes
- **integer speeds (2.0x, 3.0x, ...)**: work correctly

This made it look like practice speed change was entirely broken, since only whole-number speeds had any audible effect.

## Root cause

In `AudioEngine::mix()`, the playback cursor is advanced in a local `float frame_f` by `pitch` per output frame, then stored back into `sound::current_frame` (an `unsigned int`) at the end of the callback:

```cpp
float frame_f = (float)frame;
...
frame_f += pitch;          // per output frame
...
frame = (unsigned int)frame_f;   // fraction discarded every callback
```

The fractional part is truncated once per callback, so the error scales with callback frequency. With `buffer_size = 128` the fraction is only lost once per 128 frames (inaudible drift), but as the buffer shrinks the effective pitch collapses toward `trunc(pitch)`. At `buffer_size = 1` it degenerates completely: pitch 0.9 advances `trunc(0.9) = 0` frames per callback (frozen), pitch 1.5 advances exactly 1 (plays at 1.0x), and only integer pitches survive — matching the symptoms above exactly.

## Fix

- Persist the fractional position in a new `sound::frame_frac` field so it accumulates across `mix()` calls.
- Do the position math in `double`: `float` has a 24-bit mantissa, so absolute-position arithmetic starts dropping sub-frame increments after a few minutes of audio at 44.1 kHz.
- Reset the fraction on `play_sound` / `seek_sound` / `stop_sound`, alongside `current_frame`.

The field is read/written with the same `std::atomic_ref` pattern as the other mixer-shared fields (only the audio thread writes it during playback; control-thread resets are racless in practice since they accompany a `current_frame` reset).

## Test environment

- Windows 11 Pro 24H2 (build 26100), self-built with MSYS2 MinGW64 (GCC 16.2), current master (5f49b62)
- `config.toml`: `device_type = 4`, `buffer_size = 1`, `sample_rate = 44100` — the 1-frame buffer is what exposed the truncation at full strength
- Verified in practice mode: 0.5x/0.9x no longer freeze, 1.1x–1.9x now audibly change speed, 2.0x behaves the same as before; normal (non-practice) playback and hitsounds unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
