### PR TITLE
Fix Windows crash from mixed CRT linking; add missing <cmath> includes

### DIFF
--- a/cmake/platform.cmake
+++ b/cmake/platform.cmake
@@ -18,7 +18,6 @@ if(WIN32)
         bcrypt
         secur32
         ws2_32
-        ucrtbase
         msvcrt
         dbghelp
     )

--- a/src/libs/animation.cpp
+++ b/src/libs/animation.cpp
@@ -1,6 +1,7 @@
 #include "animation.h"
 #include "global_data.h"
 #include "rapidjson/error/en.h"
+#include <cmath>
 
 using std::runtime_error;
 

--- a/src/libs/parsers/osu.cpp
+++ b/src/libs/parsers/osu.cpp
@@ -1,5 +1,6 @@
 #include "osu.h"
 #include <fstream>
+#include <cmath>
 
 std::vector<std::string> OsuParser::read_file_lines(const fs::path& path) {
     std::vector<std::string> lines;

--- a/src/objects/game/combo.cpp
+++ b/src/objects/game/combo.cpp
@@ -1,7 +1,7 @@
 #include "combo.h"
 #include "../../libs/texture.h"
 #include "../../libs/global_data.h"
-#include <math.h>
+#include <cmath>
 
 Combo::Combo(int combo, double current_ms)
     : combo(combo) {

--- a/src/objects/game/judge_counter.cpp
+++ b/src/objects/game/judge_counter.cpp
@@ -1,6 +1,6 @@
 #include "../../libs/texture.h"
 #include "judge_counter.h"
-#include <math.h>
+#include <cmath>
 
 
 JudgeCounter::JudgeCounter()

--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -2,6 +2,7 @@
 #include "../../libs/audio.h"
 #include "../../libs/input.h"
 #include "../../libs/scores.h"
+#include <cmath>
 
 Player::Player(std::optional<SongParser>& parser_ref, PlayerNum player_num_param, int difficulty_param,
        bool is_2p_param, const Modifiers& modifiers_param)

--- a/src/objects/song_select/file_navigator/box_song.h
+++ b/src/objects/song_select/file_navigator/box_song.h
@@ -3,6 +3,7 @@
 #include "box_base.h"
 #include "score_history.h"
 #include "../../../libs/song_parser.h"
+#include <cmath>
 
 class SongBox : public BaseBox {
 public:

--- a/src/objects/song_select/file_navigator/color_utils.cpp
+++ b/src/objects/song_select/file_navigator/color_utils.cpp
@@ -1,6 +1,6 @@
 #include "color_utils.h"
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 #include <stdexcept>
 
 float rgb_to_hue(int r, int g, int b) {

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -5,6 +5,7 @@
 #include "../song_select_script.h"
 #include "../../../libs/filesystem.h"
 #include <random>
+#include <cmath>
 
 static std::unique_ptr<SongBox> make_song_box(const fs::path& path, const BoxDef& box_def, SongParser parser) {
     if (path.extension() == ".osu")

--- a/src/scenes/dan_select.cpp
+++ b/src/scenes/dan_select.cpp
@@ -4,6 +4,7 @@
 #include "../objects/song_select/file_navigator/navigator.h"
 #include "../libs/filesystem.h"
 #include <filesystem>
+#include <cmath>
 
 int DanNavigator::total_notes_for(const std::vector<DanSongEntry>& songs) {
     int total = 0;

--- a/src/scenes/game.cpp
+++ b/src/scenes/game.cpp
@@ -2,6 +2,7 @@
 #include "../libs/scores.h"
 #include "../libs/input.h"
 #include "../libs/network.h"
+#include <cmath>
 
 
 void GameScreen::on_screen_start() {

--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -1,5 +1,6 @@
 #include "game_practice.h"
 #include "../libs/input.h"
+#include <cmath>
 
 void PracticeGameScreen::on_screen_start() {
     GameScreen::on_screen_start();


### PR DESCRIPTION
## Mixed CRT crash

`cmake/platform.cmake` links both `ucrtbase` and `msvcrt`. Those are two incompatible C runtimes; on Windows 11 24H2 the resulting exe crashes with an access violation inside `_lock_file` (msvcrt) on the first `printf`/raylib `TraceLog` call. Reproduced with a minimal test program linked the same way - linking ucrtbase (alone or mixed) crashes, plain msvcrt works. MinGW already links msvcrt, so drop `ucrtbase`.

## Missing includes

`std::round` / `std::fmod` in several TUs only compiled because older mingw64 headers pulled `<cmath>` in transitively; GCC 16 (and the UCRT64 toolchain) no longer do. Add the include where the symbols are used.

Tested: MSYS2 MinGW64 GCC 16.2 on Windows 11 24H2 - clean build, game boots and plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)