### PR TITLE
Fix P2 practice-mode score popups animating toward the bottom lane

### DIFF
--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -958,7 +958,7 @@ void Player::note_correct(const Note& note, double current_ms) {
         }
         if (combo % 100 == 0 && score_method == ScoreMethod::GEN3) {
             score += 10000;
-            base_score_list.push_back(ScoreCounterAnimation(player_num, 10000));
+            base_score_list.push_back(ScoreCounterAnimation(player_num, 10000, is_2p));
         }
     }
 
@@ -981,7 +981,7 @@ void Player::check_drumroll(double current_ms, DrumType drum_type, std::optional
     if (background.has_value()) background->handle_drumroll(PlayerNum(is_2p + 1));
     score += 100;
     if (base_score_list.size() < 5) {
-        base_score_list.push_back(ScoreCounterAnimation(player_num, 100));
+        base_score_list.push_back(ScoreCounterAnimation(player_num, 100, is_2p));
     }
     if (draw_note_buffer.empty()) return;
     if (!other_notes.empty()) {
@@ -1007,7 +1007,7 @@ void Player::check_balloon(double current_ms, DrumType drum_type, const Note& ba
     curr_balloon_count++;
     total_drumroll++;
     score += 100;
-    base_score_list.push_back(ScoreCounterAnimation(player_num, 100));
+    base_score_list.push_back(ScoreCounterAnimation(player_num, 100, is_2p));
     if (curr_balloon_count == balloon.count.value()) {
         is_balloon = false;
         balloon_counter->update(current_ms, curr_balloon_count);
@@ -1026,7 +1026,7 @@ void Player::check_kusudama(double current_ms, DrumType drum_type, const Note& b
     curr_balloon_count++;
     total_drumroll++;
     score += 100;
-    base_score_list.push_back(ScoreCounterAnimation(player_num, 100));
+    base_score_list.push_back(ScoreCounterAnimation(player_num, 100, is_2p));
     if (curr_balloon_count == balloon.count.value()) {
         is_balloon = false;
         audio.play_sound("kusudama_pop", VolumePreset::HITSOUND);
@@ -1097,7 +1097,7 @@ void Player::check_note(double ms_from_start, DrumType drum_type, double current
             good_count++;
             score += base_score;
             if (base_score_list.size() < 5) {
-                base_score_list.push_back(ScoreCounterAnimation(player_num, base_score));
+                base_score_list.push_back(ScoreCounterAnimation(player_num, base_score, is_2p));
             }
             note_correct(curr_note, current_ms);
             if (dan_gauge) dan_gauge->add_good();
@@ -1112,7 +1112,7 @@ void Player::check_note(double ms_from_start, DrumType drum_type, double current
             ok_count++;
             score += 10 * std::floor(base_score / 2 / 10);
             if (base_score_list.size() < 5) {
-                base_score_list.push_back(ScoreCounterAnimation(player_num, 10 * std::floor(base_score / 2 / 10)));
+                base_score_list.push_back(ScoreCounterAnimation(player_num, 10 * std::floor(base_score / 2 / 10), is_2p));
             }
             note_correct(curr_note, current_ms);
             if (dan_gauge) dan_gauge->add_ok();
@@ -1169,7 +1169,7 @@ void Player::balloon_counter_manager(double current_ms) {
         if (balloon_counter->is_finished()) {
             if (score_method == ScoreMethod::GEN3) {
                 score += 5000;
-                base_score_list.push_back(ScoreCounterAnimation(player_num, 5000));
+                base_score_list.push_back(ScoreCounterAnimation(player_num, 5000, is_2p));
             }
             balloon_counter.reset();
             chara->set_anim(AnimIndex::DON_NORMAL);

--- a/src/objects/game/score_counter_animation.cpp
+++ b/src/objects/game/score_counter_animation.cpp
@@ -1,8 +1,8 @@
 #include "score_counter_animation.h"
 #include "../../libs/texture.h"
 
-ScoreCounterAnimation::ScoreCounterAnimation(PlayerNum player_num, int counter) : counter(counter) {
-    direction = 1;
+ScoreCounterAnimation::ScoreCounterAnimation(PlayerNum player_num, int counter, bool is_2p) : counter(counter) {
+    direction = is_2p ? -1 : 1;
     counter_str = std::to_string(counter);
     margin = tex.skin_config[SC::SCORE_COUNTER_MARGIN].x;
     total_width = counter_str.length() * margin;
@@ -24,7 +24,6 @@ ScoreCounterAnimation::ScoreCounterAnimation(PlayerNum player_num, int counter) 
 
     if (player_num == PlayerNum::P2) {
         base_color = ray::Color{84, 250, 238, 255};
-        direction = -1;
     } else {
         base_color = ray::Color{254, 102, 0, 255};
     }

--- a/src/objects/game/score_counter_animation.h
+++ b/src/objects/game/score_counter_animation.h
@@ -21,7 +21,10 @@ private:
     std::vector<float> y_pos_list;
 
 public:
-    ScoreCounterAnimation(PlayerNum player_num, int counter);
+    // player_num picks the popup color (player identity); is_2p picks the
+    // animation direction (lane layout). They differ in practice mode, where
+    // a P2 player still plays on the top (1P-positioned) lane.
+    ScoreCounterAnimation(PlayerNum player_num, int counter, bool is_2p);
 
     void update(double current_ms);
     void draw(float y);

--- a/src/objects/sandbox/fixtures.h
+++ b/src/objects/sandbox/fixtures.h
@@ -679,7 +679,7 @@ struct ScoreCounterAnimFixture : public SandboxScreen::Fixture {
     uint32_t anchor_texture_id() override { return LANE::SCORE_NUMBER; }
 
     void reset(double) override { active.reset(); type_idx = 0; }
-    void on_space(double) override { active.emplace(PlayerNum::P1, scores[type_idx]); }
+    void on_space(double) override { active.emplace(PlayerNum::P1, scores[type_idx], false); }
 
     void update(double ms) override {
         if (active && active->is_finished()) active.reset();


### PR DESCRIPTION
## Problem

Entering practice mode as **2P** makes the score-gain popups (+100 etc.) animate downward, ending up below the lane, instead of upward like for 1P - even though practice mode always draws the lane in the top (1P) position.

## Cause

`ScoreCounterAnimation` derives both its **color** and its **animation direction** from `player_num`. Those are different concerns: the color is player identity (orange/cyan), the direction is lane layout. Practice mode creates the player with `is_2p = false` (top lane) but a real `player_num` of P2, so the popups still flew in the 2P direction with the 2P offset.

## Fix

Add an explicit `is_2p` parameter to `ScoreCounterAnimation` and take the direction from it - the same flag the rest of `Player` already uses for lane-layout decisions (chara position, combo announce offset, note arcs) - while the color stays keyed to `player_num`, so a P2 player keeps cyan popups on the top lane.

## Verified

Compiles clean; in practice mode as 2P the popups now rise above the lane like 1P, and normal 2P versus mode is unchanged (`is_2p` is true there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)