### PR TITLE
Reset the chart clock on quick restart

### DIFF
--- a/src/scenes/game.cpp
+++ b/src/scenes/game.cpp
@@ -176,6 +176,15 @@ void GameScreen::restart_song() {
     audio.play_sound("restart", VolumePreset::SOUND);
     song_started = false;
     score_saved = false;
+    paused = false;
+    pause_time = 0;
+    last_resync_ms = 0;
+    // Reset the chart clock the same way on_screen_start does. With the
+    // stale start_ms, ms_from_start was already far past the start
+    // threshold, so the song began the very next frame instead of after
+    // the usual lead-in (#83).
+    start_ms = get_current_ms() - parser->metadata.offset*1000 - (double)global_data.config->general.audio_offset;
+    ms_from_start = get_current_ms() - start_ms;
 }
 
 std::optional<Screens> GameScreen::global_keys() {

--- a/src/scenes/game_2p.cpp
+++ b/src/scenes/game_2p.cpp
@@ -100,6 +100,14 @@ std::optional<Screens> Game2PScreen::update() {
         init_tja(global_data.session_data[(int)PlayerNum::P1].selected_song);
         audio.play_sound("restart", VolumePreset::SOUND);
         song_started = false;
+        score_saved = false;
+        paused = false;
+        pause_time = 0;
+        last_resync_ms = 0;
+        // See GameScreen::restart_song - reset the chart clock or the song
+        // starts immediately, skipping the lead-in (#83).
+        start_ms = get_current_ms() - parser->metadata.offset*1000 - (double)global_data.config->general.audio_offset;
+        ms_from_start = get_current_ms() - start_ms;
     }
     if (check_key_pressed(global_data.config->keys.back_key)) {
         if (song_music.has_value()) audio.stop_sound(song_music.value());


### PR DESCRIPTION
Fixes #83

## Cause

`restart_song()` clears the players and `song_started` but never resets `start_ms`, so after a quick restart `ms_from_start` continues from wherever the song was - already far past `start_song`'s threshold. The song therefore (re)starts on the very next frame with no lead-in, and the first `resync_song` hard-yanks the chart back to the audio position. It is most audible on songs whose audio begins right at the first note, like INSPION.

## Fix

Reinitialize the clock exactly like `on_screen_start` does (`start_ms = now - offset*1000 - audio_offset`), and clear `paused`/`pause_time`/`last_resync_ms` so restarting while paused also behaves. The 2P restart handler gets the same treatment.

Tested: quick restart now replays the normal lead-in on songs with and without audio intros, in 1P and 2P.

🤖 Generated with [Claude Code](https://claude.com/claude-code)