### PR TITLE
Keep dan and tower charts out of the song collections

### DIFF
--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -122,11 +122,6 @@ void Navigator::preload(std::vector<fs::path> songs_paths) {
                         if (is_song_file(it->path())) {
                             SongParser parsed_entry = SongParser(it->path());
                             parsed_entry.get_metadata();
-                            // Dan (course 6) and Tower (course 5) charts are
-                            // played from their own screens, never from a song
-                            // box: they carry no normal difficulty to select,
-                            // so picking one out of a collection breaks. Keep
-                            // them out of the index collections draw from.
                             bool playable = false;
                             for (const auto& [course, data] : parsed_entry.metadata.course_data)
                                 if (course >= 0 && course <= 4) { playable = true; break; }

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -122,7 +122,16 @@ void Navigator::preload(std::vector<fs::path> songs_paths) {
                         if (is_song_file(it->path())) {
                             SongParser parsed_entry = SongParser(it->path());
                             parsed_entry.get_metadata();
-                            song_files[{parsed_entry.metadata.title["en"], parsed_entry.metadata.subtitle["en"]}] = it->path();
+                            // Dan (course 6) and Tower (course 5) charts are
+                            // played from their own screens, never from a song
+                            // box: they carry no normal difficulty to select,
+                            // so picking one out of a collection breaks. Keep
+                            // them out of the index collections draw from.
+                            bool playable = false;
+                            for (const auto& [course, data] : parsed_entry.metadata.course_data)
+                                if (course >= 0 && course <= 4) { playable = true; break; }
+                            if (playable)
+                                song_files[{parsed_entry.metadata.title["en"], parsed_entry.metadata.subtitle["en"]}] = it->path();
                         }
                     } catch (const std::exception& inner) {
                         spdlog::warn("Skipping song during scan: {}", inner.what());


### PR DESCRIPTION
Dan dojo courses can turn up in Recommended (and in the search / sort-by-difficulty collections). Picking one shows four empty difficulty columns and then errors out.

The song index walks every chart under the song roots and indexes it. A dan course chart carries only `COURSE:Dan` — course 6 — and never a normal difficulty, so there is nothing selectable on it. Same for `COURSE:Tower` charts.

This indexes only charts that have at least one difficulty in the normal 0–4 range. All three collections read from that index, so all three are covered. The dan dojo is unaffected: it builds its list from `dan.json`, and the member songs it resolves by title are ordinary charts elsewhere in the library.

Tested on Windows against a library with the full TJADB dan dojo set (Nijiiro 2020–2022, Green): dan courses no longer appear in Recommended, and the dojo itself still loads and plays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)