### PR TITLE
Don't let a paused practice player eat the resume press

### DIFF
--- a/src/objects/game/player.h
+++ b/src/objects/game/player.h
@@ -226,7 +226,10 @@ private:
 
     virtual void spawn_hit_effects(DrumType drum_type, Side side);
 
-    void handle_input(double ms_from_start, double current_ms, std::optional<Background>& background);
+protected:
+    virtual void handle_input(double ms_from_start, double current_ms, std::optional<Background>& background);
+
+private:
 
     void draw_bar(double current_ms, float y, const Note& bar);
 

--- a/src/scenes/game_practice.h
+++ b/src/scenes/game_practice.h
@@ -30,6 +30,15 @@ public:
         judge_counter = JudgeCounter();
     }
 
+    // While paused, don't consume drum presses as hit attempts: input
+    // arrives from the polling thread mid-frame, so a resume press landing
+    // between global_keys_practice() and this player's update was eaten
+    // here and the player had to press again.
+    void handle_input(double ms_from_start, double current_ms, std::optional<Background>& background) override {
+        if (paused) return;
+        Player::handle_input(ms_from_start, current_ms, background);
+    }
+
     void spawn_hit_effects(DrumType drum_type, Side side) {
         lane_hit_effect = LaneHitEffect(drum_type, Judgments::BAD); //judgment parameter workaround
         draw_drum_hit_list.push_back(std::make_unique<DrumHitEffect>(drum_type, side));


### PR DESCRIPTION
Follow-up to #105 (this commit landed on that branch after it was merged).

## Symptom

In practice mode, resuming sometimes takes **two** don presses instead of one.

## Cause

Input arrives from the polling thread asynchronously, and a frame has two consumers: `global_keys_practice()` early (handles the resume) and `player->update()` later (handles hits). A don press landing in the window between them gets consumed by `Player::handle_input` as a hit attempt even though the screen is paused - `PracticePlayer::paused` existed but was never read. The press is gone, so the next frame's resume check sees nothing and the player has to press again. Whether you hit the window is timing luck, hence "sometimes".

## Fix

Make `Player::handle_input` virtual and have `PracticePlayer` skip hit input while paused - the press stays queued and the resume logic consumes it reliably.

Tested: paused practice now always resumes on the first don press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)