### PR TITLE
Move a played song to the top of the recent listing on screen

### DIFF
--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -610,6 +610,40 @@ void Navigator::add_to_recent(const SongBox* song) {
     if ((int)entries.size() > 25) entries.resize(25);
 
     write_song_list(song_list_path, entries);
+    promote_recent_box(song);
+}
+
+// The listing keeps back boxes interleaved every 10 songs, so move the song
+// between the song slots only and leave those separators where they are.
+void Navigator::promote_recent_box(const SongBox* song) {
+    if (!inline_state.has_value() || pending_inline_folder == nullptr) return;
+    if (pending_inline_folder->collection != "RECENT") return;
+
+    int first = inline_state->first_song_index;
+    int end   = first + inline_state->songs_count;
+    if (first < 0 || end > (int)items.size()) return;
+
+    std::vector<int> slots;
+    for (int i = first; i < end; i++)
+        if (dynamic_cast<SongBox*>(items[i].get())) slots.push_back(i);
+
+    int pos = -1;
+    for (int i = 0; i < (int)slots.size(); i++)
+        if (items[slots[i]]->path == song->path) { pos = i; break; }
+    if (pos <= 0) return;  // not in this listing, or already first
+
+    auto moved = std::move(items[slots[pos]]);
+    for (int i = pos; i > 0; i--) items[slots[i]] = std::move(items[slots[i - 1]]);
+    items[slots[0]] = std::move(moved);
+
+    // Keep the cursor on the same song rather than on whatever slid into
+    // its slot.
+    if (open_index == slots[pos]) {
+        open_index = slots[0];
+    } else {
+        for (int i = 0; i < pos; i++)
+            if (open_index == slots[i]) { open_index = slots[i + 1]; break; }
+    }
 }
 
 void Navigator::load_collection_recommended(const fs::path& path, const BoxDef& box_def) {

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -88,6 +88,9 @@ private:
     void load_collection_recommended(const fs::path& path, const BoxDef& box_def);
     void load_collection_search(const fs::path& path, const BoxDef& box_def);
     void load_songs_inline_async(const fs::path path, BoxDef box_def);
+    // Mirror add_to_recent's reordering in the boxes already on screen, so
+    // coming back to the recent collection doesn't show a stale order.
+    void promote_recent_box(const SongBox* song);
     void flush_pending_boxes();
     void exit_inline();
     void begin_inline_load();


### PR DESCRIPTION
## Repro

Open **Recently Played**, start the 5th song, finish it, come back to song select: it is still shown 5th. Leaving and reopening the folder shows it first.

## Cause

`add_to_recent` rewrites `song_list.txt` correctly (removes the old entry, inserts at the front), but the boxes built for the open collection are untouched. On returning, `Navigator::init` takes the already-initialised path, which only resets the existing items and fades them back in - so the wheel keeps the order it was built with, and only a fresh load of the folder picks up the new one.

## Fix

Mirror the reorder in the boxes right where the file is written: move the song to the front of the listing's song slots. The back boxes interleaved every 10 songs stay where they are (they are separators, not entries), and the cursor follows the song that moved so the player comes back to the one they just played.

It only touches the listing when the open collection is RECENT, so nothing changes when the song was started from a genre folder or another collection - those already load fresh next time they are opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)