### PR TITLE
Load song audio on a worker thread

### DIFF
--- a/src/scenes/game.cpp
+++ b/src/scenes/game.cpp
@@ -93,6 +93,11 @@ Screens GameScreen::on_screen_end(Screens next_screen) {
         spdlog::info("Background unloaded");
     }
     transition.reset();
+    // Let an in-flight song load land before the base class unloads all
+    // sounds, otherwise the worker inserts an orphaned "song" entry after
+    // the cleanup and its buffer leaks on the next load.
+    if (pending_song_load.valid()) pending_song_load.wait();
+    pending_song_load = {};
     song_music.reset();
     parser.reset();
     players.clear();
@@ -128,11 +133,34 @@ void GameScreen::init_tja(fs::path song) {
     global_data.session_data[(int)global_data.player_num].song_title = titles.count(lang) ? titles.at(lang) : titles.count("en") ? titles.at("en") : titles.empty() ? "" : titles.begin()->second;
     global_data.session_data[(int)global_data.player_num].song_subtitle = subtitles.count(lang) ? subtitles.at(lang) : "";
 
-    if (fs::exists(parser->metadata.wave) && !song_music.has_value()) {
-        song_music = audio.load_sound(parser->metadata.wave, "song");
+    if (fs::exists(parser->metadata.wave) && !song_music.has_value() && !pending_song_load.valid()) {
+        fs::path wave = parser->metadata.wave;
+        pending_song_load = std::async(std::launch::async, [wave] {
+            return audio.load_sound(wave, "song");
+        });
     }
 
     players.push_back(std::make_unique<Player>(parser, global_data.player_num, global_data.session_data[(int)global_data.player_num].selected_difficulty, false, get_player_modifiers(global_data.player_num)));
+}
+
+void GameScreen::poll_pending_song() {
+    if (!pending_song_load.valid() ||
+        pending_song_load.wait_for(std::chrono::seconds(0)) != std::future_status::ready)
+        return;
+
+    std::string name = pending_song_load.get();
+    if (name.empty()) return;
+    song_music = name;
+
+    // If the chart already passed its start point while the audio was still
+    // decoding, join in progress at the right position.
+    if (song_started && !paused) {
+        audio.play_sound(*song_music, VolumePreset::MUSIC);
+        double audio_ms = ms_from_start
+                        - (parser->metadata.offset * 1000 + start_delay
+                           - (double)global_data.config->general.audio_offset);
+        audio.seek_sound(*song_music, (float)std::max(0.0, audio_ms / 1000.0));
+    }
 }
 
 void GameScreen::start_song(double ms_from_start) {
@@ -294,6 +322,7 @@ std::optional<Screens> GameScreen::update() {
         ms_from_start = current_ms - start_ms;
 
     transition->update(current_ms);
+    poll_pending_song();
     if (transition->is_finished()) {
         start_song(ms_from_start);
         global_data.input_locked = 0;

--- a/src/scenes/game.h
+++ b/src/scenes/game.h
@@ -7,6 +7,7 @@
 #include "../objects/game/song_info.h"
 #include "../objects/game/result_transition.h"
 #include "../objects/global/allnet_indicator.h"
+#include <future>
 
 class GameScreen : public Screen {
 protected:
@@ -29,6 +30,10 @@ public:
 
     std::optional<VideoPlayer> movie;
     std::optional<std::string> song_music;
+    // Song audio decodes (and possibly resamples) on a worker thread; the
+    // synchronous load blocked the main thread for seconds on long songs.
+    // update() polls this and fills song_music when the load finishes.
+    std::future<std::string> pending_song_load;
     std::optional<SongParser> parser;
     std::string scene_preset;
     std::vector<std::unique_ptr<Player>> players;
@@ -49,6 +54,8 @@ public:
     virtual void init_tja(fs::path song);
 
     void start_song(double ms_from_start);
+
+    void poll_pending_song();
 
     void restart_song();
 

--- a/src/scenes/game_2p.cpp
+++ b/src/scenes/game_2p.cpp
@@ -53,6 +53,7 @@ std::optional<Screens> Game2PScreen::update() {
     if (!paused) {
         ms_from_start = current_time - start_ms;
     }
+    poll_pending_song();
     if (transition->is_finished()) {
         start_song(ms_from_start);
         global_data.input_locked = 0;

--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -225,6 +225,7 @@ std::optional<Screens> PracticeGameScreen::update() {
             ms_from_start = current_ms - start_ms;
         }
     }
+    poll_pending_song();
     if (transition->is_finished()) {
         start_song(current_ms);
         global_data.input_locked = 0;


### PR DESCRIPTION
## Problem

Entering gameplay after picking a difficulty freezes for one to several seconds on long songs: `init_tja` calls `audio.load_sound` synchronously on the main thread, which decodes the whole file and - when the file's sample rate differs from the device - runs a SINC resample over the entire song.

## Fix

- `init_tja` launches the load with `std::async`; `AudioEngine::load_sound` already takes the engine's write lock only for the final map insert, so it is safe off-thread.
- All three game screens (`GameScreen`, `Game2PScreen`, `PracticeGameScreen`) poll the future each frame and fill `song_music` when ready - every existing use is already guarded by `song_music.has_value()`.
- If the chart passes its start point before the audio lands (very long decode), the song joins in progress, seeking with the same offset math `resync_song` uses.
- `on_screen_end` drains an in-flight load before `unload_all_sounds`, so quitting immediately cannot leave an orphaned "song" entry whose buffer would leak on the next overwrite.

Tested: transition into gameplay no longer hitches on multi-minute charts; audio starts on time; practice pause/seek and instant-quit behave as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)