### PR TITLE
Let the keybind screen see plain SDL joysticks

### DIFF
--- a/src/libs/input.cpp
+++ b/src/libs/input.cpp
@@ -75,6 +75,12 @@ std::atomic<bool> touch_drum_pressed{false};
 static std::array<bool, 349> previous_key_states{};
 static std::array<bool, 18>  previous_gamepad_states{};
 
+// Gamepad/joystick buttons and axes are folded into the key space at these
+// offsets (config stores the bare button number).
+static constexpr int GAMEPAD_VKEY_BASE = 10000;
+static constexpr int AXIS_VKEY_BASE    = 20000;
+static std::atomic<int> last_gamepad_vkey{0};
+
 bool is_input_key_pressed(const std::vector<int>& keys, const std::vector<int>& gamepad_buttons) {
 
     for (int key : keys) {
@@ -410,11 +416,27 @@ void poll_keyboard_once() {
         }
     }
 
+    // Remember the newest controller press separately from pressed_keys so
+    // the keybind screen can read it: the pressed_keys entry is consumed by
+    // whatever navigates the menu before the option box ever sees it.
+    for (int vkey : local_pressed) {
+        if (vkey >= GAMEPAD_VKEY_BASE && vkey < AXIS_VKEY_BASE) {
+            last_gamepad_vkey.store(vkey, std::memory_order_relaxed);
+            break;
+        }
+    }
+
     if (!local_pressed.empty() || !local_released.empty()) {
         std::lock_guard<std::mutex> lock(input_mutex);
         pressed_keys.insert(local_pressed.begin(), local_pressed.end());
         released_keys.insert(local_released.begin(), local_released.end());
     }
+}
+
+int take_gamepad_button_pressed() {
+    int vkey = last_gamepad_vkey.exchange(0, std::memory_order_relaxed);
+    if (vkey < GAMEPAD_VKEY_BASE || vkey >= AXIS_VKEY_BASE) return 0;
+    return vkey - GAMEPAD_VKEY_BASE;
 }
 
 void input_polling_thread() {

--- a/src/libs/input.h
+++ b/src/libs/input.h
@@ -23,6 +23,12 @@ bool check_key_pressed(int key);
 // This consumes the key release event
 bool check_key_released(int key);
 
+// Most recent controller button press, as the bare button number the
+// config stores (0 if none since the last call, which this consumes).
+// Covers SDL joysticks too, unlike raylib's GetGamepadButtonPressed which
+// only sees devices it has a gamepad mapping for.
+int take_gamepad_button_pressed();
+
 // Clear all buffered input events
 // Useful when changing screens or locking input
 void clear_input_buffers();

--- a/src/objects/settings/option_box.cpp
+++ b/src/objects/settings/option_box.cpp
@@ -363,8 +363,23 @@ void KeyBindControllerOptionBox::confirm() {
 
 void KeyBindControllerOptionBox::update(double current_time) {
     flicker_fade->update(current_time);
-    if (is_highlighted) {
+    if (!is_highlighted) {
+        capture_armed = false;
+        return;
+    }
+    if (!capture_armed) {
+        // Drop the press that opened this box, plus anything buffered
+        // before it, so capture starts clean.
+        take_gamepad_button_pressed();
+        capture_armed = true;
+        return;
+    }
+    {
+        // raylib only reports devices it has a gamepad mapping for; fall
+        // back to the input layer's own polling, which also covers plain
+        // SDL joysticks (most drum controllers).
         int btn = ray::GetGamepadButtonPressed();
+        if (btn <= 0) btn = take_gamepad_button_pressed();
         if (btn > 0) {
             value = {btn};
             confirm();

--- a/src/objects/settings/option_box.h
+++ b/src/objects/settings/option_box.h
@@ -103,6 +103,9 @@ class KeyBindControllerOptionBox : public BaseOptionBox {
     std::vector<int> value;
     std::unique_ptr<OutlinedText>    value_text;
     std::unique_ptr<FadeAnimation>   flicker_fade;
+    // Capture starts one frame after highlighting, so the press that opened
+    // the box isn't immediately bound to it.
+    bool capture_armed = false;
 
     void rebuild_text();
 public:


### PR DESCRIPTION
## Problem

Controller buttons can't be bound in Settings → Controller 1P/2P for a lot of hardware: the option stays on `none` no matter what is pressed.

`KeyBindControllerOptionBox::update` captures with `ray::GetGamepadButtonPressed()`, which only reports devices raylib has a **gamepad mapping** for. Plenty of drum controllers enumerate as plain joysticks - which is exactly why `input.cpp` polls SDL joysticks directly (`SDL_GetJoystickButton`, folded into the key space at `10000 + btn + 1`) for gameplay. Those devices work in game but are invisible to the keybind screen.

## Fix

- `input.cpp` records the newest controller press (both the raylib-gamepad and SDL-joystick paths already funnel through `local_pressed`) in a small atomic, exposed as `take_gamepad_button_pressed()` returning the bare button number the config stores.
- It is deliberately **not** read out of `pressed_keys`: menu navigation consumes that entry before the option box updates, so the capture would miss it.
- The option box tries raylib first and falls back to it, so nothing changes for devices that already worked.
- Capture arms one frame after highlighting, so the press that opens the box isn't immediately bound to it (noticeable once drum buttons can bind at all).

Axis-based inputs are left alone - `is_input_key_pressed` only matches `10000 + button`, so axes aren't bindable to don/kat either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)