### PR TITLE
Mirror modifier icons next to the 2P score display

### DIFF
--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -1405,29 +1405,42 @@ void Player::draw_song_timer(double current_ms, float y) {
 }
 
 void Player::draw_modifiers(float y) {
+    // These icons hang below the score cover for 1P. The 2P score cover is
+    // shifted down and mirrored vertically, so mirror each icon's offset
+    // within the cover as well: the stack pokes above the bar instead of
+    // below (otherwise the icons draw at the 1P-relative spot, hidden under
+    // the 2P nameplate / panel edge).
+    auto icon_y = [&](uint32_t id) {
+        if (!is_2p) return y;
+        float cover_h = (float)tex.textures[LANE::LANE_SCORE_COVER]->y2[0];
+        float json_y  = (float)tex.textures[id]->y[0];
+        float icon_h  = (float)tex.textures[id]->y2[0];
+        return y + tex.skin_config[SC::SCORE_COUNTER_2P_Y_OFFSET].y
+                 + cover_h - icon_h - 2.0f * json_y;
+    };
 
     if (score_method == ScoreMethod::SHINUCHI) {
-        tex.draw_texture(LANE::MOD_SHINUCHI, {.y=y});
+        tex.draw_texture(LANE::MOD_SHINUCHI, {.y=icon_y(LANE::MOD_SHINUCHI)});
     }
 
     if (modifiers.speed >= 40) {
-        tex.draw_texture(LANE::MOD_YONBAI, {.y=y});
+        tex.draw_texture(LANE::MOD_YONBAI, {.y=icon_y(LANE::MOD_YONBAI)});
     } else if (modifiers.speed >= 30) {
-        tex.draw_texture(LANE::MOD_SANBAI, {.y=y});
+        tex.draw_texture(LANE::MOD_SANBAI, {.y=icon_y(LANE::MOD_SANBAI)});
     } else if (modifiers.speed > 10) {
-        tex.draw_texture(LANE::MOD_BAISAKU, {.y=y});
+        tex.draw_texture(LANE::MOD_BAISAKU, {.y=icon_y(LANE::MOD_BAISAKU)});
     }
 
     if (modifiers.display) {
-        tex.draw_texture(LANE::MOD_DORON, {.y=y});
+        tex.draw_texture(LANE::MOD_DORON, {.y=icon_y(LANE::MOD_DORON)});
     }
     if (modifiers.inverse) {
-        tex.draw_texture(LANE::MOD_ABEKOBE, {.y=y});
+        tex.draw_texture(LANE::MOD_ABEKOBE, {.y=icon_y(LANE::MOD_ABEKOBE)});
     }
     if (modifiers.random == 2) {
-        tex.draw_texture(LANE::MOD_DETARAME, {.y=y});
+        tex.draw_texture(LANE::MOD_DETARAME, {.y=icon_y(LANE::MOD_DETARAME)});
     } else if (modifiers.random == 1) {
-        tex.draw_texture(LANE::MOD_KIMAGURE, {.y=y});
+        tex.draw_texture(LANE::MOD_KIMAGURE, {.y=icon_y(LANE::MOD_KIMAGURE)});
     }
 }
 


### PR DESCRIPTION
## Problem

In 2P play the modifier icons (真打, 倍速, ドロン, あべこべ, きまぐれ/でたらめ) draw at their 1P-relative position, which for the bottom player lands at the top of the panel hidden behind the nameplate - they should sit next to the score display like they do for 1P.

## Fix

The 2P score cover is shifted down by `SCORE_COUNTER_2P_Y_OFFSET` and mirrored vertically. `draw_modifiers` now mirrors each icon's offset within the cover (`cover_h - icon_h - 2*json_y` plus the 2P shift), computed from the skin's texture metrics at runtime, so the icon stack pokes above the bar for 2P symmetrically to how it hangs below for 1P - on any skin resolution.

Tested in 2P play with shinuchi scoring: the 真 badge now sits next to the 2P score, and stacked modifier icons mirror correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)