### PR TITLE
Give collection songs their real genre

### DIFF
--- a/src/objects/song_select/file_navigator/box_song.cpp
+++ b/src/objects/song_select/file_navigator/box_song.cpp
@@ -4,6 +4,10 @@
 SongBox::SongBox(const fs::path& path, const BoxDef& box_def, SongParser parser)
     : BaseBox(path, box_def)
 {
+    // Same as the box's genre unless this is a collection listing, where
+    // apply_song_genre overrides it with the folder the song lives in.
+    song_genre_index = genre_index;
+
     parser.get_metadata();
     auto& titles = parser.metadata.title;
     const std::string& lang = global_data.config->general.language;

--- a/src/objects/song_select/file_navigator/box_song.h
+++ b/src/objects/song_select/file_navigator/box_song.h
@@ -21,6 +21,11 @@ public:
     double box_opened_at = 0.0;
     FadeAnimation* diff_fade_in;
     bool is_ura = false;
+    // The genre the song itself belongs to. Same as genre_index for a song
+    // sitting in its genre folder, but inside a collection the box keeps the
+    // collection's genre (its colours and background are the collection's)
+    // while the game screen still needs the song's own genre for its label.
+    GenreIndex song_genre_index = GenreIndex::DEFAULT;
 
     SongBox(const fs::path& path, const BoxDef& box_def, SongParser parser);
 

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -78,7 +78,13 @@ static bool alpha_less(const std::string& a, const std::string& b) {
     return a.size() < b.size();
 }
 
-static void apply_song_color(SongBox* song, const BoxDef& box_def) {
+// A song listed inside a collection (recent, recommended, favourite, ...)
+// is built from that collection's BoxDef, so it inherits the collection's
+// genre. Adopt the genre folder's presentation instead: its colour, and its
+// genre index - the collection ones are past the end of the genre graphics,
+// so the game screen's genre label came out blank.
+static void apply_song_genre(SongBox* song, const BoxDef& box_def) {
+    song->genre_index = box_def.genre_index;
     if (box_def.fore_color.has_value())
         song->fore_color = box_def.fore_color;
     else if (box_def.back_color.has_value())
@@ -479,7 +485,7 @@ void Navigator::load_collection_new(const fs::path& path, const BoxDef& box_def)
             if (songs_added > 0 && songs_added % 10 == 0)
                 enqueue_inline_box(make_back_box(path.parent_path()));
             auto song = make_song_box(entry.path(), box_def, SongParser(entry.path()));
-            apply_song_color(song.get(), sibling_box_def);
+            apply_song_genre(song.get(), sibling_box_def);
             song->fade_in(266);
             enqueue_inline_box(std::move(song));
             songs_added++;
@@ -504,7 +510,7 @@ void Navigator::load_collection_difficulty(const fs::path& path, const BoxDef& b
             if (songs_added > 0 && songs_added % 10 == 0)
                 enqueue_inline_box(make_back_box(path.parent_path()));
             auto song = make_song_box(entry.path(), box_def, parser);
-            apply_song_color(song.get(), sibling_box_def);
+            apply_song_genre(song.get(), sibling_box_def);
             song->fade_in(266);
             enqueue_inline_box(std::move(song));
             songs_added++;
@@ -545,7 +551,7 @@ void Navigator::load_from_song_list(const fs::path& path, const BoxDef& box_def,
         if (mark_favorite) song->is_favorite = true;
         fs::path genre_folder = find_box_def_folder(song_path);
         if (!genre_folder.empty())
-            apply_song_color(song.get(), parse_box_def(genre_folder));
+            apply_song_genre(song.get(), parse_box_def(genre_folder));
         song->fade_in(266);
         enqueue_inline_box(std::move(song));
         songs_added++;
@@ -631,7 +637,7 @@ void Navigator::load_collection_recommended(const fs::path& path, const BoxDef& 
         auto song = make_song_box(song_path, box_def, SongParser(song_path));
         fs::path genre_folder = find_box_def_folder(song_path);
         if (!genre_folder.empty())
-            apply_song_color(song.get(), parse_box_def(genre_folder));
+            apply_song_genre(song.get(), parse_box_def(genre_folder));
         song->fade_in(266);
         enqueue_inline_box(std::move(song));
     }
@@ -652,7 +658,7 @@ void Navigator::load_collection_search(const fs::path& path, const BoxDef& box_d
         auto song = make_song_box(song_path, box_def, SongParser(song_path));
         fs::path genre_folder = find_box_def_folder(song_path);
         if (!genre_folder.empty())
-            apply_song_color(song.get(), parse_box_def(genre_folder));
+            apply_song_genre(song.get(), parse_box_def(genre_folder));
         song->fade_in(266);
         enqueue_inline_box(std::move(song));
         songs_added++;

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -78,13 +78,12 @@ static bool alpha_less(const std::string& a, const std::string& b) {
     return a.size() < b.size();
 }
 
-// A song listed inside a collection (recent, recommended, favourite, ...)
-// is built from that collection's BoxDef, so it inherits the collection's
-// genre. Adopt the genre folder's presentation instead: its colour, and its
-// genre index - the collection ones are past the end of the genre graphics,
-// so the game screen's genre label came out blank.
+// Record where the song really lives. A song listed inside a collection is
+// built from that collection's BoxDef, so the box keeps the collection's
+// genre on purpose - its colours and the wheel background stay the
+// collection's - but the game screen's genre label needs the song's own.
 static void apply_song_genre(SongBox* song, const BoxDef& box_def) {
-    song->genre_index = box_def.genre_index;
+    song->song_genre_index = box_def.genre_index;
     if (box_def.fore_color.has_value())
         song->fore_color = box_def.fore_color;
     else if (box_def.back_color.has_value())

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -43,7 +43,7 @@ void SongSelectScreen::select_song(SongBox* song) {
     session_data.selected_song = song->path;
     session_data.selected_difficulty = (int)player->selected_difficulty;
     session_data.song_hash = song->hashes[session_data.selected_difficulty];
-    session_data.genre_index = (int)song->genre_index - 1;
+    session_data.genre_index = (int)song->song_genre_index - 1;
     global_data.last_difficulty[(int)global_data.player_num] = session_data.selected_difficulty;
     game_transition.emplace(song->text_name, song->text_subtitle, false);
     if (exists(session_data.selected_song.parent_path() / "Loading.png")) {

--- a/src/scenes/song_select_2p.cpp
+++ b/src/scenes/song_select_2p.cpp
@@ -58,13 +58,13 @@ void SongSelect2PScreen::select_song(SongBox* song) {
     sd1.selected_song = song->path;
     sd1.selected_difficulty = (int)player->selected_difficulty;
     sd1.song_hash = song->hashes[sd1.selected_difficulty];
-    sd1.genre_index = (int)song->genre_index - 1;
+    sd1.genre_index = (int)song->song_genre_index - 1;
 
     auto& sd2 = global_data.session_data[(int)PlayerNum::P2];
     sd2.selected_song = song->path;
     sd2.selected_difficulty = (int)player_2->selected_difficulty;
     sd2.song_hash = song->hashes[sd2.selected_difficulty];
-    sd2.genre_index = (int)song->genre_index - 1;
+    sd2.genre_index = (int)song->song_genre_index - 1;
 
     global_data.last_difficulty[(int)PlayerNum::P1] = sd1.selected_difficulty;
     global_data.last_difficulty[(int)PlayerNum::P2] = sd2.selected_difficulty;


### PR DESCRIPTION
## Repro

Start a song from **Recently Played** or **Recommended Songs**: the genre label in the top-right of the game screen is missing. Starting the same song from its genre folder shows it.

## Cause

Songs inside a collection are created with the collection's `BoxDef`, so `BaseBox` gives the box `GenreIndex::RECENT` (12) / `RECOMMENDED` (10) / `FAVORITE` (11). The game screen draws its label as frame `genre_index - 1`, and those are past the end of the genre graphics (TUTORIAL..NAMCO = 0..8), so nothing is drawn.

## Fix

`SongBox` carries the song's own genre in a separate `song_genre_index`, defaulting to the box's genre and overridden (next to the existing colour lookup) only for collection listings, where the song's real genre folder is already known. Only the game screen's genre label reads it.

The box's own `genre_index` is deliberately left alone, so a collection keeps its own colours, banner and wheel background - browsing Recommended looks exactly as it does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)