### PR TITLE
Prefer the localised texture when resolving a script texture name

### DIFF
--- a/src/libs/script.cpp
+++ b/src/libs/script.cpp
@@ -369,6 +369,12 @@ void ScriptManager::register_lua_bindings() {
         info["name"] = tex_obj->name;
         info["x"] = sol::as_table(tex_obj->x);
         info["y"] = sol::as_table(tex_obj->y);
+        // Drawn size per position, which is what draw_texture uses. This
+        // differs from width/height (the source image size) whenever
+        // texture.json stretches the texture, e.g. a nine-slice centre
+        // piece - scripts need it to lay out against what is on screen.
+        info["x2"] = sol::as_table(tex_obj->x2);
+        info["y2"] = sol::as_table(tex_obj->y2);
         info["width"] = tex_obj->width;
         info["height"] = tex_obj->height;
 
@@ -406,9 +412,14 @@ void ScriptManager::register_lua_bindings() {
 
         script_manager.tex.load_folder(screen_name, subset);
 
-        auto it = tex_id_map.find(subset + "/" + texture_name);
+        // Look for the localised variant first. Texture ids are keyed by
+        // subset, not by screen, so an unrelated screen using the same
+        // subset name can own the unsuffixed id - result/background asking
+        // for "result_text" resolved to dan_result's, which isn't loaded
+        // here, and the header silently didn't draw.
+        auto it = tex_id_map.find(subset + "/" + texture_name + "_" + global_data.config->general.language);
         if (it != tex_id_map.end()) return static_cast<uint32_t>(it->second);
-        it = tex_id_map.find(subset + "/" + texture_name + "_" + global_data.config->general.language);
+        it = tex_id_map.find(subset + "/" + texture_name);
         if (it != tex_id_map.end()) return static_cast<uint32_t>(it->second);
         return sol::nullopt;
     });


### PR DESCRIPTION
## Symptom

The 成績発表 header on the results screen doesn't draw.

## Cause

`tex.load_texture` resolves the unsuffixed name first:

```cpp
auto it = tex_id_map.find(subset + "/" + texture_name);
if (it != tex_id_map.end()) return ...;
it = tex_id_map.find(subset + "/" + texture_name + "_" + language);
```

`result_background.lua` asks for `result/background/result_text`. PyTaikoGreen's `result/background` only ships `result_text_ja`/`result_text_en` - but `tex_id_map` is keyed by **subset**, not by screen, and `dan_result/background` does have a plain `result_text`. So the first lookup hits **dan_result's** id, which isn't loaded while the normal result screen is up, and nothing is drawn.

## Fix

Try `name_<language>` first, then the plain name. When a texture ships language variants that is the one the script wants regardless, and it stops an unrelated screen's identically-named texture from shadowing it.

The underlying subset-keyed id space is the deeper issue (any two screens sharing a subset name share ids), but that is a much larger change; this fixes the class of bug that language variants run into.

## Also needed, skin-side

PyTaikoGreen's `result_player.lua` indexes the クリア graphic with:

```lua
local clear_idx = (self.difficulty + p_idx * 3) - 1
```

The texture has 3 positions per player (easy/normal/hard). Difficulty isn't clamped, so ura (4) as 1P lands on index 3 - the first **2P** slot, matching the "it moves to the first 2P location instead of the last 1P location" report - and the stray `-1` shifts every difficulty down one, with easy reaching index -1 (`x[]` is an unchecked `std::vector` access, hence the random positions). It should match the C++ it was ported from:

```lua
local clear_idx = math.min(self.difficulty, 2) + p_idx * 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)