### PR TITLE
Swap practice-mode tempo icons to match key behavior

### DIFF
--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -414,8 +414,12 @@ void PracticeGameScreen::draw() {
         tex.draw_texture(PRACTICE::SKIP_L_KAT,  {.scale = skip_l_kat_anim  ? (float)skip_l_kat_anim->attribute  : 1.0f, .center = true, .index = player_idx * 2});
         tex.draw_texture(PRACTICE::SKIP_R_KAT,  {.scale = skip_r_kat_anim  ? (float)skip_r_kat_anim->attribute  : 1.0f, .center = true, .index = player_idx * 2 + 1});
         tex.draw_texture(PRACTICE::MENU_DON,    {.scale = menu_don_anim    ? (float)menu_don_anim->attribute    : 1.0f, .center = true, .index = other_idx});
-        tex.draw_texture(PRACTICE::SPEED_L_KAT, {.scale = speed_l_kat_anim ? (float)speed_l_kat_anim->attribute : 1.0f, .center = true, .index = other_idx * 2});
-        tex.draw_texture(PRACTICE::SPEED_R_KAT, {.scale = speed_r_kat_anim ? (float)speed_r_kat_anim->attribute : 1.0f, .center = true, .index = other_idx * 2 + 1});
+        // The skin's speed_l_kat sprite reads 速 (faster) and speed_r_kat reads
+        // 遅 (slower), but left kat lowers the tempo and right kat raises it
+        // (matching measure skip: left = back, right = forward). Draw the
+        // sprites swapped so the icons match what the keys actually do (#89).
+        tex.draw_texture(PRACTICE::SPEED_R_KAT, {.scale = speed_l_kat_anim ? (float)speed_l_kat_anim->attribute : 1.0f, .center = true, .index = other_idx * 2});
+        tex.draw_texture(PRACTICE::SPEED_L_KAT, {.scale = speed_r_kat_anim ? (float)speed_r_kat_anim->attribute : 1.0f, .center = true, .index = other_idx * 2 + 1});
     }
 
     if (!paused) {


### PR DESCRIPTION
Fixes #89

## Problem

On the practice-mode paused screen, the tempo icons are reversed relative to what the keys actually do: the left kat slot shows 速 (faster) and the right slot shows 遅 (slower), but pressing the other player's **left** kat *lowers* `song_speed` and the **right** kat *raises* it (`global_keys_practice()` in `game_practice.cpp`).

## Fix

Keep the input behavior (left = slower / right = faster is consistent with the measure-skip binding, where left kat goes back a measure and right kat goes forward) and draw the two sprites swapped, so 遅 appears in the left slot and 速 in the right slot. The pulse animations stay bound to the pressed key, so the icon that flashes is still the one for the key you hit.

The root cause is arguably that PyTaikoGreen's `speed_l_kat.png` / `speed_r_kat.png` contain each other's artwork — if you'd rather fix it skin-side by swapping the two images, feel free to close this in favor of that; this PR fixes it in code so every checkout of the current skin revision shows the right thing.

## Verification

Confirmed the mismatch at the source: `Skins/PyTaikoGreen/Graphics/game/practice/speed_l_kat.png` contains the 速 artwork and `speed_r_kat.png` contains 遅, while the code binds left kat to `song_speed - 1` and right kat to `song_speed + 1`. Both sprites share the same position table in `texture.json` (indexed `other_idx * 2` / `+ 1`), so swapping the texture ids swaps only which slot each sprite is drawn in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
