### PR TITLE
Make the 3D chara resolution-independent

### DIFF
--- a/src/objects/global/chara_3d.cpp
+++ b/src/objects/global/chara_3d.cpp
@@ -231,8 +231,13 @@ void Chara3D::load_face_textures(fs::path& face_dir) {
     if (paths.empty()) return;
     std::sort(paths.begin(), paths.end());
     ray::Image sheet = ray::LoadImage(paths[0].string().c_str());
-    for (int f = 0; f < 12; f++) {
-        ray::Rectangle rect = {0, (float)(f * 128), 128, 128};
+    // Frames are square and stacked vertically; derive the size from the
+    // sheet width instead of assuming 128px, so higher-resolution skins
+    // slice on the right boundaries (the UVs are normalized anyway).
+    int frame_size = sheet.width;
+    int frame_count = frame_size > 0 ? sheet.height / frame_size : 0;
+    for (int f = 0; f < frame_count; f++) {
+        ray::Rectangle rect = {0, (float)(f * frame_size), (float)frame_size, (float)frame_size};
         ray::Image frame_img = ray::ImageFromImage(sheet, rect);
         face_textures.push_back(ray::LoadTextureFromImage(frame_img));
         ray::UnloadImage(frame_img);
@@ -408,7 +413,10 @@ void Chara3D::draw_outline(float x, float y) {
     cos_model.transform = rotation_xyz(rot_x * DEG2RAD, y_angle * DEG2RAD, rot_z * DEG2RAD);
 
     rlSetCullFace(RL_CULL_FACE_FRONT);
-    ray::DrawModel(cos_model, {x, y, 400.0f}, scale, ray::WHITE);
+    // scale is in 1280x720 virtual units; the camera maps the skin's virtual
+    // canvas to the window, so follow the skin resolution or the model
+    // shrinks relative to everything else on hi-res skins.
+    ray::DrawModel(cos_model, {x, y, 400.0f}, scale * tex.screen_scale, ray::WHITE);
     rlSetCullFace(RL_CULL_FACE_BACK);
 
     cos_model.transform = saved_transform;
@@ -420,7 +428,7 @@ void Chara3D::draw_3d(float x, float y) {
     ray::Matrix saved = cos_model.transform;
     float y_angle = mirror ? -rot_y : rot_y;
     cos_model.transform = rotation_xyz(rot_x * DEG2RAD, y_angle * DEG2RAD, rot_z * DEG2RAD);
-    ray::DrawModel(cos_model, {x, y, 400.0f}, scale, ray::WHITE);
+    ray::DrawModel(cos_model, {x, y, 400.0f}, scale * tex.screen_scale, ray::WHITE);
     cos_model.transform = saved;
 }
 


### PR DESCRIPTION
The engine already supports skins declaring a higher virtual resolution via the `screen` block in `skin_config.json`, but the 3D chara had two hardcoded pixel assumptions that broke on them (found while testing 1080/1440/2160 upscales of PyTaikoGreen):

1. **Model scale.** `scale = 650` is in 1280x720 virtual units while `compute_camera2d` maps the skin's virtual canvas to the window - so on a 1.5x/2x/3x skin the chara rendered at 2/3, 1/2 or 1/3 of its intended size next to correctly-scaled 2D elements. Both `DrawModel` sites now multiply by `tex.screen_scale`.

2. **Face sheet slicing.** `load_face_textures` cut the expression sheet in hardcoded 128x128 squares. On a higher-resolution sheet every frame got cut on wrong boundaries, so the face visibly glitched between misaligned crops as expressions cycled. The frame size is now derived from the sheet width (frames are square and stacked vertically); since the face UVs are normalized, larger frames simply render sharper.

No behavior change for standard 720p skins (`screen_scale == 1`, sheets are 128 wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)