### PR TITLE
Keep the first player when cancelling the second player's side select

### DIFF
--- a/src/scenes/entry.cpp
+++ b/src/scenes/entry.cpp
@@ -57,6 +57,14 @@ std::optional<Screens> EntryScreen::handle_input() {
     if (state == EntryState::SELECT_SIDE) {
         if (is_l_don_pressed() || is_r_don_pressed()) {
             if (side == 1) {
+                if (players[0]) {
+                    // The side select was opened to add a second player -
+                    // cancelling it goes back to the first player's mode
+                    // select instead of dropping the whole entry to title.
+                    audio.play_sound("don", VolumePreset::SOUND);
+                    state = EntryState::SELECT_MODE;
+                    return std::nullopt;
+                }
                 return on_screen_end(Screens::TITLE);
             }
             global_data.player_num = (side == 0) ? PlayerNum::P1 : PlayerNum::P2;


### PR DESCRIPTION
## Repro

1. 1P registers and reaches mode select
2. Press a P2 key - the side select opens to add the second player
3. Confirm the middle やめる option

The whole entry screen ends to title/attract, discarding the already-registered 1P session.

## Fix

The やめる confirm handler called `on_screen_end(Screens::TITLE)` unconditionally. When `players[0]` already exists, cancel now just returns to `SELECT_MODE` (with a don sound for feedback) and the first player's session is untouched. The solo case - opening entry and immediately picking やめる - still exits to title as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)