### PR TITLE
Don't accept mode-select input before the boxes appear

### DIFF
--- a/src/scenes/entry.cpp
+++ b/src/scenes/entry.cpp
@@ -108,6 +108,9 @@ std::optional<Screens> EntryScreen::handle_input() {
             if (player) player->handle_input();
         }
     } else if (state == EntryState::SELECT_MODE) {
+        // The mode boxes are only drawn once every player's entry animation
+        // has played out; don't let them be picked while they are invisible.
+        if (!mode_select_ready()) return std::nullopt;
         for (auto& player : players) {
             if (player) player->handle_input();
         }
@@ -196,10 +199,15 @@ void EntryScreen::draw_player_drum() {
     }
 }
 
-void EntryScreen::draw_mode_select() {
+bool EntryScreen::mode_select_ready() {
     for (auto& player : players) {
-        if (player && !player->is_cloud_animation_finished()) return;
+        if (player && !player->is_cloud_animation_finished()) return false;
     }
+    return true;
+}
+
+void EntryScreen::draw_mode_select() {
+    if (!mode_select_ready()) return;
     box_manager->draw();
 }
 

--- a/src/scenes/entry.h
+++ b/src/scenes/entry.h
@@ -42,6 +42,9 @@ private:
     void draw_side_select(float fade);
     void draw_player_drum();
     void draw_mode_select();
+    // True once every registered player's entry animation has played out,
+    // i.e. once the mode boxes are actually on screen.
+    bool mode_select_ready();
     std::optional<Screens> handle_input();
 
 public:


### PR DESCRIPTION
## Problem

On the entry screen, after registering (1P, or 1P and 2P), the mode boxes fly in with the entry animation - but input is accepted immediately. You can pick a mode and be in song select before the boxes have even appeared, which reads as the game skipping a step.

## Cause

`draw_mode_select()` already gates drawing on every registered player's entry animation being finished:

```cpp
for (auto& player : players)
    if (player && !player->is_cloud_animation_finished()) return;
box_manager->draw();
```

`handle_input()`'s `SELECT_MODE` branch has no such check, so the invisible boxes respond to input.

## Fix

Pull the condition into `mode_select_ready()` and use it in both places, so input opens exactly when the boxes become visible. The 2P join branch is inside the same gate, which is consistent - the screen isn't ready yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)