### PR TITLE
Fix mirrored slide animations in neiro and option selectors

### DIFF
--- a/src/objects/song_select/modifier.cpp
+++ b/src/objects/song_select/modifier.cpp
@@ -122,15 +122,17 @@ void ModifierSelector::left() {
     if (is_confirmed) return;
     const std::string& mod_name = MOD_NAMES[current_mod_index];
 
+    // dir is the on-screen slide direction (see NeiroSelector): pressing left
+    // scrolls the content rightward so the previous value enters from the left.
     if (mod_name == "speed") {
         player->modifier_speed = std::max(1, player->modifier_speed - 1);
-        start_text_animation(-1);
+        start_text_animation(1);
     } else if (mod_name == "random") {
         player->modifier_random = std::max(0, player->modifier_random - 1);
-        start_text_animation(-1);
+        start_text_animation(1);
     } else {
         set_bool(current_mod_index, !get_bool(current_mod_index));
-        start_text_animation(-1);
+        start_text_animation(1);
     }
 }
 
@@ -140,13 +142,13 @@ void ModifierSelector::right() {
 
     if (mod_name == "speed") {
         player->modifier_speed += 1;
-        start_text_animation(1);
+        start_text_animation(-1);
     } else if (mod_name == "random") {
         player->modifier_random = (player->modifier_random + 1) % 3;
-        start_text_animation(1);
+        start_text_animation(-1);
     } else {
         set_bool(current_mod_index, !get_bool(current_mod_index));
-        start_text_animation(1);
+        start_text_animation(-1);
     }
 }
 

--- a/src/objects/song_select/neiro.cpp
+++ b/src/objects/song_select/neiro.cpp
@@ -63,7 +63,10 @@ void NeiroSelector::left() {
     text = std::move(text_2);
     text_2 = std::make_unique<OutlinedText>(sounds[selected_sound], tex.skin_config[SC::NEIRO_TEXT].font_size, ray::WHITE, ray::BLACK, false);
 
-    direction = -1;
+    // direction is the on-screen slide direction of the texts: pressing left
+    // scrolls the content rightward so the previous value enters from the
+    // left edge (the incoming text is placed at direction * -OPTION_TEXT_IN.x).
+    direction = 1;
     if (selected_sound == (int)sounds.size() - 1) return;
     audio.play_sound(curr_sound, VolumePreset::HITSOUND);
 }
@@ -79,7 +82,7 @@ void NeiroSelector::right() {
     text = std::move(text_2);
     text_2 = std::make_unique<OutlinedText>(sounds[selected_sound], tex.skin_config[SC::NEIRO_TEXT].font_size, ray::WHITE, ray::BLACK, false);
 
-    direction = 1;
+    direction = -1;
     if (selected_sound == (int)sounds.size() - 1) return;
     audio.play_sound(curr_sound, VolumePreset::HITSOUND);
 }


### PR DESCRIPTION
Fixes #91

## Problem

In the song-select neiro (hitsound) selector and the option (modifier) menu, pressing **right** plays the left-press slide animation and vice versa: the incoming value slides in from the opposite side of the key you pressed.

## Cause

Both `NeiroSelector` and `ModifierSelector` set `direction = -1` in `left()` and `+1` in `right()`. The draw code places the incoming text at `direction * -OPTION_TEXT_IN.x` and slides both texts by `move_sideways->attribute * direction`, so with those signs the incoming item starts on the wrong side: press right → new value enters from the left.

## Fix

Flip the sign in both selectors (left → `+1`, right → `-1`) so `direction` consistently means the on-screen slide direction of the content: pressing right scrolls the content leftward and the next value enters from the right edge. No other behavior changes; the fade/move animations are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)