### PR TITLE
Keep song_list.txt collections in file order

### DIFF
--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -542,6 +542,10 @@ void Navigator::load_from_song_list(const fs::path& path, const BoxDef& box_def,
         if (songs_added > 0 && songs_added % 10 == 0)
             enqueue_inline_box(make_back_box(path.parent_path()));
         auto song = make_song_box(song_path, box_def, SongParser(song_path));
+        // The text file is the order: most recent first for RECENT, the
+        // order they were added for FAVORITE. Without this the completion
+        // sort alphabetises them and that meaning is lost.
+        song->preserve_order = true;
         if (mark_favorite) song->is_favorite = true;
         fs::path genre_folder = find_box_def_folder(song_path);
         if (!genre_folder.empty())


### PR DESCRIPTION
Folders backed by `song_list.txt` should follow the file's order, but **Recently Played** and **Favorites** come out alphabetised, so "recently played" doesn't actually show the most recent first.

`sort_items` already skips boxes flagged `preserve_order`, and `parse_song_list` sets that flag - but `load_from_song_list`, which builds the RECENT and FAVORITE collections, never did, so the completion sort reordered them.

Set the flag there too. Pairs with #120, which keeps that order live on screen after a song is played.

🤖 Generated with [Claude Code](https://claude.com/claude-code)