### PR TITLE
Fix the input test screen being silent

### DIFF
--- a/src/libs/audio.cpp
+++ b/src/libs/audio.cpp
@@ -807,9 +807,13 @@ void AudioEngine::load_screen_sounds(const std::string& screen_name) {
     fs::path parent_sounds = tex.parent_root() / "Sounds";
 
     fs::path path = sounds_path / screen_name;
-    if (!fs::exists(path) && !(has_parent && fs::exists(parent_sounds / screen_name))) {
+    // A screen without its own sound folder still gets don/kat and the
+    // global folder - those are screen-independent. Returning here also
+    // took those away, leaving such screens (input_test, loading) silent.
+    bool has_screen_sounds = fs::exists(path) ||
+                             (has_parent && fs::exists(parent_sounds / screen_name));
+    if (!has_screen_sounds) {
         spdlog::warn("Sounds for screen {} not found", screen_name);
-        return;
     }
 
     if (has_parent) load_sound(parent_sounds / "don.wav", "don");
@@ -817,8 +821,10 @@ void AudioEngine::load_screen_sounds(const std::string& screen_name) {
     if (has_parent) load_sound(parent_sounds / "ka.wav", "kat");
     load_sound(sounds_path / "ka.wav", "kat");
 
-    if (has_parent) scan(parent_sounds / screen_name);
-    scan(path);
+    if (has_screen_sounds) {
+        if (has_parent) scan(parent_sounds / screen_name);
+        scan(path);
+    }
 
     if (has_parent) scan(parent_sounds / "global");
     scan(sounds_path / "global");

--- a/src/scenes/input_test.cpp
+++ b/src/scenes/input_test.cpp
@@ -2,6 +2,10 @@
 #include "../libs/input.h"
 
 void InputTestScreen::on_screen_start() {
+    // Loads the screen's sounds (don/kat come from the skin root), which the
+    // hit handlers below play. Without it the screen was silent - the
+    // previous screen's on_screen_end had already unloaded everything.
+    Screen::on_screen_start();
     tex.load_animations("game");
     tex.load_folder("game", "practice");
     tex.load_folder("settings", "background");


### PR DESCRIPTION
The input test screen (F3 in settings) plays `don`/`kat` on every hit but is completely silent. Two causes, one per commit:

## 1. The screen never loaded its sounds

`InputTestScreen::on_screen_start` overrides the base without calling it, so `load_screen_textures`/`load_screen_sounds` never ran for the screen. The previous screen's `on_screen_end` had already called `unload_all_sounds`, so there was nothing left to play.

## 2. Screens without a sound folder lose don/kat entirely

`load_screen_sounds` returns early when the screen has no folder of its own:

```cpp
if (!fs::exists(path) && !(has_parent && fs::exists(parent_sounds / screen_name))) {
    spdlog::warn("Sounds for screen {} not found", screen_name);
    return;
}

if (has_parent) load_sound(parent_sounds / "don.wav", "don");
load_sound(sounds_path / "don.wav", "don");
...
scan(sounds_path / "global");
```

Everything after that `return` is screen-independent - the don/kat drum sounds and the global folder - so with (1) fixed the screen would still be silent, since `Sounds/input_test` doesn't exist. Keep the warning, skip only the per-screen scan. The loading screen hits the same path.

Confirmed from the log: entering the screen printed `input_test initialized` with no `Sounds for screen input_test` warning at all, which is what pointed at (1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)