### PR TITLE
Keep both players on the same side of the oni/ura toggle

### DIFF
--- a/src/objects/song_select/player.cpp
+++ b/src/objects/song_select/player.cpp
@@ -96,6 +96,14 @@ void SongSelectPlayer::start_background_diffs() {
     selected_diff_highlight_fade->start();
 }
 
+void SongSelectPlayer::sync_ura(bool ura) {
+    if (is_ura == ura) return;
+    is_ura = ura;
+    ura_toggle = 0;
+    if (selected_difficulty == Difficulty::ONI || selected_difficulty == Difficulty::URA)
+        selected_difficulty = Difficulty(7 - (int)selected_difficulty);
+}
+
 SongSelectState SongSelectPlayer::select_song() {
     audio.play_sound("don", VolumePreset::SOUND);
     BaseBox* item = navigator.get_current_item();

--- a/src/objects/song_select/player.cpp
+++ b/src/objects/song_select/player.cpp
@@ -126,6 +126,9 @@ void SongSelectPlayer::start_background_diffs() {
 }
 
 void SongSelectPlayer::sync_ura(bool ura) {
+    // A player who already confirmed keeps what the column showed when
+    // they pressed; only someone still choosing follows the toggle.
+    if (voice_played || is_ready) return;
     if (is_ura == ura) return;
     is_ura = ura;
     ura_toggle = 0;

--- a/src/objects/song_select/player.h
+++ b/src/objects/song_select/player.h
@@ -49,6 +49,11 @@ public:
     bool is_voice_playing();
 
     SongSelectState select_song();
+    // Follow the other player's oni/ura toggle. The difficulty column is
+    // shared in 2P, so both players must sit on the same side of it -
+    // otherwise the column reads ura while this player still starts oni.
+    // No sound or switch animation: the player who toggled already ran it.
+    void sync_ura(bool ura);
     // Fully cancel this player's difficulty pick (leaving diff select).
     // Clears voice_played too: it survives is_ready, and the ready check in
     // update() re-arms from it, instantly re-locking the player otherwise.

--- a/src/scenes/song_select_2p.cpp
+++ b/src/scenes/song_select_2p.cpp
@@ -33,12 +33,21 @@ void SongSelect2PScreen::handle_input_browsing(double current_ms) {
 }
 
 void SongSelect2PScreen::handle_input_selecting() {
+    bool ura_1p = player->is_ura;
+    bool ura_2p = player_2->is_ura;
+
     if (!player->is_ready) {
         player->handle_input_selecting();
     }
     if (!player_2->is_ready) {
         player_2->handle_input_selecting();
     }
+
+    // Both players share one difficulty column, so whoever flipped the
+    // oni/ura toggle this frame decides it for both - what the column
+    // shows is what both players get.
+    if (player->is_ura != ura_1p)        player_2->sync_ura(player->is_ura);
+    else if (player_2->is_ura != ura_2p) player->sync_ura(player_2->is_ura);
 }
 
 void SongSelect2PScreen::select_song(SongBox* song) {


### PR DESCRIPTION
## Repro

2P mode, a song with both oni and ura, both players on the おに column. 1P taps right ten times - the column visibly becomes ura. Both confirm: **1P plays ura, 2P plays oni**, even though the screen only ever showed one difficulty.

## Cause

The difficulty column is shared between both players, but `is_ura` and `selected_difficulty` are per player. `toggle_ura_mode()` flips only the toggling player and writes `song->is_ura` on the shared `SongBox` - which is what the column draws. The other player is never told, so the display and their actual difficulty diverge.

## Rule

What the column shows **when you press** is what you get:

- a player still choosing follows the toggle, so the column always matches what they will play
- a player who has already confirmed keeps their pick

So 1P confirming on ura, then 2P tapping back to oni and confirming, correctly gives 1P ura and 2P oni - each got what was on screen at their moment of confirming.

## Change

`SongSelect2PScreen::handle_input_selecting` compares each player's `is_ura` before and after their input; whoever flipped it this frame has the other call `sync_ura()`. `sync_ura` ignores a player who has confirmed, and only adopts the state (flipping ONI↔URA when they're on that column) - it deliberately doesn't replay the switch sound or animation, since there is one shared column and the toggling player already ran both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)