### PR TITLE
Show left and right don separately on the input test

### DIFF
--- a/src/scenes/input_test.h
+++ b/src/scenes/input_test.h
@@ -14,7 +14,18 @@ public:
 
     void draw(float) override {
         if (type == DrumType::DON) {
+            // The skin ships a single full-face don flash, so clip it to the
+            // half that was actually hit - otherwise left and right don look
+            // identical on the input test.
+            auto& drum   = *tex.textures[PRACTICE::LARGE_DRUM];
+            float left   = x_offset + (float)drum.x[0];
+            float centre = left + drum.width / 2.0f;
+            float right  = left + (float)drum.width;
+            int sx = virtual_to_screen_x(side == Side::LEFT ? left   : centre);
+            int ex = virtual_to_screen_x(side == Side::LEFT ? centre : right);
+            ray::BeginScissorMode(sx, 0, ex - sx, ray::GetScreenHeight());
             tex.draw_texture(PRACTICE::LARGE_DRUM_DON, {.x = x_offset, .y = y_offset, .fade = fade->attribute});
+            ray::EndScissorMode();
         } else if (side == Side::LEFT) {
             tex.draw_texture(PRACTICE::LARGE_DRUM_KAT_L, {.x = x_offset, .y = y_offset, .fade = fade->attribute});
         } else {


### PR DESCRIPTION
On the input test screen (F3 in settings), left don and right don look identical: `InputTestDrumEffect::draw` uses the same `LARGE_DRUM_DON` texture for both sides, so the whole drum head flashes red either way and you can't verify which input actually fired.

The practice skin only ships one full-face don flash (kat already has `_L`/`_R` variants), so clip the flash to the half matching the side that was hit, using the drum's own texture metrics - no new art needed and it scales with the skin resolution.

Pairs with #115, which makes the screen's hit sounds audible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)