### PR TITLE
Speed up song-select folder loading

### DIFF
--- a/src/objects/song_select/file_navigator/box_folder.cpp
+++ b/src/objects/song_select/file_navigator/box_folder.cpp
@@ -2,6 +2,27 @@
 #include "../../../libs/filesystem.h"
 #include "../../../libs/scores.h"
 #include "../../../libs/audio.h"
+#include <mutex>
+
+// The crown/count scan below walks the folder's whole subtree and runs a
+// score query per chart. Every FolderBox at a directory level does this when
+// the level loads (each genre box at the root scans its entire genre), so
+// cache the result per folder until scores or song lists change - otherwise
+// every back-navigation repeats seconds of I/O and the main thread hitches
+// on join_loader() waiting for it.
+namespace {
+struct FolderScan {
+    std::map<int, Crown> crown;
+    int tja_count;
+};
+std::mutex scan_cache_mutex;
+std::map<fs::path, FolderScan> scan_cache;
+}
+
+void FolderBox::invalidate_scan_cache() {
+    std::lock_guard<std::mutex> lock(scan_cache_mutex);
+    scan_cache.clear();
+}
 
 FolderBox::FolderBox(const fs::path& path, const BoxDef& box_def, std::map<std::pair<std::string, std::string>, fs::path>& song_files)
     : BaseBox(path, box_def), tja_count(0)
@@ -12,6 +33,16 @@ FolderBox::FolderBox(const fs::path& path, const BoxDef& box_def, std::map<std::
 }
 
 void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs::path>& song_files) {
+    {
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        auto it = scan_cache.find(path);
+        if (it != scan_cache.end()) {
+            crown = it->second.crown;
+            tja_count = it->second.tja_count;
+            return;
+        }
+    }
+
     crown.clear();
     tja_count = 0;
     std::set<int> disqualified;
@@ -51,6 +82,11 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
             tja_count++;
             update_crown(entry.path());
         }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        scan_cache[path] = {crown, tja_count};
     }
 }
 

--- a/src/objects/song_select/file_navigator/box_folder.h
+++ b/src/objects/song_select/file_navigator/box_folder.h
@@ -25,6 +25,9 @@ public:
     void exit_box() override;
 
     void refresh_scores(std::map<std::pair<std::string, std::string>, fs::path>& song_files);
+    // Drop the cached crown/tja_count folder scans. Call whenever scores or
+    // song lists change (after a play, favorite toggle, recent update).
+    static void invalidate_scan_cache();
 
     const char* lua_kind() const override { return "folder"; }
 

--- a/src/objects/song_select/file_navigator/box_song.cpp
+++ b/src/objects/song_select/file_navigator/box_song.cpp
@@ -4,7 +4,6 @@
 SongBox::SongBox(const fs::path& path, const BoxDef& box_def, SongParser parser)
     : BaseBox(path, box_def)
 {
-    this->parser = parser;
     parser.get_metadata();
     auto& titles = parser.metadata.title;
     const std::string& lang = global_data.config->general.language;
@@ -12,6 +11,12 @@ SongBox::SongBox(const fs::path& path, const BoxDef& box_def, SongParser parser)
 
     auto& subtitles = parser.metadata.subtitle;
     text_subtitle = subtitles.count(lang) ? subtitles.at(lang) : subtitles.count("en") ? subtitles.at("en") : subtitles.empty() ? "" : subtitles.begin()->second;
+
+    // Move, don't copy: the parser holds every line of the chart file, and
+    // the copy showed up hard when a big folder builds hundreds of boxes.
+    // Moving after get_metadata() also means the member actually carries the
+    // parsed metadata.
+    this->parser = std::move(parser);
 
     is_favorite = false;
     diff_fade_in = (FadeAnimation*)tex.get_animation(12);

--- a/src/objects/song_select/file_navigator/box_song_osu.cpp
+++ b/src/objects/song_select/file_navigator/box_song_osu.cpp
@@ -1,14 +1,14 @@
 #include "box_song_osu.h"
 
 SongBoxOsu::SongBoxOsu(const fs::path& path, const BoxDef& box_def, SongParser parser)
-    : SongBox(path, box_def, parser)
+    : SongBox(path, box_def, std::move(parser))
 {
-    this->parser = parser;
-    parser.get_metadata();
-    text_name = parser.get_difficulty_name();
+    // The base constructor already parsed the metadata and owns the parser -
+    // read from the member instead of keeping two more copies alive.
+    text_name = this->parser.get_difficulty_name();
 
     const std::string& lang = global_data.config->general.language;
-    auto& subtitles = parser.metadata.subtitle;
+    auto& subtitles = this->parser.metadata.subtitle;
     text_subtitle = subtitles.count(lang) ? subtitles.at(lang) : subtitles.count("en") ? subtitles.at("en") : subtitles.empty() ? "" : subtitles.begin()->second;
 
     is_favorite = false;

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -12,6 +12,49 @@ static std::unique_ptr<SongBox> make_song_box(const fs::path& path, const BoxDef
     return std::make_unique<SongBox>(path, box_def, std::move(parser));
 }
 
+// Parse many charts concurrently. Reading and line-parsing the chart file is
+// the dominant cost when a big folder opens, and it is embarrassingly
+// parallel, so pre-parse on a small pool and let the loader thread consume
+// the results in directory order.
+static std::unordered_map<std::string, std::unique_ptr<SongParser>>
+parse_songs_parallel(const std::vector<fs::path>& paths, std::atomic<bool>& abort_flag) {
+    std::vector<std::unique_ptr<SongParser>> parsed(paths.size());
+    unsigned workers = std::clamp(std::thread::hardware_concurrency(), 2u, 8u);
+    std::atomic<size_t> next{0};
+    std::vector<std::thread> pool;
+    for (unsigned t = 0; t < workers && t < paths.size(); t++) {
+        pool.emplace_back([&] {
+            for (size_t i; (i = next.fetch_add(1)) < paths.size();) {
+                if (abort_flag.load()) break;
+                try {
+                    parsed[i] = std::make_unique<SongParser>(paths[i]);
+                } catch (const std::exception& e) {
+                    spdlog::warn("Failed to parse {}: {}", paths[i].string(), e.what());
+                }
+            }
+        });
+    }
+    for (auto& th : pool) th.join();
+
+    std::unordered_map<std::string, std::unique_ptr<SongParser>> out;
+    for (size_t i = 0; i < paths.size(); i++)
+        if (parsed[i]) out.emplace(paths[i].string(), std::move(parsed[i]));
+    return out;
+}
+
+// Move a pre-parsed parser out of the map, or parse on the spot when the
+// pre-pass missed the file (fallback only - should not happen).
+static SongParser take_parser(std::unordered_map<std::string, std::unique_ptr<SongParser>>& preparsed,
+                              const fs::path& path) {
+    auto it = preparsed.find(path.string());
+    if (it != preparsed.end()) {
+        SongParser p = std::move(*it->second);
+        preparsed.erase(it);
+        return p;
+    }
+    return SongParser(path);
+}
+
 static std::unique_ptr<BackBox> make_back_box(const fs::path& parent_path) {
     BoxDef d;
     d.back_color    = BackBox::COLOR;
@@ -213,6 +256,7 @@ void sort_items(std::vector<std::unique_ptr<BaseBox>>& items, int first_index, i
 }
 
 void Navigator::refresh_scores() {
+    FolderBox::invalidate_scan_cache();
     SongBox* curr_item = dynamic_cast<SongBox*>(get_current_item());
     if (curr_item) {
         curr_item->refresh_scores();
@@ -321,6 +365,18 @@ void Navigator::load_current_directory_async(const fs::path path) {
 
     setup_back_box(path, true);
 
+    // Pre-parse the level's song files on a worker pool (see
+    // parse_songs_parallel) so the streaming loop below only assembles boxes.
+    std::vector<fs::path> song_paths;
+    try {
+        for (const fs::directory_entry& entry : fs::directory_iterator(path)) {
+            if (abort_loading) break;
+            if (!fs::is_directory(entry.path()) && is_song_file(entry.path()))
+                song_paths.push_back(entry.path());
+        }
+    } catch (const fs::filesystem_error&) { /* main loop reports errors */ }
+    auto preparsed = parse_songs_parallel(song_paths, abort_loading);
+
     try {
         for (const fs::directory_entry& entry : fs::directory_iterator(path)) {
             if (abort_loading) break;
@@ -333,7 +389,7 @@ void Navigator::load_current_directory_async(const fs::path path) {
                         continue;
                     }
                     if (is_song_file(curr_path))
-                        enqueue_box(make_song_box(curr_path, box_def, SongParser(curr_path)));
+                        enqueue_box(make_song_box(curr_path, box_def, take_parser(preparsed, curr_path)));
                     continue;
                 }
                 if (has_def_file(curr_path)) {
@@ -480,6 +536,7 @@ void Navigator::load_from_song_list(const fs::path& path, const BoxDef& box_def,
 
 void Navigator::toggle_favorite(SongBox* song) {
     if (!favorite_folder_path) return;
+    FolderBox::invalidate_scan_cache();  // song_list.txt counts change
     auto& t = song->parser.metadata.title;
     auto& s = song->parser.metadata.subtitle;
     std::string title    = t.count("en") ? t.at("en") : t.begin()->second;
@@ -518,6 +575,7 @@ fs::path Navigator::find_box_def_folder(const fs::path& song_path) {
 
 void Navigator::add_to_recent(const SongBox* song) {
     if (!recent_folder_path) return;
+    FolderBox::invalidate_scan_cache();  // song_list.txt counts change
     fs::path song_list_path = *recent_folder_path / "song_list.txt";
 
     auto& titles    = song->parser.metadata.title;
@@ -537,25 +595,25 @@ void Navigator::add_to_recent(const SongBox* song) {
 }
 
 void Navigator::load_collection_recommended(const fs::path& path, const BoxDef& box_def) {
-    std::vector<std::pair<fs::path, BoxDef>> all_songs;
-    for (const auto& sibling : fs::directory_iterator(path.parent_path())) {
-        if (abort_loading) break;
-        if (!fs::is_directory(sibling) || sibling.path() == path) continue;
-        BoxDef sibling_box_def = parse_box_def(sibling.path());
-        for (const auto& entry : fs::recursive_directory_iterator(sibling)) {
-            if (abort_loading) break;
-            if (is_song_file(entry.path()))
-                all_songs.push_back({entry.path(), sibling_box_def});
-        }
-    }
+    // Pick from the already-built song index instead of re-walking the whole
+    // library on disk: that recursive scan took seconds on a large library,
+    // and any navigation issued meanwhile stalled on join_loader() until it
+    // finished.
+    std::vector<fs::path> all_songs;
+    all_songs.reserve(song_files.size());
+    for (const auto& [key, song_path] : song_files)
+        all_songs.push_back(song_path);
+
     std::mt19937 rng(std::random_device{}());
     std::shuffle(all_songs.begin(), all_songs.end(), rng);
     int count = std::min((int)all_songs.size(), 10);
     for (int i = 0; i < count; i++) {
         if (abort_loading) break;
-        const auto& [song_path, song_box_def] = all_songs[i];
+        const fs::path& song_path = all_songs[i];
         auto song = make_song_box(song_path, box_def, SongParser(song_path));
-        apply_song_color(song.get(), song_box_def);
+        fs::path genre_folder = find_box_def_folder(song_path);
+        if (!genre_folder.empty())
+            apply_song_color(song.get(), parse_box_def(genre_folder));
         song->fade_in(266);
         enqueue_inline_box(std::move(song));
     }
@@ -586,11 +644,12 @@ void Navigator::load_collection_search(const fs::path& path, const BoxDef& box_d
 void Navigator::load_songs_inline_async(const fs::path path, BoxDef box_def) {
     wait_for_song_files();
     int songs_added = 0;
+    std::unordered_map<std::string, std::unique_ptr<SongParser>> preparsed;
 
     auto add_song = [&](const fs::path& song_path) {
         if (songs_added > 0 && songs_added % 10 == 0)
             enqueue_inline_box(make_back_box(path.parent_path()));
-        auto box = make_song_box(song_path, box_def, SongParser(song_path));
+        auto box = make_song_box(song_path, box_def, take_parser(preparsed, song_path));
         box->fade_in(266);
         enqueue_inline_box(std::move(box));
         songs_added++;
@@ -625,6 +684,33 @@ void Navigator::load_songs_inline_async(const fs::path path, BoxDef box_def) {
         return;
     }
 
+    // Pre-pass: gather the song files this loop will visit (same filters as
+    // below) and parse them on a worker pool before streaming the boxes in.
+    std::vector<fs::path> song_paths;
+    try {
+        for (const fs::directory_entry& entry : fs::directory_iterator(path)) {
+            if (abort_loading) break;
+            const fs::path& curr_path = entry.path();
+            if (!fs::is_directory(curr_path)) {
+                if (is_song_file(curr_path)) song_paths.push_back(curr_path);
+                continue;
+            }
+            if (is_osu_song_folder(curr_path)) continue;
+            std::error_code ec;
+            auto it = fs::recursive_directory_iterator(curr_path, ec);
+            while (it != fs::end(it)) {
+                if (abort_loading) break;
+                if (fs::is_directory(it->path()) && is_osu_song_folder(it->path()))
+                    it.disable_recursion_pending();
+                else if (is_song_file(it->path()))
+                    song_paths.push_back(it->path());
+                it.increment(ec);
+                if (ec) { ec.clear(); }
+            }
+        }
+    } catch (const fs::filesystem_error&) { /* main loop reports errors */ }
+    preparsed = parse_songs_parallel(song_paths, abort_loading);
+
     try {
         for (const fs::directory_entry& entry : fs::directory_iterator(path)) {
             if (abort_loading) break;
@@ -636,7 +722,7 @@ void Navigator::load_songs_inline_async(const fs::path path, BoxDef box_def) {
                         continue;
                     }
                     if (is_song_file(curr_path))
-                        enqueue_inline_box(make_song_box(curr_path, box_def, SongParser(curr_path)));
+                        enqueue_inline_box(make_song_box(curr_path, box_def, take_parser(preparsed, curr_path)));
                     continue;
                 }
                 if (is_osu_song_folder(curr_path)) {


### PR DESCRIPTION
Opening a big genre folder (e.g. a Namco Original with hundreds of charts) stalled for seconds, and navigation issued meanwhile blocked on `join_loader()`. Four independent changes attack it:

1. **Parallel chart parsing.** The per-song file read + line parse dominates and is embarrassingly parallel. Both loaders now pre-collect the level's song files (same filters as the streaming loop) and parse them on a small worker pool; the loader thread consumes results in directory order. Abort is checked inside the pool, so leaving the folder still cancels quickly.

2. **Move the parser into SongBox instead of copying.** The parser holds every line of the chart file and was deep-copied per box (twice for the osu variant). Moving it also fixes a subtlety where the member parser never carried the parsed metadata (it was copied before `get_metadata()`).

3. **Cache FolderBox crown/count scans.** Every folder box recursively walked its whole subtree with a score lookup per chart, on every directory (re)load - each genre box at the root scans its entire genre. The scan result is now cached per folder and invalidated when scores or song lists change (play finished, favorite toggled, recent updated).

4. **Build RECOMMENDED from the in-memory song index** built at boot instead of re-walking the entire library on disk; the picked songs' genre colors come from their own box.def folders (same approach as SEARCH).

Tested on a ~3000-song library, MSYS2 MinGW64 / Windows 11: genre folders open without the multi-second stall, back-navigation to the root is instant after the first visit, and Recommended fills immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)