### PR TITLE
Don't create a close-folder box at root levels

### DIFF
--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -254,7 +254,10 @@ void Navigator::flush_pending_boxes() {
         } else if (items.size() > 1) {
             std::vector<int> sortable_indices;
             std::vector<std::unique_ptr<BaseBox>> sortable;
-            for (int i = 1; i < (int)items.size(); i++) {
+            // Skip index 0 only when it actually is the level's back box
+            // (root levels no longer have one).
+            int first_sortable = dynamic_cast<BackBox*>(items[0].get()) ? 1 : 0;
+            for (int i = first_sortable; i < (int)items.size(); i++) {
                 if (!items[i]->preserve_order) {
                     sortable_indices.push_back(i);
                     sortable.push_back(std::move(items[i]));
@@ -978,11 +981,15 @@ bool Navigator::jump_to_song(const std::string& hash) {
 }
 
 void Navigator::setup_back_box(const fs::path& path, bool has_children) {
-    auto back = make_back_box(path.parent_path());
     if (has_children) {
         items.clear();
-        items.push_back(std::move(back));
+        // A root level has no folder to close: the box would point at the
+        // songs dir's parent and selecting it does nothing sensible.
+        if (std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end())
+            return;
+        items.push_back(make_back_box(path.parent_path()));
     } else {
+        auto back = make_back_box(path.parent_path());
         back->fade_in(266);
         items.erase(items.begin() + open_index);
         items.insert(items.begin() + open_index, std::move(back));


### PR DESCRIPTION
## Problem

Songs living directly under a `tja_path` root without a `box.def` genre folder display fine, but the root level also carries a close-folder (もどる/とじる) box that does nothing sensible: `setup_back_box` unconditionally creates it pointing at `path.parent_path()`, which for a root is the songs dir's **parent** - selecting it attempts to load the game directory as a music folder.

## Fix

- `setup_back_box` skips the box when the loaded path is one of the configured roots (`root_paths`), so root levels no longer offer a close option that can't work.
- The completion sort assumed `items[0]` is always the level's back box and pinned it unconditionally; it now pins index 0 only when it actually is a `BackBox`, so the first real entry at a root level sorts with the rest.

Sub-folders with a `box.def` are unaffected - their close box still appears and works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)