### PR TITLE
Leave the dan dojo out of practice mode

### DIFF
--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -154,9 +154,6 @@ void Navigator::preload(std::vector<fs::path> songs_paths) {
 }
 
 void Navigator::init(std::vector<fs::path> songs_paths) {
-    // The dojo is left out for practice, so a listing built for one mode is
-    // not the listing the other mode wants. Without this the wheel is simply
-    // reused and normal play inherits practice's missing dojo.
     if (is_init && hide_dan != built_hide_dan) {
         join_loader();
         is_inline = false;

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -154,6 +154,25 @@ void Navigator::preload(std::vector<fs::path> songs_paths) {
 }
 
 void Navigator::init(std::vector<fs::path> songs_paths) {
+    // The dojo is left out for practice, so a listing built for one mode is
+    // not the listing the other mode wants. Without this the wheel is simply
+    // reused and normal play inherits practice's missing dojo.
+    if (is_init && hide_dan != built_hide_dan) {
+        join_loader();
+        is_inline = false;
+        inline_state.reset();
+        pending_inline_path.reset();
+        pending_inline_folder = nullptr;
+        genre_bg.reset();
+        genre_bg_end_pos.reset();
+        awaiting_diff_sort = false;
+        diff_sort_filter.reset();
+        items.clear();
+        open_index = 0;
+        is_init = false;
+    }
+    built_hide_dan = hide_dan;
+
     if (!is_init) {
         if (!is_preloaded) {
             preload(songs_paths);
@@ -417,6 +436,11 @@ void Navigator::load_current_directory_async(const fs::path path) {
                 }
                 if (has_def_file(curr_path)) {
                     BoxDef entry_box_def = parse_box_def(curr_path);
+                    // Practice has no dan mode to enter, so the dojo is left
+                    // out of the wheel rather than leading somewhere that
+                    // cannot honour it.
+                    if (hide_dan && entry_box_def.genre_index == GenreIndex::DAN)
+                        continue;
                     auto folder = std::make_unique<FolderBox>(curr_path, entry_box_def, song_files);
                     if (entry_box_def.collection == "RECOMMENDED")
                         folder->tja_count = 10;

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -89,8 +89,6 @@ private:
     void load_collection_recommended(const fs::path& path, const BoxDef& box_def);
     void load_collection_search(const fs::path& path, const BoxDef& box_def);
     void load_songs_inline_async(const fs::path path, BoxDef box_def);
-    // Mirror add_to_recent's reordering in the boxes already on screen, so
-    // coming back to the recent collection doesn't show a stale order.
     void promote_recent_box(const SongBox* song);
     void flush_pending_boxes();
     void exit_inline();
@@ -101,13 +99,7 @@ public:
     ~Navigator();
 
     bool is_processing = false;
-    // Set before init to keep the dan dojo out of the listing.
     bool hide_dan = false;
-    // True while an inline collection (RECOMMENDED, etc.) is still streaming
-    // boxes in from the loader thread. is_processing is deliberately false
-    // during that window so the flush can finalise, but navigation must stay
-    // blocked: the completion step sorts and repositions items around
-    // open_index, so moving the selection mid-load corrupts the display.
     bool inline_streaming = false;
     fs::path current_path;
     std::string current_search;

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -31,6 +31,7 @@ private:
     int open_index;
     bool is_init      = false;
     bool is_preloaded = false;
+    bool built_hide_dan = false;
 
     std::optional<InlineState>  inline_state;
     std::optional<fs::path>     pending_inline_path;
@@ -100,6 +101,8 @@ public:
     ~Navigator();
 
     bool is_processing = false;
+    // Set before init to keep the dan dojo out of the listing.
+    bool hide_dan = false;
     // True while an inline collection (RECOMMENDED, etc.) is still streaming
     // boxes in from the loader thread. is_processing is deliberately false
     // during that window so the flush can finalise, but navigation must stay

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -20,6 +20,7 @@ void SongSelectScreen::on_screen_start() {
     game_transition.reset();
     dan_transition.reset();
 
+    navigator.hide_dan = hides_dan();
     navigator.init(global_data.config->paths.tja_path);
 #ifndef __EMSCRIPTEN__
     stats_future = std::async(std::launch::async, [this]() {

--- a/src/scenes/song_select.h
+++ b/src/scenes/song_select.h
@@ -54,6 +54,7 @@ protected:
 
     virtual void draw_overlays();
 
+    virtual bool hides_dan() { return false; }
     virtual Screens get_game_screen_target() { return Screens::GAME; }
 
 public:

--- a/src/scenes/song_select_practice.h
+++ b/src/scenes/song_select_practice.h
@@ -4,6 +4,7 @@
 class PracticeSongSelectScreen : public SongSelectScreen {
 protected:
     Screens get_game_screen_target() override { return Screens::GAME_PRACTICE; }
+    bool hides_dan() override { return true; }
 
 public:
     PracticeSongSelectScreen() : SongSelectScreen("song_select") {}


### PR DESCRIPTION
Practice mode cannot enter a dan course, so the dojo folder is dropped while the listing is built instead of sitting in the wheel leading nowhere.

The listing is built once and reused on later visits to song select, so filtering alone is not enough: the mode the listing was built for is now remembered, and the wheel is rebuilt when it changes. Without that, normal play entered after practice inherits practice's listing and loses the dojo as well. The rebuild only happens on an actual mode change, so repeated visits in the same mode still reuse the listing.

Tested on Windows: dojo hidden in practice, present in normal play, and still present after going practice → back → normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)