### PR TITLE
Block navigation while an inline collection is still streaming in

### DIFF
--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -270,6 +270,7 @@ void Navigator::flush_pending_boxes() {
         set_positions(false, 800);
         if (!items.empty()) items[open_index]->expand_box();
         is_processing = false;
+        inline_streaming = false;
         loading_complete = false;
     }
 }
@@ -1079,7 +1080,7 @@ void Navigator::set_positions(bool init, float duration) {
 }
 
 void Navigator::navigate(int delta, bool snap) {
-    if (items.empty()) return;
+    if (items.empty() || inline_streaming) return;
     items[open_index]->close_box();
     last_bg_genre_index = bg_genre_index;
     open_index = ((open_index + delta) % (int)items.size() + (int)items.size()) % (int)items.size();
@@ -1171,6 +1172,7 @@ void Navigator::update(double current_ms) {
             inline_state->songs_count = 0; // will be updated as boxes arrive
             pending_inline_path.reset();
             is_processing = false; // flush_pending_boxes will finalise
+            inline_streaming = true;
         }
     }
 

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -97,6 +97,12 @@ public:
     ~Navigator();
 
     bool is_processing = false;
+    // True while an inline collection (RECOMMENDED, etc.) is still streaming
+    // boxes in from the loader thread. is_processing is deliberately false
+    // during that window so the flush can finalise, but navigation must stay
+    // blocked: the completion step sorts and repositions items around
+    // open_index, so moving the selection mid-load corrupts the display.
+    bool inline_streaming = false;
     fs::path current_path;
     std::string current_search;
 

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -102,7 +102,7 @@ void SongSelectScreen::poll_song_jump(double current_ms) {
 }
 
 void SongSelectScreen::handle_input(double current_ms) {
-    if (navigator.is_processing) {
+    if (navigator.is_processing || navigator.inline_streaming) {
         clear_input_buffers();
         return;
     }


### PR DESCRIPTION
Fixes #93

## Problem

Opening an inline collection such as **Recommended** streams its boxes in from a background loader. `Navigator::update()` deliberately sets `is_processing = false` right after spawning the loader ("flush_pending_boxes will finalise"), which also reopens the song-select input gate - so left/right kat works while songs are still arriving, and the completion step (sort of the inserted range + `set_positions` + `expand_box(items[open_index])`) then runs against a selection that moved out from under it, corrupting the display.

## Fix

Add an `inline_streaming` flag that covers exactly the window between spawning the inline loader and the `loading_complete` finalisation in `flush_pending_boxes`:

- `SongSelectScreen::handle_input` treats it like `is_processing` (input ignored, buffers cleared)
- `Navigator::navigate()` guards on it directly, so other entry points (Lua script bindings, web song jump) can't move the selection mid-load either

Collections load ~10 songs, so the blocked window is a fraction of a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)