### PR TITLE
Expose the drawn texture size to Lua

### DIFF
--- a/src/libs/script.cpp
+++ b/src/libs/script.cpp
@@ -369,6 +369,12 @@ void ScriptManager::register_lua_bindings() {
         info["name"] = tex_obj->name;
         info["x"] = sol::as_table(tex_obj->x);
         info["y"] = sol::as_table(tex_obj->y);
+        // Drawn size per position, which is what draw_texture uses. This
+        // differs from width/height (the source image size) whenever
+        // texture.json stretches the texture, e.g. a nine-slice centre
+        // piece - scripts need it to lay out against what is on screen.
+        info["x2"] = sol::as_table(tex_obj->x2);
+        info["y2"] = sol::as_table(tex_obj->y2);
         info["width"] = tex_obj->width;
         info["height"] = tex_obj->height;
 


### PR DESCRIPTION
Groundwork for #85, plus a gap in the script API.

## Problem

`tex.get_texture_info` returns `x`, `y`, `width`, `height` - but `width`/`height` are the **source image** size, while `draw_texture` draws at `x2`/`y2` from texture.json. For any stretched texture a script has no way to know what is actually on screen.

That is the cause of #85: PyTaikoGreen's costume menu centres its title on `bc.width` where `bc` is the nine-slice box centre - a **64px** source stretched to **336px** on screen. The title ends up centred on 64 instead of 336, about 76px too far left, so its first characters run off the panel.

## Change

Expose `x2`/`y2` as tables alongside `x`/`y`. Purely additive - `width`/`height` keep their current meaning, which the tiling background scripts (`bg_fever`, the collab backgrounds, ...) depend on.

## Skin-side follow-up

The actual #85 fix is one line in PyTaikoGreen (separate repo) and needs this binding:

```lua
    local bc = self.bc_info
    -- Centre on the drawn width (x2), not the source image width: the box
    -- centre is a nine-slice piece stretched far wider than its texture,
    -- so using width put the title off the left edge of the panel.
    local bc_width = (bc.x2 and bc.x2[1]) or bc.width
    local cx = bc.x[1] + x + bc_width / 2 - self.title_text.width / 2
```

(the `or bc.width` fallback keeps it working on an older build). Verified locally with both changes: the costume-select title is centred in the panel at 720p and on 1080/1440/2160 skins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)