### PR TITLE
Remember each player's last difficulty and start the cursor there

### DIFF
--- a/src/libs/global_data.h
+++ b/src/libs/global_data.h
@@ -129,6 +129,11 @@ struct GlobalData {
     PlayerNum first_login_player = PlayerNum::P1;
     int input_locked = 0;
     std::vector<SessionData> session_data = std::vector<SessionData>(3);
+    // Difficulty each player last confirmed, indexed like session_data;
+    // -1 until they pick one. Only used to place the difficulty cursor, so
+    // it lives for the run and is deliberately not written to the config.
+    // Not part of SessionData: that is reset after every song.
+    std::vector<int> last_difficulty = std::vector<int>(3, -1);
 
     GlobalData() {
         // Initialize vectors with default-constructed elements

--- a/src/objects/song_select/player.cpp
+++ b/src/objects/song_select/player.cpp
@@ -84,6 +84,35 @@ bool SongSelectPlayer::is_voice_playing() {
     return audio.is_sound_playing("voice_start_song_" + std::to_string((int)player_num) + "p");
 }
 
+void SongSelectPlayer::init_diff_cursor() {
+    int last = global_data.last_difficulty[(int)player_num];
+    if (last < (int)Difficulty::EASY) return;
+
+    // An ura pick lands the cursor on the oni column; the player flips to
+    // ura themselves if this song has one.
+    Difficulty desired = (Difficulty)std::min(last, (int)Difficulty::ONI);
+
+    Difficulty pick = Difficulty::BACK;
+    for (Difficulty d : curr_diffs) {
+        if (d < Difficulty::EASY || d > Difficulty::ONI) continue;
+        if (d <= desired && (pick == Difficulty::BACK || d > pick)) pick = d;
+    }
+    if (pick == Difficulty::BACK) {
+        // nothing at or below the remembered difficulty - take the lowest
+        for (Difficulty d : curr_diffs) {
+            if (d < Difficulty::EASY || d > Difficulty::ONI) continue;
+            if (pick == Difficulty::BACK || d < pick) pick = d;
+        }
+    }
+    if (pick != Difficulty::BACK) {
+        selected_difficulty = pick;
+        // draw_selector positions from prev_diff until the move animation
+        // has run; leaving it at BACK draws the cursor over the option
+        // column instead of the picked difficulty.
+        prev_diff = pick;
+    }
+}
+
 void SongSelectPlayer::reset_selection() {
     is_ready = false;
     selected_song = false;
@@ -106,6 +135,7 @@ SongSelectState SongSelectPlayer::select_song() {
         selected_song = true;
         SongBox* song_item = (SongBox*)item;
         curr_diffs = song_item->get_diffs();
+        init_diff_cursor();
         selected_diff_bounce->start();
         selected_diff_fadein->start();
         return SongSelectState::SONG_SELECTED;
@@ -352,6 +382,10 @@ void SongSelectPlayer::toggle_ura_mode() {
 }
 
 void SongSelectPlayer::draw_selector(bool is_half, float fade_in) {
+    // Keep the cursor hidden until the difficulty panel finished expanding:
+    // parts of the selector (the outline) draw unfaded, so a pre-placed
+    // cursor popped in at full opacity over the still-fading panel.
+    if (fade_in < 1.0f) return;
     float fade = (neiro_selector.has_value() || modifier_selector.has_value())
         ? 0.5f : fade_in;
     float direction = diff_select_move_right ? 1.0f : -1.0f;

--- a/src/objects/song_select/player.h
+++ b/src/objects/song_select/player.h
@@ -49,6 +49,10 @@ public:
     bool is_voice_playing();
 
     SongSelectState select_song();
+    // Place the difficulty cursor on this player's last confirmed
+    // difficulty. Ura maps onto Oni; if the song doesn't have that course,
+    // the nearest available one below is used.
+    void init_diff_cursor();
     // Fully cancel this player's difficulty pick (leaving diff select).
     // Clears voice_played too: it survives is_ready, and the ready check in
     // update() re-arms from it, instantly re-locking the player otherwise.

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -44,6 +44,7 @@ void SongSelectScreen::select_song(SongBox* song) {
     session_data.selected_difficulty = (int)player->selected_difficulty;
     session_data.song_hash = song->hashes[session_data.selected_difficulty];
     session_data.genre_index = (int)song->genre_index - 1;
+    global_data.last_difficulty[(int)global_data.player_num] = session_data.selected_difficulty;
     game_transition.emplace(song->text_name, song->text_subtitle, false);
     if (exists(session_data.selected_song.parent_path() / "Loading.png")) {
         game_transition->add_loading_graphic((session_data.selected_song.parent_path() / "Loading.png").string());
@@ -103,6 +104,12 @@ void SongSelectScreen::poll_song_jump(double current_ms) {
 
 void SongSelectScreen::handle_input(double current_ms) {
     if (navigator.is_processing || navigator.inline_streaming) {
+        clear_input_buffers();
+        return;
+    }
+    // Ignore input while the difficulty panel is still expanding, matching
+    // the cursor which only appears once the animation is done.
+    if (state == SongSelectState::SONG_SELECTED && navigator.get_diff_fade_in() < 1.0f) {
         clear_input_buffers();
         return;
     }

--- a/src/scenes/song_select_2p.cpp
+++ b/src/scenes/song_select_2p.cpp
@@ -9,6 +9,7 @@ void SongSelect2PScreen::on_screen_start() {
 static void init_player_diffs(SongSelectPlayer* p, SongBox* song) {
     p->selected_song = true;
     p->curr_diffs = song->get_diffs();
+    p->init_diff_cursor();
     p->selected_diff_bounce->start();
     p->selected_diff_fadein->start();
 }
@@ -55,6 +56,9 @@ void SongSelect2PScreen::select_song(SongBox* song) {
     sd2.selected_difficulty = (int)player_2->selected_difficulty;
     sd2.song_hash = song->hashes[sd2.selected_difficulty];
     sd2.genre_index = (int)song->genre_index - 1;
+
+    global_data.last_difficulty[(int)PlayerNum::P1] = sd1.selected_difficulty;
+    global_data.last_difficulty[(int)PlayerNum::P2] = sd2.selected_difficulty;
 
     game_transition.emplace(song->text_name, song->text_subtitle, false);
     if (exists(sd1.selected_song.parent_path() / "Loading.png")) {


### PR DESCRIPTION
## Feature

Opening a song's difficulty select places the cursor on the difficulty that player last confirmed:

- oni → oni, hard → hard, normal → normal, easy → easy
- an **ura** pick lands the cursor on the **oni** column - the player flips to ura themselves if the song has one
- if the song lacks that course, the nearest available one below is used (falling back to the lowest)
- each player keeps their own value in 2P

## Storage

Kept in `GlobalData` for the run only - **no config keys, nothing persists between launches**.

It is deliberately not in `SessionData`: that is reset by `reset_session()` on the result screen, i.e. after every song, which is exactly the case the cursor is meant to help with (playing several songs in a row).

## Supporting details

- `init_diff_cursor` also sets `prev_diff`, since `draw_selector` positions from it until the move animation has run - otherwise the selection box drew over the option column while the logical selection was already correct.
- The cursor and difficulty-select input both wait for the panel's expand animation to finish. Parts of the selector (the outline) draw unfaded, so a pre-placed cursor popped in at full opacity over the still-fading panel, and presses were accepted before it was visible.

Tested in 1P and 2P: cursor lands on the remembered difficulty, ura history lands on oni, songs missing the course snap to the nearest lower one, and a fresh launch starts with no cursor hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)