### PR TITLE
Dan course song number, genre and early finish

### DIFF
--- a/src/objects/game/song_info.cpp
+++ b/src/objects/game/song_info.cpp
@@ -1,11 +1,11 @@
 #include "song_info.h"
 #include "../../libs/global_data.h"
 
-SongInfo::SongInfo(const std::string& song_name, int genre)
+SongInfo::SongInfo(const std::string& song_name, int genre, int song_num)
     : song_name(song_name), genre(genre) {
 
     song_title = std::make_unique<OutlinedText>(song_name, tex.skin_config[SC::SONG_INFO].font_size, ray::WHITE, ray::BLACK, false, 5);
-    song_num = std::make_unique<SongNum>(global_data.songs_played + 1);
+    this->song_num = std::make_unique<SongNum>(song_num);
     fade = (FadeAnimation*)tex.get_animation(3);
 }
 
@@ -29,10 +29,10 @@ SongNum::SongNum(int song_num) {
     std::string song_format = tex.skin_config[SC::SONG_NUM].text[global_data.config->general.language];
     size_t pos = song_format.find("{0}");
     if (pos != std::string::npos) {
-        song_format.replace(pos, 3, std::to_string(global_data.songs_played + 1));
+        song_format.replace(pos, 3, std::to_string(song_num));
     }
     ray::Color outline_color;
-    if (global_data.config->general.song_limit > 0 && global_data.config->general.song_limit == global_data.songs_played + 1) {
+    if (global_data.config->general.song_limit > 0 && global_data.config->general.song_limit == song_num) {
         outline_color = ray::RED;
     } else {
         outline_color = ray::BLACK;

--- a/src/objects/game/song_info.h
+++ b/src/objects/game/song_info.h
@@ -24,7 +24,7 @@ private:
 
 public:
     SongInfo() = default;
-    SongInfo(const std::string& song_name, int genre);
+    SongInfo(const std::string& song_name, int genre, int song_num);
 
     void update(double current_ms);
     void draw();

--- a/src/objects/sandbox/fixtures.h
+++ b/src/objects/sandbox/fixtures.h
@@ -705,10 +705,10 @@ struct SongInfoFixture : public SandboxScreen::Fixture {
 
     uint32_t anchor_texture_id() override { return SONG_INFO::GENRE; }
 
-    void reset(double) override { active.emplace("Test Song", genre); }
+    void reset(double) override { active.emplace("Test Song", genre, 1); }
     void on_tab(double) override {
         genre = (genre + 1) % 9;
-        active.emplace("Test Song", genre);
+        active.emplace("Test Song", genre, 1);
     }
 
     void update(double ms) override { if (active) active->update(ms); }

--- a/src/scenes/game.cpp
+++ b/src/scenes/game.cpp
@@ -52,7 +52,7 @@ void GameScreen::on_screen_start() {
     init_tja(session_data.selected_song);
     spdlog::info("TJA initialized for song: {}", session_data.selected_song.string());
     load_hitsounds();
-    song_info = SongInfo(session_data.song_title, session_data.genre_index);
+    song_info = SongInfo(session_data.song_title, session_data.genre_index, global_data.songs_played + 1);
     result_transition = ResultTransition(global_data.player_num);
     bpm = parser->metadata.bpm;
     scene_preset = parser->metadata.scene_preset;

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -1,4 +1,5 @@
 #include "game_dan.h"
+#include <algorithm>
 #include "../libs/input.h"
 
 void DanGameScreen::on_screen_start() {
@@ -249,7 +250,12 @@ std::optional<Screens> DanGameScreen::update() {
             sd.dan_result_data.songs.push_back(song_res);
         }
 
-        bool is_last = (song_index == (int)sd.selected_dan.size() - 1);
+        // A course is over once a condition has been lost: the songs left
+        // cannot bring it back, so the run finishes with this song and goes to
+        // the results instead of moving on.
+        bool any_failed = std::any_of(exam_failed.begin(), exam_failed.end(),
+                                      [](bool failed) { return failed; });
+        bool is_last = (song_index == (int)sd.selected_dan.size() - 1) || any_failed;
         if (is_last) {
             if (ms_from_start >= players[0]->end_time + 1000 && !score_saved) {
                 sd.dan_result_data.dan_color   = dan_color;

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -250,9 +250,6 @@ std::optional<Screens> DanGameScreen::update() {
             sd.dan_result_data.songs.push_back(song_res);
         }
 
-        // A course is over once a condition has been lost: the songs left
-        // cannot bring it back, so the run finishes with this song and goes to
-        // the results instead of moving on.
         bool any_failed = std::any_of(exam_failed.begin(), exam_failed.end(),
                                       [](bool failed) { return failed; });
         bool is_last = (song_index == (int)sd.selected_dan.size() - 1) || any_failed;

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -89,7 +89,7 @@ void DanGameScreen::init_dan() {
     hori_name = std::make_unique<OutlinedText>(title, tex.skin_config[SC::DAN_TITLE].font_size, ray::WHITE, ray::BLACK, false);
 
     current_song_title = parser->metadata.title.count(lang) ? parser->metadata.title.at(lang) : parser->metadata.title.at("en");
-    song_info = SongInfo(current_song_title, first.genre_index);
+    song_info = SongInfo(current_song_title, first.genre_index - 1, 1);
 
     start_ms = get_current_ms() - parser->metadata.offset * 1000;
 }
@@ -115,7 +115,7 @@ void DanGameScreen::change_song() {
 
     const std::string& lang = global_data.config->general.language;
     current_song_title = parser->metadata.title.count(lang) ? parser->metadata.title.at(lang) : parser->metadata.title.at("en");
-    song_info = SongInfo(current_song_title, entry.genre_index);
+    song_info = SongInfo(current_song_title, entry.genre_index - 1, song_index + 1);
 
     //dan_transition.start();
     start_ms = get_current_ms() - parser->metadata.offset * 1000;

--- a/src/scenes/result.cpp
+++ b/src/scenes/result.cpp
@@ -15,7 +15,7 @@ void ResultScreen::on_screen_start() {
         background.emplace(global_data.player_num, tex.screen_width);
     }
     player_1.emplace(global_data.player_num, false, false);
-    song_num = std::make_unique<SongNum>(global_data.songs_played);
+    song_num = std::make_unique<SongNum>(global_data.songs_played + 1);
 }
 
 Screens ResultScreen::on_screen_end(Screens next_screen) {

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -32,7 +32,7 @@ void SongSelectScreen::on_screen_start() {
     player->script = script.get();
 
     indicator = std::make_unique<Indicator>(Indicator::State::SELECT);
-    song_num = std::make_unique<SongNum>(global_data.songs_played);
+    song_num = std::make_unique<SongNum>(global_data.songs_played + 1);
     select_timer = std::make_unique<Timer>(100, get_current_ms(), [this]() { player->select_song(); });
     diff_select_timer = nullptr;
 }


### PR DESCRIPTION
Three things noticed while playing a dan course.

**Every song says it is the first.** `SongNum` takes a song number and ignores it, reading `global_data.songs_played` instead. That counter does not move inside a course, so all three songs announce themselves as 1曲目. It now uses the number passed in. The two existing callers passed the raw count and relied on `SongNum` adding one, so they now pass `songs_played + 1` and render exactly as before; a dan course passes its own position within the course.

**The genre label is off by one.** Song select stores a genre as `GenreIndex - 1`, which is what the in-game genre graphic is indexed by. Dan kept the raw value, so every song in a course showed the label of the genre next to its own. The shift is applied where the label is built, so the dan box banners and the dan result screen — which index their graphics by the raw value — are untouched.

**A lost condition does not end the course.** Failing a condition part way through carried on into the next song, though nothing there can win it back. The run now finishes with the song being played and goes to the results.

Best merged after #126: without the exam timing fix there, every `more` condition is failed on the first frame, so the early finish would end every course after its first song.

Tested on Windows against the TJADB dan dojo set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)