### PR TITLE
Count each song played once

### DIFF
--- a/src/scenes/game.cpp
+++ b/src/scenes/game.cpp
@@ -279,7 +279,6 @@ void GameScreen::save_score(int player_id, PlayerNum player_num) {
     }
     scores_manager.save_score(hash, session_data.selected_difficulty, player_id, score);
     network.submit_score(hash, session_data.selected_difficulty, global_data.config->general.access_code, score);
-    global_data.songs_played += 1;
 }
 
 void GameScreen::resync_song(double current_ms) {
@@ -312,6 +311,8 @@ void GameScreen::end_song() {
         for (auto& player : players) {
             player->spawn_ending_anim();
         }
+        // One song was played, whatever was or wasn't recorded for it.
+        global_data.songs_played += 1;
         score_saved = true;
     }
     if (ms_from_start >= players[0]->end_time + 8533.34) {

--- a/src/scenes/game.cpp
+++ b/src/scenes/game.cpp
@@ -311,7 +311,6 @@ void GameScreen::end_song() {
         for (auto& player : players) {
             player->spawn_ending_anim();
         }
-        // One song was played, whatever was or wasn't recorded for it.
         global_data.songs_played += 1;
         score_saved = true;
     }


### PR DESCRIPTION
`global_data.songs_played` is incremented inside `GameScreen::save_score`, which runs once per player and only when a score is actually recorded — neither of which matches "a song was played".

- `Game2PScreen::end_song` calls `save_score` for both players and then increments the counter itself, so every song in two player play counts **three** times.
- An auto-play run skips `save_score` entirely, so it counts **zero**.

This moves the increment out of `save_score` and into `GameScreen::end_song`, next to the one `Game2PScreen::end_song` already has. Every song end now counts exactly one, in one player, two player and auto-play alike.

Tested on Windows: the 1曲目 / 2曲目 counter on song select now advances by one per song in both 1P and 2P.

🤖 Generated with [Claude Code](https://claude.com/claude-code)