### PR TITLE
Fix 2P difficulty select locking up after a BACK pick

### DIFF
--- a/src/objects/song_select/player.cpp
+++ b/src/objects/song_select/player.cpp
@@ -84,6 +84,12 @@ bool SongSelectPlayer::is_voice_playing() {
     return audio.is_sound_playing("voice_start_song_" + std::to_string((int)player_num) + "p");
 }
 
+void SongSelectPlayer::reset_selection() {
+    is_ready = false;
+    selected_song = false;
+    voice_played = false;
+}
+
 void SongSelectPlayer::start_background_diffs() {
     selected_diff_text_resize->start();
     selected_diff_text_fadein->start();

--- a/src/objects/song_select/player.h
+++ b/src/objects/song_select/player.h
@@ -49,6 +49,10 @@ public:
     bool is_voice_playing();
 
     SongSelectState select_song();
+    // Fully cancel this player's difficulty pick (leaving diff select).
+    // Clears voice_played too: it survives is_ready, and the ready check in
+    // update() re-arms from it, instantly re-locking the player otherwise.
+    void reset_selection();
     SongSelectState handle_input_browsing(double current_ms);
     SongSelectState handle_input_selecting();
     std::optional<std::pair<int,int>> handle_input_diff_sort(DiffSortSelect* diff_sort_selector);

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -152,8 +152,7 @@ std::optional<Screens> SongSelectScreen::update() {
         } else if (player->selected_difficulty == Difficulty::BACK) {
             navigator.exit_diff_select();
             state = SongSelectState::BROWSING;
-            player->is_ready = false;
-            player->selected_song = false;
+            player->reset_selection();
         }
     }
 

--- a/src/scenes/song_select_2p.cpp
+++ b/src/scenes/song_select_2p.cpp
@@ -93,13 +93,18 @@ std::optional<Screens> SongSelect2PScreen::update() {
             BaseBox* item = navigator.get_current_item();
             select_song((SongBox*)item);
         }
-    } else if (player->is_ready && player->selected_difficulty == Difficulty::BACK) {
+    }
+    // A BACK pick from either player cancels diff select for both. This must
+    // not be an else-if on the both-ready branch: with the other player
+    // already ready, a BACK pick used to land in that branch, do nothing,
+    // and leave both players locked.
+    if (!game_transition.has_value() &&
+        ((player->is_ready && player->selected_difficulty == Difficulty::BACK) ||
+         (player_2->is_ready && player_2->selected_difficulty == Difficulty::BACK))) {
         navigator.exit_diff_select();
         state = SongSelectState::BROWSING;
-        player->is_ready = false;
-        player->selected_song = false;
-        player_2->is_ready = false;
-        player_2->selected_song = false;
+        player->reset_selection();
+        player_2->reset_selection();
     }
 
     if (screen_init) navigator.update(current_time);


### PR DESCRIPTION
## Repro

1. 2P mode, pick a song
2. P2 confirms a difficulty (ready)
3. P1 picks 戻る (BACK)

Nothing happens - both players are ready so the both-ready branch matches, its `>= EASY` check fails, and the BACK reset (an `else if`) never runs. Both players are locked. A BACK pick from P2 was not handled at all.

There is a second layer: even when the reset does run, it cleared `is_ready`/`selected_song` but not `voice_played` - and `SongSelectPlayer::update()` re-arms `is_ready` from `voice_played` once the start voice finishes, so the cancelled player instantly re-locked with their previously chosen difficulty when the next song was opened.

## Fix

- `SongSelectPlayer::reset_selection()` clears `is_ready`, `selected_song` **and** `voice_played`; both screens use it.
- The 2P BACK handling is no longer an `else if` of the both-ready branch and covers a BACK pick from either player.

Tested: P2 ready → P1 BACK now cancels for both and both can re-choose; same for the mirrored case; single-player BACK unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)