### PR TITLE
Read the gen 4 arcade song data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,12 +145,7 @@ if(NOT ANDROID AND NOT EMSCRIPTEN)
 endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE portaudio)
 
-# G.719 support is optional: without it the gen 4 arcade songs still load and
-# play, they are simply silent.
-if(YATAIDON_G719)
-  target_link_libraries(${PROJECT_NAME} PRIVATE g719)
-  target_compile_definitions(${PROJECT_NAME} PRIVATE YATAIDON_G719)
-endif()
+target_link_libraries(${PROJECT_NAME} PRIVATE g719)
 
 include(cmake/platform.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,13 @@ if(NOT ANDROID AND NOT EMSCRIPTEN)
 endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE portaudio)
 
+# G.719 support is optional: without it the gen 4 arcade songs still load and
+# play, they are simply silent.
+if(YATAIDON_G719)
+  target_link_libraries(${PROJECT_NAME} PRIVATE g719)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE YATAIDON_G719)
+endif()
+
 include(cmake/platform.cmake)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -130,8 +130,16 @@ FetchContent_MakeAvailable(sol2)
 if(NOT ANDROID AND NOT EMSCRIPTEN)
   set(ZLIB_USE_STATIC_LIBS ON)
   if(WIN32)
-    set(CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE ON CACHE BOOL "" FORCE)
-    set(CPPTRACE_UNWIND_WITH_DBGHELP        ON CACHE BOOL "" FORCE)
+    # dbghelp, not addr2line: with addr2line on the PATH its location is baked
+    # into a define whose quoting does not survive this toolchain, and dbghelp
+    # resolves mingw symbols fine.
+    set(CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE OFF CACHE BOOL "" FORCE)
+    # dbghelp resolves the system DLLs' pdb symbols, libdwarf resolves our own
+    # mingw DWARF ones - without it a crash inside the game prints bare
+    # addresses for exactly the frames that matter.
+    set(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF  ON  CACHE BOOL "" FORCE)
+    set(CPPTRACE_GET_SYMBOLS_WITH_DBGHELP   ON  CACHE BOOL "" FORCE)
+    set(CPPTRACE_UNWIND_WITH_DBGHELP        ON  CACHE BOOL "" FORCE)
   endif()
   FetchContent_Declare(
       cpptrace

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -469,33 +469,30 @@ endif()
 # Ericsson/Polycom copyright, so they are fetched at build time and never
 # vendored into this tree; the repository has no CMake build of its own, so the
 # targets are declared here.
-option(YATAIDON_G719 "Build G.719 audio support for gen 4 arcade data" OFF)
-if(YATAIDON_G719)
-  FetchContent_Declare(
-    libg719
-    GIT_REPOSITORY https://github.com/kode54/libg719_decode.git
-    GIT_TAG master
-    GIT_SHALLOW TRUE
-  )
-  FetchContent_Populate(libg719)
+FetchContent_Declare(
+  libg719
+  GIT_REPOSITORY https://github.com/kode54/libg719_decode.git
+  GIT_TAG master
+  GIT_SHALLOW TRUE
+)
+FetchContent_Populate(libg719)
 
-  file(GLOB G719_SOURCES
-       ${libg719_SOURCE_DIR}/g719.c
-       ${libg719_SOURCE_DIR}/reference_code/common/*.c
-       ${libg719_SOURCE_DIR}/reference_code/decoder/*.c)
+file(GLOB G719_SOURCES
+     ${libg719_SOURCE_DIR}/g719.c
+     ${libg719_SOURCE_DIR}/reference_code/common/*.c
+     ${libg719_SOURCE_DIR}/reference_code/decoder/*.c)
 
-  add_library(g719 STATIC ${G719_SOURCES})
-  target_include_directories(g719 PUBLIC
-                             ${libg719_SOURCE_DIR}
-                             ${libg719_SOURCE_DIR}/reference_code/include)
-  set_target_properties(g719 PROPERTIES C_STANDARD 99)
-  # Its stack_alloc.h refuses to compile until one of the two temporary
-  # allocation modes is picked. VAR_ARRAYS uses C99 variable length arrays,
-  # which every compiler we target has, and unlike alloca it needs no
-  # platform header.
-  target_compile_definitions(g719 PRIVATE VAR_ARRAYS)
-  if(NOT MSVC)
-    # Reference code, not ours to tidy: keep its warnings out of our build log.
-    target_compile_options(g719 PRIVATE -w)
-  endif()
+add_library(g719 STATIC ${G719_SOURCES})
+target_include_directories(g719 PUBLIC
+                           ${libg719_SOURCE_DIR}
+                           ${libg719_SOURCE_DIR}/reference_code/include)
+set_target_properties(g719 PROPERTIES C_STANDARD 99)
+# Its stack_alloc.h refuses to compile until one of the two temporary
+# allocation modes is picked. VAR_ARRAYS uses C99 variable length arrays,
+# which every compiler we target has, and unlike alloca it needs no
+# platform header.
+target_compile_definitions(g719 PRIVATE VAR_ARRAYS)
+if(NOT MSVC)
+  # Reference code, not ours to tidy: keep its warnings out of our build log.
+  target_compile_options(g719 PRIVATE -w)
 endif()

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -454,3 +454,40 @@ if(WIN32)
 else()
   add_library(portaudio INTERFACE IMPORTED)
 endif()
+
+# G.719 (Siren 22) -- the codec inside the .nus3bank audio of the gen 4 arcade
+# games. No decoder for it exists in FFmpeg, and the only working one is
+# kode54's library, which wraps the ITU reference sources. Those carry an
+# Ericsson/Polycom copyright, so they are fetched at build time and never
+# vendored into this tree; the repository has no CMake build of its own, so the
+# targets are declared here.
+option(YATAIDON_G719 "Build G.719 audio support for gen 4 arcade data" OFF)
+if(YATAIDON_G719)
+  FetchContent_Declare(
+    libg719
+    GIT_REPOSITORY https://github.com/kode54/libg719_decode.git
+    GIT_TAG master
+    GIT_SHALLOW TRUE
+  )
+  FetchContent_Populate(libg719)
+
+  file(GLOB G719_SOURCES
+       ${libg719_SOURCE_DIR}/g719.c
+       ${libg719_SOURCE_DIR}/reference_code/common/*.c
+       ${libg719_SOURCE_DIR}/reference_code/decoder/*.c)
+
+  add_library(g719 STATIC ${G719_SOURCES})
+  target_include_directories(g719 PUBLIC
+                             ${libg719_SOURCE_DIR}
+                             ${libg719_SOURCE_DIR}/reference_code/include)
+  set_target_properties(g719 PROPERTIES C_STANDARD 99)
+  # Its stack_alloc.h refuses to compile until one of the two temporary
+  # allocation modes is picked. VAR_ARRAYS uses C99 variable length arrays,
+  # which every compiler we target has, and unlike alloca it needs no
+  # platform header.
+  target_compile_definitions(g719 PRIVATE VAR_ARRAYS)
+  if(NOT MSVC)
+    # Reference code, not ours to tidy: keep its warnings out of our build log.
+    target_compile_options(g719 PRIVATE -w)
+  endif()
+endif()

--- a/src/libs/audio.cpp
+++ b/src/libs/audio.cpp
@@ -1,4 +1,5 @@
 #include "audio.h"
+#include "gen4_audio.h"
 #include "texture.h"
 #ifdef __ANDROID__
 extern "C" {
@@ -641,8 +642,73 @@ std::string AudioEngine::path_to_string(const fs::path& path) const {
     return path.string();
 }
 
+// A decoded buffer handed over as raw float PCM, resampled to the device rate
+// if it does not already match. Returns null on failure; frames and rate are
+// updated in place.
+static float* adopt_decoded_pcm(std::vector<float>& samples, int channels,
+                                unsigned int& frames, unsigned int& rate,
+                                double target_rate) {
+    float* data = new float[samples.size()];
+    std::memcpy(data, samples.data(), samples.size() * sizeof(float));
+
+    if ((double)rate == target_rate) return data;
+
+    double ratio = target_rate / (double)rate;
+    long out_frames = (long)(frames * ratio) + 1;
+    float* resampled = new float[(size_t)out_frames * channels];
+    SRC_DATA sd{};
+    sd.data_in = data;          sd.input_frames = frames;
+    sd.data_out = resampled;    sd.output_frames = out_frames;
+    sd.src_ratio = ratio;       sd.end_of_input = 1;
+    int err = src_simple(&sd, SRC_SINC_FASTEST, channels);
+    delete[] data;
+    if (err) {
+        delete[] resampled;
+        spdlog::error("Resampling a decoded stream failed: {}", src_strerror(err));
+        return nullptr;
+    }
+    frames = (unsigned int)sd.output_frames_gen;
+    rate   = (unsigned int)target_rate;
+    return resampled;
+}
+
 std::string AudioEngine::load_sound(const fs::path& file_path, const std::string& name) {
     try {
+        // The gen 4 arcade banks hold G.719, which neither libsndfile nor
+        // FFmpeg reads, so they are decoded here before the usual path.
+        if (file_path.extension() == ".nus3bank") {
+            gen4::DecodedAudio decoded;
+            if (!gen4::decode_nus3bank(file_path, decoded)) return "";
+
+            unsigned int frames = (unsigned int)decoded.frame_count();
+            unsigned int rate   = (unsigned int)decoded.sample_rate;
+            float* data = adopt_decoded_pcm(decoded.samples, decoded.channels,
+                                            frames, rate, target_sample_rate);
+            if (!data) return "";
+
+            sound snd;
+            snd.data            = data;
+            snd.frame_count     = frames;
+            snd.sample_rate     = rate;
+            snd.channels        = decoded.channels;
+            snd.is_playing      = false;
+            snd.current_frame   = 0;
+            snd.loop            = false;
+            snd.volume          = 1.0f;
+            snd.pan             = 0.5f;
+            snd.pitch           = 1.0f;
+            snd.frame_frac      = 0.0f;
+            snd.resampler       = nullptr;
+            snd.resample_buffer = nullptr;
+            {
+                std::unique_lock<std::shared_mutex> guard(rw_lock);
+                sounds[name] = snd;
+            }
+            spdlog::info("Loaded sound (G.719): {} ({} frames, {} Hz, {} ch)",
+                         name, frames, rate, snd.channels);
+            return name;
+        }
+
         SF_INFO file_info;
         std::memset(&file_info, 0, sizeof(SF_INFO));
 
@@ -977,6 +1043,47 @@ void AudioEngine::seek_sound(const std::string& name, float position) {
 
 std::string AudioEngine::load_music_stream(const fs::path& file_path, const std::string& name) {
     try {
+        // As in load_sound: G.719 is decoded here, and the result is kept in
+        // memory rather than streamed, since there is no file handle to read
+        // from once it has been decoded.
+        if (file_path.extension() == ".nus3bank") {
+            gen4::DecodedAudio decoded;
+            if (!gen4::decode_nus3bank(file_path, decoded)) return "";
+
+            unsigned int frames = (unsigned int)decoded.frame_count();
+            unsigned int rate   = (unsigned int)decoded.sample_rate;
+            float* data = adopt_decoded_pcm(decoded.samples, decoded.channels,
+                                            frames, rate, target_sample_rate);
+            if (!data) return "";
+
+            music mus{};
+            mus.file_handle        = nullptr;
+            mus.file_info.channels = decoded.channels;
+            mus.file_info.samplerate = (int)rate;
+            mus.file_path          = file_path.string();
+            mus.pcm_data           = data;
+            mus.pcm_total_frames   = frames;
+            mus.buffer_size        = 4096;
+            mus.stream_buffer      = new float[mus.buffer_size * decoded.channels];
+            mus.buffer_position    = 0;
+            mus.frames_in_buffer   = 0;
+            mus.is_playing         = false;
+            mus.current_frame      = 0;
+            mus.loop               = false;
+            mus.volume             = 1.0f;
+            mus.pan                = 0.5f;
+            mus.pitch              = 1.0f;
+            mus.resampler          = nullptr;
+            mus.resample_buffer    = nullptr;
+            {
+                std::unique_lock<std::shared_mutex> guard(rw_lock);
+                music_streams[name] = mus;
+            }
+            spdlog::info("Loaded music stream (G.719): {} ({} frames, {} Hz, {} ch)",
+                         name, frames, rate, decoded.channels);
+            return name;
+        }
+
         SF_INFO file_info;
         std::memset(&file_info, 0, sizeof(SF_INFO));
 

--- a/src/libs/audio.cpp
+++ b/src/libs/audio.cpp
@@ -647,7 +647,8 @@ std::string AudioEngine::path_to_string(const fs::path& path) const {
 // updated in place.
 static float* adopt_decoded_pcm(std::vector<float>& samples, int channels,
                                 unsigned int& frames, unsigned int& rate,
-                                double target_rate) {
+                                double target_rate,
+                                int converter = SRC_SINC_FASTEST) {
     float* data = new float[samples.size()];
     std::memcpy(data, samples.data(), samples.size() * sizeof(float));
 
@@ -660,7 +661,7 @@ static float* adopt_decoded_pcm(std::vector<float>& samples, int channels,
     sd.data_in = data;          sd.input_frames = frames;
     sd.data_out = resampled;    sd.output_frames = out_frames;
     sd.src_ratio = ratio;       sd.end_of_input = 1;
-    int err = src_simple(&sd, SRC_SINC_FASTEST, channels);
+    int err = src_simple(&sd, converter, channels);
     delete[] data;
     if (err) {
         delete[] resampled;
@@ -1041,47 +1042,70 @@ void AudioEngine::seek_sound(const std::string& name, float position) {
     }
 }
 
+bool AudioEngine::prepare_nus3bank_pcm(const fs::path& file_path, PreparedPCM& out,
+                                       bool quick_resample) {
+    gen4::DecodedAudio decoded;
+    if (!gen4::decode_nus3bank(file_path, decoded)) return false;
+
+    unsigned int frames = (unsigned int)decoded.frame_count();
+    unsigned int rate   = (unsigned int)decoded.sample_rate;
+    // A preview is listened to for a few seconds through wheel movement, and
+    // the sinc pass costs more than the whole G.719 decode: linear is not
+    // audibly worse there, while the song loaded for play keeps the quality.
+    float* data = adopt_decoded_pcm(decoded.samples, decoded.channels,
+                                    frames, rate, target_sample_rate,
+                                    quick_resample ? SRC_LINEAR : SRC_SINC_FASTEST);
+    if (!data) return false;
+
+    out.data.reset(data);
+    out.frames      = frames;
+    out.rate        = rate;
+    out.channels    = decoded.channels;
+    out.preview_ms  = decoded.preview_ms;
+    out.source_path = file_path.string();
+    return true;
+}
+
+std::string AudioEngine::load_music_stream_prepared(PreparedPCM&& pcm, const std::string& name) {
+    if (!pcm.data || pcm.frames == 0 || pcm.channels <= 0) return "";
+
+    music mus{};
+    mus.file_handle        = nullptr;
+    mus.file_info.channels = pcm.channels;
+    mus.file_info.samplerate = (int)pcm.rate;
+    mus.file_path          = pcm.source_path;
+    mus.pcm_data           = pcm.data.release();
+    mus.pcm_total_frames   = pcm.frames;
+    mus.buffer_size        = 4096;
+    mus.stream_buffer      = new float[mus.buffer_size * pcm.channels];
+    mus.buffer_position    = 0;
+    mus.frames_in_buffer   = 0;
+    mus.is_playing         = false;
+    mus.current_frame      = 0;
+    mus.loop               = false;
+    mus.volume             = 1.0f;
+    mus.pan                = 0.5f;
+    mus.pitch              = 1.0f;
+    mus.resampler          = nullptr;
+    mus.resample_buffer    = nullptr;
+    {
+        std::unique_lock<std::shared_mutex> guard(rw_lock);
+        music_streams[name] = mus;
+    }
+    spdlog::info("Loaded music stream (G.719): {} ({} frames, {} Hz, {} ch)",
+                 name, pcm.frames, pcm.rate, pcm.channels);
+    return name;
+}
+
 std::string AudioEngine::load_music_stream(const fs::path& file_path, const std::string& name) {
     try {
         // As in load_sound: G.719 is decoded here, and the result is kept in
         // memory rather than streamed, since there is no file handle to read
         // from once it has been decoded.
         if (file_path.extension() == ".nus3bank") {
-            gen4::DecodedAudio decoded;
-            if (!gen4::decode_nus3bank(file_path, decoded)) return "";
-
-            unsigned int frames = (unsigned int)decoded.frame_count();
-            unsigned int rate   = (unsigned int)decoded.sample_rate;
-            float* data = adopt_decoded_pcm(decoded.samples, decoded.channels,
-                                            frames, rate, target_sample_rate);
-            if (!data) return "";
-
-            music mus{};
-            mus.file_handle        = nullptr;
-            mus.file_info.channels = decoded.channels;
-            mus.file_info.samplerate = (int)rate;
-            mus.file_path          = file_path.string();
-            mus.pcm_data           = data;
-            mus.pcm_total_frames   = frames;
-            mus.buffer_size        = 4096;
-            mus.stream_buffer      = new float[mus.buffer_size * decoded.channels];
-            mus.buffer_position    = 0;
-            mus.frames_in_buffer   = 0;
-            mus.is_playing         = false;
-            mus.current_frame      = 0;
-            mus.loop               = false;
-            mus.volume             = 1.0f;
-            mus.pan                = 0.5f;
-            mus.pitch              = 1.0f;
-            mus.resampler          = nullptr;
-            mus.resample_buffer    = nullptr;
-            {
-                std::unique_lock<std::shared_mutex> guard(rw_lock);
-                music_streams[name] = mus;
-            }
-            spdlog::info("Loaded music stream (G.719): {} ({} frames, {} Hz, {} ch)",
-                         name, frames, rate, decoded.channels);
-            return name;
+            PreparedPCM pcm;
+            if (!prepare_nus3bank_pcm(file_path, pcm)) return "";
+            return load_music_stream_prepared(std::move(pcm), name);
         }
 
         SF_INFO file_info;

--- a/src/libs/audio.h
+++ b/src/libs/audio.h
@@ -130,6 +130,22 @@ public:
     float get_sound_time_played(const std::string& name) const;
     void  seek_sound(const std::string& name, float position);
 
+    // The two halves of loading a .nus3bank as a music stream. Decoding and
+    // resampling one takes over a second, so the heavy half touches no engine
+    // state and can run on a worker thread; the cheap half hands the finished
+    // buffer to the engine.
+    struct PreparedPCM {
+        std::unique_ptr<float[]> data;      // interleaved, at the device rate
+        unsigned int frames     = 0;
+        unsigned int rate       = 0;
+        int          channels   = 0;
+        int          preview_ms = 0;        // the bank's own preview point
+        std::string  source_path;
+    };
+    bool prepare_nus3bank_pcm(const fs::path& file_path, PreparedPCM& out,
+                              bool quick_resample = false);
+    std::string load_music_stream_prepared(PreparedPCM&& pcm, const std::string& name);
+
     std::string load_music_stream(const fs::path& file_path, const std::string& name);
 #ifndef __EMSCRIPTEN__
     std::string load_music_stream_memory(const av::AVAudioStream& audio_stream, const std::string& name);

--- a/src/libs/filesystem.cpp
+++ b/src/libs/filesystem.cpp
@@ -121,8 +121,19 @@ std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
                 }
 
                 auto ext = entry.path().extension();
-                if (ext == ".tja" || ext == ".osu" || ext == ".bin")
+                if (ext == ".tja" || ext == ".osu") {
                     songs.push_back(entry.path());
+                } else if (ext == ".bin") {
+                    // Charts only ever live under a fumen folder. Everywhere
+                    // else .bin is the extension of the games' data tables,
+                    // and trying to read one as a chart is just noise.
+                    bool under_fumen = false;
+                    for (fs::path dir = entry.path().parent_path();
+                         !dir.empty() && dir != dir.parent_path(); dir = dir.parent_path()) {
+                        if (dir.filename() == "fumen") { under_fumen = true; break; }
+                    }
+                    if (under_fumen) songs.push_back(entry.path());
+                }
             }
         } catch (const std::filesystem::filesystem_error& e) {
             spdlog::error("Error scanning song directory: {}", e.what());

--- a/src/libs/filesystem.cpp
+++ b/src/libs/filesystem.cpp
@@ -1,5 +1,6 @@
 #include "filesystem.h"
 #include "miniz/miniz.h"
+#include "gen4.h"
 #include <fstream>
 #include <spdlog/spdlog.h>
 #include <unistd.h>
@@ -104,12 +105,24 @@ std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
 
         // Second pass: collect .tja and .osu files
         try {
-            for (const auto& entry : std::filesystem::recursive_directory_iterator(
-                     path, std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink)) {
-                auto ext = entry.path().extension();
-                if (ext == ".tja" || ext == ".osu" || ext == ".bin") {
-                    songs.push_back(entry.path());
+            auto it = std::filesystem::recursive_directory_iterator(
+                path, std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink);
+            for (; it != std::filesystem::end(it); ++it) {
+                const auto& entry = *it;
+
+                // A game data root is walked by the song wheel itself, which
+                // reads the game's tables. Descending into it here would mean
+                // tens of thousands of files that are chart data and tables
+                // rather than songs, and every one of them opened.
+                if (entry.is_directory() && !gen4::find_data_root(entry.path()).empty() &&
+                    gen4::find_data_root(entry.path()) == entry.path()) {
+                    it.disable_recursion_pending();
+                    continue;
                 }
+
+                auto ext = entry.path().extension();
+                if (ext == ".tja" || ext == ".osu" || ext == ".bin")
+                    songs.push_back(entry.path());
             }
         } catch (const std::filesystem::filesystem_error& e) {
             spdlog::error("Error scanning song directory: {}", e.what());

--- a/src/libs/gen4.cpp
+++ b/src/libs/gen4.cpp
@@ -1,0 +1,556 @@
+#include "gen4.h"
+
+#include <spdlog/spdlog.h>
+#include <rapidjson/document.h>
+#include <cstring>
+#include <fstream>
+#include <mutex>
+
+#include "miniz/miniz.h"
+
+
+namespace gen4 {
+
+const char* DATATABLE_SEED = "WX`Eo9yQLRJ9qsqGty`RqPCqgwBjMRbr";
+const char* FUMEN_SEED     = "[ohk39bYp7FbRRd{cPhToxBeP23W9GK{";
+
+// ---------------------------------------------------------------- SHA-256
+
+namespace {
+
+const uint32_t SHA_K[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+// -------------------------------------------------------------------- MD5
+//
+// The last step of the key derivation is an MD5 of the hex text. The TJA
+// parser has its own copy for chart hashes, but that one has internal linkage,
+// so this is a second one rather than a change to its visibility.
+
+const uint32_t MD5_SHIFT[64] = {
+    7,12,17,22, 7,12,17,22, 7,12,17,22, 7,12,17,22,
+    5, 9,14,20, 5, 9,14,20, 5, 9,14,20, 5, 9,14,20,
+    4,11,16,23, 4,11,16,23, 4,11,16,23, 4,11,16,23,
+    6,10,15,21, 6,10,15,21, 6,10,15,21, 6,10,15,21 };
+
+const uint32_t MD5_K[64] = {
+    0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee,0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501,
+    0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be,0x6b901122,0xfd987193,0xa679438e,0x49b40821,
+    0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa,0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8,
+    0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed,0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a,
+    0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c,0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70,
+    0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05,0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665,
+    0xf4292244,0x432aff97,0xab9423a7,0xfc93a039,0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1,
+    0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1,0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391 };
+
+void md5(const uint8_t* data, size_t len, uint32_t out[4]) {
+    out[0] = 0x67452301; out[1] = 0xefcdab89;
+    out[2] = 0x98badcfe; out[3] = 0x10325476;
+
+    size_t padded = ((len + 8) / 64 + 1) * 64 - 8;
+    std::vector<uint8_t> msg(padded + 8, 0);
+    memcpy(msg.data(), data, len);
+    msg[len] = 0x80;
+    uint64_t bits = (uint64_t)len * 8;
+    for (int i = 0; i < 8; i++) msg[padded + i] = (uint8_t)(bits >> (i * 8));
+
+    for (size_t off = 0; off < msg.size(); off += 64) {
+        uint32_t w[16];
+        for (int i = 0; i < 16; i++)
+            w[i] = (uint32_t)msg[off + i * 4] | ((uint32_t)msg[off + i * 4 + 1] << 8) |
+                   ((uint32_t)msg[off + i * 4 + 2] << 16) | ((uint32_t)msg[off + i * 4 + 3] << 24);
+
+        uint32_t a = out[0], b = out[1], c = out[2], d = out[3];
+        for (int i = 0; i < 64; i++) {
+            uint32_t f, g;
+            if (i < 16)      { f = (b & c) | (~b & d);  g = i; }
+            else if (i < 32) { f = (d & b) | (~d & c);  g = (5 * i + 1) % 16; }
+            else if (i < 48) { f = b ^ c ^ d;           g = (3 * i + 5) % 16; }
+            else             { f = c ^ (b | ~d);        g = (7 * i) % 16; }
+            uint32_t tmp = d;
+            d = c;
+            c = b;
+            uint32_t x = a + f + MD5_K[i] + w[g];
+            b = b + ((x << MD5_SHIFT[i]) | (x >> (32 - MD5_SHIFT[i])));
+            a = tmp;
+        }
+        out[0] += a; out[1] += b; out[2] += c; out[3] += d;
+    }
+}
+
+inline uint32_t rotr(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
+
+void sha256_block(uint32_t state[8], const uint8_t* p) {
+    uint32_t w[64];
+    for (int i = 0; i < 16; i++)
+        w[i] = ((uint32_t)p[i * 4] << 24) | ((uint32_t)p[i * 4 + 1] << 16) |
+               ((uint32_t)p[i * 4 + 2] << 8) | (uint32_t)p[i * 4 + 3];
+    for (int i = 16; i < 64; i++) {
+        uint32_t s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+        uint32_t s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+        w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+
+    uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
+    uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+
+    for (int i = 0; i < 64; i++) {
+        uint32_t s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+        uint32_t ch = (e & f) ^ (~e & g);
+        uint32_t t1 = h + s1 + ch + SHA_K[i] + w[i];
+        uint32_t s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+        uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+        uint32_t t2 = s0 + maj;
+        h = g; g = f; f = e; e = d + t1;
+        d = c; c = b; b = a; a = t1 + t2;
+    }
+
+    state[0] += a; state[1] += b; state[2] += c; state[3] += d;
+    state[4] += e; state[5] += f; state[6] += g; state[7] += h;
+}
+
+std::string to_hex_upper(const std::vector<uint8_t>& bytes) {
+    static const char* digits = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(bytes.size() * 2);
+    for (uint8_t b : bytes) {
+        out.push_back(digits[b >> 4]);
+        out.push_back(digits[b & 0x0F]);
+    }
+    return out;
+}
+
+// ------------------------------------------------------------------- AES
+
+const uint8_t AES_SBOX[256] = {
+    0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,
+    0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,
+    0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,
+    0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,
+    0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,
+    0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,
+    0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,
+    0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,
+    0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,
+    0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,
+    0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,
+    0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,
+    0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,
+    0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,
+    0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,
+    0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16,
+};
+
+uint8_t AES_INV_SBOX[256];
+
+void build_inv_sbox() {
+    static bool built = false;
+    if (built) return;
+    for (int i = 0; i < 256; i++) AES_INV_SBOX[AES_SBOX[i]] = (uint8_t)i;
+    built = true;
+}
+
+inline uint8_t xtime(uint8_t x) { return (uint8_t)((x << 1) ^ ((x >> 7) * 0x1B)); }
+
+uint8_t gmul(uint8_t a, uint8_t b) {
+    uint8_t p = 0;
+    for (int i = 0; i < 8; i++) {
+        if (b & 1) p ^= a;
+        a = xtime(a);
+        b >>= 1;
+    }
+    return p;
+}
+
+// AES-256: 14 rounds, 60 words of round key.
+void expand_key(const uint8_t key[32], uint8_t round_keys[240]) {
+    memcpy(round_keys, key, 32);
+    uint8_t rcon = 1;
+    for (int i = 8; i < 60; i++) {
+        uint8_t t[4];
+        memcpy(t, round_keys + (i - 1) * 4, 4);
+        if (i % 8 == 0) {
+            uint8_t tmp = t[0];
+            t[0] = (uint8_t)(AES_SBOX[t[1]] ^ rcon);
+            t[1] = AES_SBOX[t[2]];
+            t[2] = AES_SBOX[t[3]];
+            t[3] = AES_SBOX[tmp];
+            rcon = xtime(rcon);
+        } else if (i % 8 == 4) {
+            for (int j = 0; j < 4; j++) t[j] = AES_SBOX[t[j]];
+        }
+        for (int j = 0; j < 4; j++)
+            round_keys[i * 4 + j] = (uint8_t)(round_keys[(i - 8) * 4 + j] ^ t[j]);
+    }
+}
+
+void add_round_key(uint8_t s[16], const uint8_t* rk) {
+    for (int i = 0; i < 16; i++) s[i] ^= rk[i];
+}
+
+void inv_shift_rows(uint8_t s[16]) {
+    uint8_t t;
+    t = s[13]; s[13] = s[9];  s[9]  = s[5];  s[5]  = s[1];  s[1]  = t;
+    t = s[2];  s[2]  = s[10]; s[10] = t;     t     = s[6];  s[6]  = s[14]; s[14] = t;
+    t = s[3];  s[3]  = s[7];  s[7]  = s[11]; s[11] = s[15]; s[15] = t;
+}
+
+void inv_sub_bytes(uint8_t s[16]) {
+    for (int i = 0; i < 16; i++) s[i] = AES_INV_SBOX[s[i]];
+}
+
+void inv_mix_columns(uint8_t s[16]) {
+    for (int c = 0; c < 4; c++) {
+        uint8_t* p = s + c * 4;
+        uint8_t a0 = p[0], a1 = p[1], a2 = p[2], a3 = p[3];
+        p[0] = (uint8_t)(gmul(a0, 14) ^ gmul(a1, 11) ^ gmul(a2, 13) ^ gmul(a3, 9));
+        p[1] = (uint8_t)(gmul(a0, 9)  ^ gmul(a1, 14) ^ gmul(a2, 11) ^ gmul(a3, 13));
+        p[2] = (uint8_t)(gmul(a0, 13) ^ gmul(a1, 9)  ^ gmul(a2, 14) ^ gmul(a3, 11));
+        p[3] = (uint8_t)(gmul(a0, 11) ^ gmul(a1, 13) ^ gmul(a2, 9)  ^ gmul(a3, 14));
+    }
+}
+
+void decrypt_block(const uint8_t round_keys[240], uint8_t block[16]) {
+    add_round_key(block, round_keys + 14 * 16);
+    for (int round = 13; round >= 1; round--) {
+        inv_shift_rows(block);
+        inv_sub_bytes(block);
+        add_round_key(block, round_keys + round * 16);
+        inv_mix_columns(block);
+    }
+    inv_shift_rows(block);
+    inv_sub_bytes(block);
+    add_round_key(block, round_keys);
+}
+
+}  // namespace
+
+std::vector<uint8_t> sha256(const uint8_t* data, size_t len) {
+    uint32_t state[8] = { 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                          0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 };
+
+    size_t full = len / 64;
+    for (size_t i = 0; i < full; i++) sha256_block(state, data + i * 64);
+
+    uint8_t tail[128] = {};
+    size_t rest = len - full * 64;
+    memcpy(tail, data + full * 64, rest);
+    tail[rest] = 0x80;
+    size_t tail_len = (rest < 56) ? 64 : 128;
+    uint64_t bits = (uint64_t)len * 8;
+    for (int i = 0; i < 8; i++)
+        tail[tail_len - 1 - i] = (uint8_t)(bits >> (i * 8));
+    for (size_t i = 0; i < tail_len; i += 64) sha256_block(state, tail + i);
+
+    std::vector<uint8_t> out(32);
+    for (int i = 0; i < 8; i++) {
+        out[i * 4]     = (uint8_t)(state[i] >> 24);
+        out[i * 4 + 1] = (uint8_t)(state[i] >> 16);
+        out[i * 4 + 2] = (uint8_t)(state[i] >> 8);
+        out[i * 4 + 3] = (uint8_t)(state[i]);
+    }
+    return out;
+}
+
+std::vector<uint8_t> aes256_cbc_decrypt(const std::vector<uint8_t>& key,
+                                        const uint8_t* iv,
+                                        const uint8_t* data, size_t len) {
+    if (key.size() != 32 || len == 0 || len % 16 != 0) return {};
+    build_inv_sbox();
+
+    uint8_t round_keys[240];
+    expand_key(key.data(), round_keys);
+
+    std::vector<uint8_t> out(len);
+    uint8_t prev[16];
+    memcpy(prev, iv, 16);
+
+    for (size_t off = 0; off < len; off += 16) {
+        uint8_t block[16], cipher[16];
+        memcpy(cipher, data + off, 16);
+        memcpy(block, cipher, 16);
+        decrypt_block(round_keys, block);
+        for (int i = 0; i < 16; i++) out[off + i] = (uint8_t)(block[i] ^ prev[i]);
+        memcpy(prev, cipher, 16);
+    }
+
+    // PKCS#7, unpadded by hand so that a wrong key is a clear failure rather
+    // than a buffer of noise handed on to the inflater.
+    uint8_t pad = out.back();
+    if (pad == 0 || pad > 16 || pad > out.size()) {
+        spdlog::warn("gen4: bad PKCS#7 padding ({}), wrong key?", (int)pad);
+        return {};
+    }
+    for (size_t i = out.size() - pad; i < out.size(); i++) {
+        if (out[i] != pad) {
+            spdlog::warn("gen4: PKCS#7 padding not uniform, wrong key?");
+            return {};
+        }
+    }
+    out.resize(out.size() - pad);
+    return out;
+}
+
+std::vector<uint8_t> gzip_inflate(const uint8_t* data, size_t len) {
+    // Both the tables and the charts are gzip, not bare zlib, so the member
+    // header is stepped over and the deflate stream fed in raw.
+    if (len < 18 || data[0] != 0x1F || data[1] != 0x8B) {
+        spdlog::warn("gen4: not a gzip stream");
+        return {};
+    }
+
+    size_t pos = 10;
+    uint8_t flags = data[3];
+    if (flags & 0x04) {                       // FEXTRA
+        if (pos + 2 > len) return {};
+        size_t extra = (size_t)data[pos] | ((size_t)data[pos + 1] << 8);
+        pos += 2 + extra;
+    }
+    if (flags & 0x08) while (pos < len && data[pos++]) {}   // FNAME
+    if (flags & 0x10) while (pos < len && data[pos++]) {}   // FCOMMENT
+    if (flags & 0x02) pos += 2;                             // FHCRC
+    if (pos >= len) return {};
+
+    // The gzip trailer carries the uncompressed size, which saves growing the
+    // output buffer blindly.
+    uint32_t isize = (uint32_t)data[len - 4] | ((uint32_t)data[len - 3] << 8) |
+                     ((uint32_t)data[len - 2] << 16) | ((uint32_t)data[len - 1] << 24);
+
+    std::vector<uint8_t> out(isize ? isize : (len * 4));
+    mz_stream stream = {};
+    stream.next_in   = data + pos;
+    stream.avail_in  = (unsigned int)(len - pos - 8);
+    stream.next_out  = out.data();
+    stream.avail_out = (unsigned int)out.size();
+
+    if (mz_inflateInit2(&stream, -MZ_DEFAULT_WINDOW_BITS) != MZ_OK) {
+        spdlog::warn("gen4: inflate init failed");
+        return {};
+    }
+    int status = mz_inflate(&stream, MZ_FINISH);
+    mz_inflateEnd(&stream);
+    if (status != MZ_STREAM_END && status != MZ_OK) {
+        spdlog::warn("gen4: inflate failed ({})", status);
+        return {};
+    }
+    out.resize(stream.total_out);
+    return out;
+}
+
+std::vector<uint8_t> derive_key(const std::string& seed) {
+    std::vector<uint8_t> buf(seed.begin(), seed.end());
+    for (uint8_t& b : buf) b ^= 0x01;
+
+    std::string hex = to_hex_upper(sha256(buf.data(), buf.size()));
+    for (int i = 0; i < 1000; i++)
+        hex = to_hex_upper(sha256((const uint8_t*)hex.data(), hex.size()));
+
+    uint32_t digest_words[4];
+    md5((const uint8_t*)hex.data(), hex.size(), digest_words);
+
+    std::vector<uint8_t> digest(16);
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            digest[i * 4 + j] = (uint8_t)(digest_words[i] >> (j * 8));
+
+    std::string key_text = to_hex_upper(digest);
+    return std::vector<uint8_t>(key_text.begin(), key_text.end());
+}
+
+bool looks_encrypted(const std::vector<uint8_t>& raw) {
+    return raw.size() >= 32 && raw.size() % 16 == 0;
+}
+
+// ------------------------------------------------------------- Library
+
+namespace {
+
+// The suffix each difficulty's chart file carries, in the game's difficulty
+// order. Ura is a separate file rather than a flag on oni.
+const char* DIFF_SUFFIX[5] = { "_e", "_n", "_h", "_m", "_x" };
+
+// wordlist column -> the language codes this game uses.
+const struct { const char* field; const char* lang; } WORD_LANGS[] = {
+    { "japaneseText",  "ja"    },
+    { "englishUsText", "en"    },
+    { "chineseTText",  "zh-tw" },
+    { "koreanText",    "ko"    },
+    { "chineseSText",  "zh-cn" },
+};
+
+std::string json_string(const rapidjson::Value& v, const char* name) {
+    auto it = v.FindMember(name);
+    if (it == v.MemberEnd() || !it->value.IsString()) return "";
+    return it->value.GetString();
+}
+
+int json_int(const rapidjson::Value& v, const char* name) {
+    auto it = v.FindMember(name);
+    if (it == v.MemberEnd() || !it->value.IsInt()) return 0;
+    return it->value.GetInt();
+}
+
+bool json_bool(const rapidjson::Value& v, const char* name) {
+    auto it = v.FindMember(name);
+    if (it == v.MemberEnd() || !it->value.IsBool()) return false;
+    return it->value.GetBool();
+}
+
+}  // namespace
+
+bool Library::load(const fs::path& root) {
+    is_loaded = false;
+    entries.clear();
+    data_root = root;
+
+    std::vector<uint8_t> table_key = derive_key(DATATABLE_SEED);
+    fumen_key = derive_key(FUMEN_SEED);
+
+    std::vector<uint8_t> music = load_encrypted(root / "datatable" / "musicinfo.bin", table_key);
+    if (music.empty()) {
+        spdlog::warn("gen4: no readable musicinfo under {}", root.string());
+        return false;
+    }
+
+    rapidjson::Document doc;
+    doc.Parse(reinterpret_cast<const char*>(music.data()), music.size());
+    if (doc.HasParseError() || !doc.HasMember("items") || !doc["items"].IsArray()) {
+        spdlog::warn("gen4: musicinfo is not the expected JSON");
+        return false;
+    }
+
+    // Difficulty names as musicinfo spells them, in difficulty order.
+    static const char* STAR_FIELDS[5]   = { "starEasy", "starNormal", "starHard", "starMania", "starUra" };
+    static const char* BRANCH_FIELDS[5] = { "branchEasy", "branchNormal", "branchHard", "branchMania", "branchUra" };
+
+    for (const auto& item : doc["items"].GetArray()) {
+        if (!item.IsObject()) continue;
+        SongEntry e;
+        e.id         = json_string(item, "id");
+        if (e.id.empty()) continue;
+        e.unique_id  = json_int(item, "uniqueId");
+        e.genre_no   = json_int(item, "genreNo");
+        e.sound_file = json_string(item, "songFileName");
+        for (int d = 0; d < 5; d++) {
+            e.stars[d]  = json_int(item, STAR_FIELDS[d]);
+            e.branch[d] = json_bool(item, BRANCH_FIELDS[d]);
+        }
+        entries.push_back(std::move(e));
+    }
+
+    // Titles live in a separate table, keyed by the song id.
+    std::vector<uint8_t> words = load_encrypted(root / "datatable" / "wordlist.bin", table_key);
+    if (!words.empty()) {
+        rapidjson::Document wdoc;
+        wdoc.Parse(reinterpret_cast<const char*>(words.data()), words.size());
+        if (!wdoc.HasParseError() && wdoc.HasMember("items") && wdoc["items"].IsArray()) {
+            std::map<std::string, const rapidjson::Value*> by_key;
+            for (const auto& item : wdoc["items"].GetArray()) {
+                if (!item.IsObject()) continue;
+                std::string key = json_string(item, "key");
+                if (!key.empty()) by_key[key] = &item;
+            }
+            for (SongEntry& e : entries) {
+                auto title = by_key.find("song_" + e.id);
+                auto sub   = by_key.find("song_sub_" + e.id);
+                for (const auto& col : WORD_LANGS) {
+                    if (title != by_key.end())
+                        e.title[col.lang] = json_string(*title->second, col.field);
+                    if (sub != by_key.end())
+                        e.subtitle[col.lang] = json_string(*sub->second, col.field);
+                }
+            }
+        } else {
+            spdlog::warn("gen4: wordlist is not the expected JSON, songs will show their ids");
+        }
+    }
+
+    is_loaded = true;
+    spdlog::info("gen4: {} songs from {}", entries.size(), root.string());
+    return true;
+}
+
+const SongEntry* Library::find(const std::string& id) const {
+    for (const SongEntry& e : entries)
+        if (e.id == id) return &e;
+    return nullptr;
+}
+
+bool Library::has_difficulty(const std::string& id, int difficulty) const {
+    if (difficulty < 0 || difficulty > 4) return false;
+    std::error_code ec;
+    return fs::exists(data_root / "fumen" / id / (id + DIFF_SUFFIX[difficulty] + ".bin"), ec);
+}
+
+std::vector<uint8_t> Library::load_chart(const std::string& id, int difficulty) const {
+    if (difficulty < 0 || difficulty > 4) return {};
+    fs::path path = data_root / "fumen" / id / (id + DIFF_SUFFIX[difficulty] + ".bin");
+    std::error_code ec;
+    if (!fs::exists(path, ec)) return {};
+    return load_encrypted(path, fumen_key);
+}
+
+fs::path find_data_root(const fs::path& path) {
+    std::error_code ec;
+    for (fs::path dir = path; !dir.empty(); dir = dir.parent_path()) {
+        if (fs::exists(dir / "datatable" / "musicinfo.bin", ec) &&
+            fs::is_directory(dir / "fumen", ec))
+            return dir;
+        if (dir == dir.parent_path()) break;
+    }
+    return {};
+}
+
+const Library* library_for(const fs::path& path) {
+    fs::path root = find_data_root(path);
+    if (root.empty()) return nullptr;
+
+    // One library per root, kept for the life of the process: the tables are a
+    // couple of megabytes of JSON and every song box would otherwise re-read
+    // and re-decrypt them.
+    static std::map<std::string, Library> cache;
+    static std::mutex cache_mutex;
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    auto it = cache.find(root.string());
+    if (it == cache.end()) {
+        Library lib;
+        lib.load(root);
+        it = cache.emplace(root.string(), std::move(lib)).first;
+    }
+    return it->second.loaded() ? &it->second : nullptr;
+}
+
+std::vector<uint8_t> load_encrypted(const fs::path& path, const std::vector<uint8_t>& key) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        spdlog::warn("gen4: cannot open {}", path.string());
+        return {};
+    }
+    std::vector<uint8_t> raw((std::istreambuf_iterator<char>(f)),
+                             std::istreambuf_iterator<char>());
+    if (!looks_encrypted(raw)) {
+        spdlog::warn("gen4: {} is not a whole number of blocks", path.string());
+        return {};
+    }
+
+    // The IV is the first block of the file, the rest is the ciphertext.
+    std::vector<uint8_t> plain =
+        aes256_cbc_decrypt(key, raw.data(), raw.data() + 16, raw.size() - 16);
+    if (plain.empty()) return {};
+
+    return gzip_inflate(plain.data(), plain.size());
+}
+
+}  // namespace gen4

--- a/src/libs/gen4.cpp
+++ b/src/libs/gen4.cpp
@@ -4,6 +4,7 @@
 #include <rapidjson/document.h>
 #include <cstring>
 #include <fstream>
+#include <algorithm>
 #include <mutex>
 
 #include "miniz/miniz.h"
@@ -476,8 +477,32 @@ bool Library::load(const fs::path& root) {
         }
     }
 
+    // The running order decides what each genre holds and in what order.
+    std::vector<uint8_t> order = load_encrypted(root / "datatable" / "music_order.bin", table_key);
+    if (!order.empty()) {
+        rapidjson::Document odoc;
+        odoc.Parse(reinterpret_cast<const char*>(order.data()), order.size());
+        if (!odoc.HasParseError() && odoc.HasMember("items") && odoc["items"].IsArray()) {
+            for (const auto& item : odoc["items"].GetArray()) {
+                if (!item.IsObject()) continue;
+                OrderEntry e;
+                e.id       = json_string(item, "id");
+                e.genre_no = json_int(item, "genreNo");
+                if (!e.id.empty()) order_entries.push_back(std::move(e));
+            }
+        }
+    }
+    if (order_entries.empty()) {
+        // No running order to go by: fall back to the genre on each song, in
+        // the order the song table lists them.
+        spdlog::warn("gen4: no music order, falling back to each song's own genre");
+        for (const SongEntry& e : entries)
+            order_entries.push_back({ e.genre_no, e.id });
+    }
+
     is_loaded = true;
-    spdlog::info("gen4: {} songs from {}", entries.size(), root.string());
+    spdlog::info("gen4: {} songs, {} listings from {}",
+                 entries.size(), order_entries.size(), root.string());
     return true;
 }
 
@@ -499,6 +524,68 @@ std::vector<uint8_t> Library::load_chart(const std::string& id, int difficulty) 
     std::error_code ec;
     if (!fs::exists(path, ec)) return {};
     return load_encrypted(path, fumen_key);
+}
+
+// Genre numbering, established by reading the titles filed under each number
+// rather than by assuming the older games' order:
+//   0 pops, 1 anime, 2 kids, 3 vocaloid, 4 game, 5 namco, 6 variety, 7 classic
+// The values on the right are GenreIndex, which orders them differently.
+int genre_index_for(int genre_no) {
+    static const int TO_GENRE_INDEX[8] = {
+        1,  // pops     -> JPOP
+        2,  // anime    -> ANIME
+        4,  // kids     -> CHILDREN
+        3,  // vocaloid -> VOCALOID
+        7,  // game     -> GAME
+        8,  // namco    -> NAMCO
+        5,  // variety  -> VARIETY
+        6,  // classic  -> CLASSICAL
+    };
+    if (genre_no < 0 || genre_no > 7) return 8;
+    return TO_GENRE_INDEX[genre_no];
+}
+
+std::string genre_name(int genre_no, const std::string& language) {
+    static const char* NAMES[8][3] = {
+        // ja                      en                  zh
+        { "ポップス",              "J-POP",            "流行" },
+        { "アニメ",                "Anime",            "動畫" },
+        { "キッズ",                "Kids",             "兒童" },
+        { "ボーカロイド",          "Vocaloid",         "VOCALOID" },
+        { "ゲームミュージック",    "Game Music",       "遊戲音樂" },
+        { "ナムコオリジナル",      "Namco Original",   "南夢宮原創" },
+        { "バラエティ",            "Variety",          "綜合" },
+        { "クラシック",            "Classical",        "古典" },
+    };
+    if (genre_no < 0 || genre_no > 7) return "";
+    int column = 0;
+    if (language.rfind("en", 0) == 0)      column = 1;
+    else if (language.rfind("zh", 0) == 0) column = 2;
+    return NAMES[genre_no][column];
+}
+
+std::vector<int> genres_present(const Library& library) {
+    std::vector<int> found;
+    for (const OrderEntry& e : library.order()) {
+        if (std::find(found.begin(), found.end(), e.genre_no) == found.end())
+            found.push_back(e.genre_no);
+    }
+    std::sort(found.begin(), found.end());
+    return found;
+}
+
+fs::path genre_path(const fs::path& data_root, int genre_no) {
+    return data_root / ("@genre_" + std::to_string(genre_no));
+}
+
+int genre_of_path(const fs::path& path) {
+    std::string name = path.filename().string();
+    if (name.rfind("@genre_", 0) != 0) return -1;
+    try {
+        return std::stoi(name.substr(7));
+    } catch (...) {
+        return -1;
+    }
 }
 
 fs::path find_data_root(const fs::path& path) {

--- a/src/libs/gen4.cpp
+++ b/src/libs/gen4.cpp
@@ -588,12 +588,28 @@ int genre_of_path(const fs::path& path) {
     }
 }
 
-fs::path find_data_root(const fs::path& path) {
+// Whether one directory is a data root, remembered: the walk below runs for
+// every directory the song scan meets, and the same ancestors come up over
+// and over, each check costing two disk lookups.
+static bool is_root_dir(const fs::path& dir) {
+    static std::mutex               mutex;
+    static std::map<fs::path, bool> cache;
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = cache.find(dir);
+        if (it != cache.end()) return it->second;
+    }
     std::error_code ec;
+    bool ok = fs::exists(dir / "datatable" / "musicinfo.bin", ec) &&
+              fs::is_directory(dir / "fumen", ec);
+    std::lock_guard<std::mutex> lock(mutex);
+    cache[dir] = ok;
+    return ok;
+}
+
+fs::path find_data_root(const fs::path& path) {
     for (fs::path dir = path; !dir.empty(); dir = dir.parent_path()) {
-        if (fs::exists(dir / "datatable" / "musicinfo.bin", ec) &&
-            fs::is_directory(dir / "fumen", ec))
-            return dir;
+        if (is_root_dir(dir)) return dir;
         if (dir == dir.parent_path()) break;
     }
     return {};

--- a/src/libs/gen4.h
+++ b/src/libs/gen4.h
@@ -1,0 +1,94 @@
+#pragma once
+
+// Reading the data of the arcade "gen 4" games (Nijiiro and its regional
+// builds). Their datatable and fumen files are AES-256-CBC encrypted and then
+// gzipped; the keys are derived from a string built into the executable, one
+// for the tables and one for the charts.
+//
+// See research notes in issue #24 for how the formats were established.
+
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace gen4 {
+
+// The seeds the game derives its two keys from.
+extern const char* DATATABLE_SEED;
+extern const char* FUMEN_SEED;
+
+// seed XOR 0x01 -> SHA256 -> uppercase hex -> (SHA256 -> uppercase hex) x1000
+// -> MD5 -> uppercase hex, and those 32 ASCII characters are the AES-256 key.
+std::vector<uint8_t> derive_key(const std::string& seed);
+
+// Decrypts and inflates one file. Returns an empty vector and logs why if the
+// file cannot be read, the padding is wrong (which means the wrong key) or the
+// gzip stream is damaged.
+std::vector<uint8_t> load_encrypted(const fs::path& path, const std::vector<uint8_t>& key);
+
+// True if the file looks like one of these containers rather than a plain one:
+// too short to hold an IV plus a block, or not a multiple of the block size,
+// and it cannot be.
+bool looks_encrypted(const std::vector<uint8_t>& raw);
+
+// One song as the game's own tables describe it. The five difficulty slots are
+// in the game's order: easy, normal, hard, oni, ura.
+struct SongEntry {
+    std::string id;                 // "10jiku", also the fumen folder name
+    int         unique_id = 0;
+    int         genre_no  = 0;
+    std::string sound_file;         // "sound/song_10jiku", no extension
+    int         stars[5]  = {};
+    bool        branch[5] = {};
+    std::map<std::string, std::string> title;     // YataiDON language code -> text
+    std::map<std::string, std::string> subtitle;
+};
+
+// The datatable of one game data root, ie. the folder holding datatable/,
+// fumen/ and sound/. Loading is all-or-nothing and happens once.
+class Library {
+public:
+    // Reads datatable/musicinfo.bin and datatable/wordlist.bin. Returns false
+    // and logs if either is missing or will not decrypt.
+    bool load(const fs::path& data_root);
+
+    bool loaded() const { return is_loaded; }
+    const fs::path& root() const { return data_root; }
+
+    const SongEntry* find(const std::string& id) const;
+    const std::vector<SongEntry>& songs() const { return entries; }
+
+    // The chart of one difficulty, decrypted and inflated, or empty if that
+    // difficulty does not exist.
+    std::vector<uint8_t> load_chart(const std::string& id, int difficulty) const;
+
+    // Which of the five difficulties this song actually ships a chart for.
+    bool has_difficulty(const std::string& id, int difficulty) const;
+
+private:
+    bool                   is_loaded = false;
+    fs::path               data_root;
+    std::vector<SongEntry> entries;
+    std::vector<uint8_t>   fumen_key;
+};
+
+// The library covering a path, loading it the first time it is asked for.
+// Returns null when the path is not inside a game data root.
+const Library* library_for(const fs::path& path);
+
+// The data root a path belongs to, or an empty path. A root is recognised by
+// holding datatable/musicinfo.bin next to a fumen/ folder.
+fs::path find_data_root(const fs::path& path);
+
+// Building blocks, exposed for tests.
+std::vector<uint8_t> sha256(const uint8_t* data, size_t len);
+std::vector<uint8_t> aes256_cbc_decrypt(const std::vector<uint8_t>& key,
+                                        const uint8_t* iv,
+                                        const uint8_t* data, size_t len);
+std::vector<uint8_t> gzip_inflate(const uint8_t* data, size_t len);
+
+}  // namespace gen4

--- a/src/libs/gen4.h
+++ b/src/libs/gen4.h
@@ -50,6 +50,14 @@ struct SongEntry {
 
 // The datatable of one game data root, ie. the folder holding datatable/,
 // fumen/ and sound/. Loading is all-or-nothing and happens once.
+// One line of the game's own running order. A song can be listed under more
+// than one genre, so this is what decides both what a genre contains and in
+// what order, rather than the single genre number on the song itself.
+struct OrderEntry {
+    int         genre_no = 0;
+    std::string id;
+};
+
 class Library {
 public:
     // Reads datatable/musicinfo.bin and datatable/wordlist.bin. Returns false
@@ -62,6 +70,10 @@ public:
     const SongEntry* find(const std::string& id) const;
     const std::vector<SongEntry>& songs() const { return entries; }
 
+    // The running order, in file order. Songs missing from it are not listed
+    // by the game and are not listed here either.
+    const std::vector<OrderEntry>& order() const { return order_entries; }
+
     // The chart of one difficulty, decrypted and inflated, or empty if that
     // difficulty does not exist.
     std::vector<uint8_t> load_chart(const std::string& id, int difficulty) const;
@@ -72,9 +84,29 @@ public:
 private:
     bool                   is_loaded = false;
     fs::path               data_root;
-    std::vector<SongEntry> entries;
-    std::vector<uint8_t>   fumen_key;
+    std::vector<SongEntry>  entries;
+    std::vector<OrderEntry> order_entries;
+    std::vector<uint8_t>    fumen_key;
 };
+
+// These games number their genres differently from the ones this project grew
+// up with, so the numbering is translated rather than used directly. Returns a
+// GenreIndex value.
+int genre_index_for(int genre_no);
+
+// The genre's own name, in the language given, falling back to Japanese.
+std::string genre_name(int genre_no, const std::string& language);
+
+// The genres that actually have songs, in the game's own order.
+std::vector<int> genres_present(const Library& library);
+
+// The path used for a genre inside a game data root. These do not exist on
+// disk: a genre is a property of a song, not a folder, and the wheel needs
+// something to hang the boxes on.
+fs::path genre_path(const fs::path& data_root, int genre_no);
+
+// The genre a path made by genre_path names, or -1.
+int genre_of_path(const fs::path& path);
 
 // The library covering a path, loading it the first time it is asked for.
 // Returns null when the path is not inside a game data root.

--- a/src/libs/gen4_audio.cpp
+++ b/src/libs/gen4_audio.cpp
@@ -1,0 +1,200 @@
+#include "gen4_audio.h"
+
+#include <spdlog/spdlog.h>
+#include <cstring>
+#include <fstream>
+
+#ifdef YATAIDON_G719
+extern "C" {
+#include <g719.h>
+}
+#endif
+
+namespace gen4 {
+
+namespace {
+
+uint32_t read_be32(const uint8_t* p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3];
+}
+uint16_t read_be16(const uint8_t* p) {
+    return (uint16_t)(((uint32_t)p[0] << 8) | p[1]);
+}
+uint32_t read_le32(const uint8_t* p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+// What the BNSF stream says about itself, and where its payload starts.
+struct Bnsf {
+    int    channels      = 0;
+    int    sample_rate   = 0;
+    int    num_samples   = 0;
+    int    block_size    = 0;   // bytes per frame, all channels together
+    int    block_samples = 0;   // samples per frame per channel, 960 for G.719
+    size_t data_offset   = 0;
+    size_t data_size     = 0;
+};
+
+// Walks the outer container to the PACK chunk, then reads the first BNSF blob
+// in it. A song bank holds exactly one; effect banks hold several back to back
+// and only the first is wanted here.
+bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
+    if (file.size() < 0x18 || memcmp(file.data(), "NUS3", 4) != 0) {
+        spdlog::warn("gen4 audio: not a NUS3 container");
+        return false;
+    }
+    if (memcmp(file.data() + 8, "BANKTOC ", 8) != 0) {
+        spdlog::warn("gen4 audio: no BANKTOC where one is expected");
+        return false;
+    }
+
+    // The chunks follow the table of contents, each one named and sized, so
+    // the table itself does not have to be understood to find PACK.
+    size_t pos = 0x14 + read_le32(file.data() + 0x10);
+    size_t pack = 0, pack_size = 0;
+    while (pos + 8 <= file.size()) {
+        uint32_t size = read_le32(file.data() + pos + 4);
+        if (memcmp(file.data() + pos, "PACK", 4) == 0) {
+            pack      = pos + 8;
+            pack_size = size;
+            break;
+        }
+        pos += 8 + size;
+    }
+    if (!pack || pack + pack_size > file.size()) {
+        spdlog::warn("gen4 audio: no PACK chunk");
+        return false;
+    }
+
+    const uint8_t* p = file.data() + pack;
+    if (pack_size < 0x2C || memcmp(p, "BNSF", 4) != 0) {
+        spdlog::warn("gen4 audio: PACK does not start with a BNSF stream");
+        return false;
+    }
+    if (memcmp(p + 8, "IS22", 4) != 0) {
+        spdlog::warn("gen4 audio: codec tag is {:.4s}, only IS22 is supported",
+                     (const char*)(p + 8));
+        return false;
+    }
+    if (memcmp(p + 0x0C, "sfmt", 4) != 0) {
+        spdlog::warn("gen4 audio: no sfmt where one is expected");
+        return false;
+    }
+
+    const uint8_t* fmt = p + 0x14;
+    uint16_t flags     = read_be16(fmt);
+    out.channels       = read_be16(fmt + 2);
+    out.sample_rate    = (int)read_be32(fmt + 4);
+    out.num_samples    = (int)read_be32(fmt + 8);
+    out.block_size     = read_be16(fmt + 0x10);
+    out.block_samples  = read_be16(fmt + 0x12);
+
+    if (flags != 0) {
+        spdlog::warn("gen4 audio: stream is flagged {}, expected plain", flags);
+        return false;
+    }
+    if (out.channels < 1 || out.channels > 2 || out.block_size <= 0) {
+        spdlog::warn("gen4 audio: unsupported stream shape ({} ch, block {})",
+                     out.channels, out.block_size);
+        return false;
+    }
+
+    // sdat follows sfmt and holds the codec payload.
+    size_t sfmt_size = read_be32(p + 0x10);
+    size_t sdat = 0x0C + 4 + 4 + sfmt_size;
+    if (pack + sdat + 8 > file.size() || memcmp(p + sdat, "sdat", 4) != 0) {
+        spdlog::warn("gen4 audio: no sdat where one is expected");
+        return false;
+    }
+    out.data_size   = read_be32(p + sdat + 4);
+    out.data_offset = pack + sdat + 8;
+    if (out.data_offset + out.data_size > file.size())
+        out.data_size = file.size() - out.data_offset;
+
+    return true;
+}
+
+}  // namespace
+
+bool audio_supported() {
+#ifdef YATAIDON_G719
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
+#ifndef YATAIDON_G719
+    (void)path; (void)out;
+    spdlog::warn("gen4 audio: {} needs G.719 support, which this build does not have",
+                 path.filename().string());
+    return false;
+#else
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        spdlog::warn("gen4 audio: cannot open {}", path.string());
+        return false;
+    }
+    std::vector<uint8_t> file((std::istreambuf_iterator<char>(f)),
+                              std::istreambuf_iterator<char>());
+
+    Bnsf info;
+    if (!parse_container(file, info)) return false;
+
+    // One decoder per channel, each fed its own frames: the channels are
+    // interleaved a whole frame at a time, not sample by sample.
+    int frame_bytes = info.block_size / info.channels;
+    std::vector<g719_handle*> decoders(info.channels, nullptr);
+    for (int c = 0; c < info.channels; c++) {
+        decoders[c] = g719_init(frame_bytes);
+        if (!decoders[c]) {
+            spdlog::warn("gen4 audio: decoder would not start for {}", path.string());
+            for (g719_handle* h : decoders) if (h) g719_free(h);
+            return false;
+        }
+    }
+
+    out.channels    = info.channels;
+    out.sample_rate = info.sample_rate;
+    out.samples.clear();
+    out.samples.reserve((size_t)info.num_samples * info.channels);
+
+    const int    samples_per_frame = info.block_samples > 0 ? info.block_samples : 960;
+    const uint8_t* data = file.data() + info.data_offset;
+    size_t       pos    = 0;
+    std::vector<std::vector<int16_t>> pcm(info.channels,
+                                          std::vector<int16_t>(samples_per_frame));
+
+    while (pos + (size_t)info.block_size <= info.data_size) {
+        for (int c = 0; c < info.channels; c++) {
+            g719_decode_frame(decoders[c],
+                              (void*)(data + pos + (size_t)c * frame_bytes),
+                              pcm[c].data());
+        }
+        pos += info.block_size;
+
+        for (int s = 0; s < samples_per_frame; s++)
+            for (int c = 0; c < info.channels; c++)
+                out.samples.push_back((float)pcm[c][s] / 32768.0f);
+    }
+
+    for (g719_handle* h : decoders) g719_free(h);
+
+    // The header's sample count is the real length; the last frame is padding.
+    size_t wanted = (size_t)info.num_samples * info.channels;
+    if (info.num_samples > 0 && wanted < out.samples.size())
+        out.samples.resize(wanted);
+
+    if (out.samples.empty()) {
+        spdlog::warn("gen4 audio: {} decoded to nothing", path.filename().string());
+        return false;
+    }
+
+    spdlog::debug("gen4 audio: {} decoded, {} frames, {} Hz, {} ch",
+                  path.filename().string(), out.frame_count(), out.sample_rate, out.channels);
+    return true;
+#endif
+}
+
+}  // namespace gen4

--- a/src/libs/gen4_audio.cpp
+++ b/src/libs/gen4_audio.cpp
@@ -1,6 +1,7 @@
 #include "gen4_audio.h"
 
 #include <spdlog/spdlog.h>
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 
@@ -29,7 +30,6 @@ struct Bnsf {
     int    channels      = 0;
     int    sample_rate   = 0;
     int    num_samples   = 0;
-    int    preview_ms    = 0;   // from the TONE chunk, 0 when absent
     int    block_size    = 0;   // bytes per frame, all channels together
     int    block_samples = 0;   // samples per frame per channel, 960 for G.719
     size_t data_offset   = 0;
@@ -55,10 +55,10 @@ int find_preview_ms(const uint8_t* tone, size_t size) {
     return 0;
 }
 
-// Walks the outer container to the PACK chunk, then reads the first BNSF blob
-// in it. A song bank holds exactly one; effect banks hold several back to back
-// and only the first is wanted here.
-bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
+// Walks the outer container to the PACK chunk, picking the preview point out
+// of TONE on the way. A song bank holds exactly one stream.
+bool find_pack(const std::vector<uint8_t>& file, size_t& pack, size_t& pack_size,
+               int& preview_ms) {
     if (file.size() < 0x18 || memcmp(file.data(), "NUS3", 4) != 0) {
         spdlog::warn("gen4 audio: not a NUS3 container");
         return false;
@@ -71,11 +71,11 @@ bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
     // The chunks follow the table of contents, each one named and sized, so
     // the table itself does not have to be understood to find PACK.
     size_t pos = 0x14 + read_le32(file.data() + 0x10);
-    size_t pack = 0, pack_size = 0;
+    pack = 0; pack_size = 0;
     while (pos + 8 <= file.size()) {
         uint32_t size = read_le32(file.data() + pos + 4);
         if (memcmp(file.data() + pos, "TONE", 4) == 0 && pos + 8 + size <= file.size()) {
-            out.preview_ms = find_preview_ms(file.data() + pos + 8, size);
+            preview_ms = find_preview_ms(file.data() + pos + 8, size);
         }
         if (memcmp(file.data() + pos, "PACK", 4) == 0) {
             pack      = pos + 8;
@@ -88,7 +88,13 @@ bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
         spdlog::warn("gen4 audio: no PACK chunk");
         return false;
     }
+    return true;
+}
 
+// Reads the BNSF blob at the start of PACK (the G.719 stream of the Chinese
+// builds).
+bool parse_container(const std::vector<uint8_t>& file, size_t pack, size_t pack_size,
+                     Bnsf& out) {
     const uint8_t* p = file.data() + pack;
     if (pack_size < 0x2C || memcmp(p, "BNSF", 4) != 0) {
         spdlog::warn("gen4 audio: PACK does not start with a BNSF stream");
@@ -137,6 +143,97 @@ bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
     return true;
 }
 
+// The IDSP stream of the Japanese builds: Nintendo DSP-ADPCM, one standard
+// 0x60-byte channel header each (coefficients at +0x1C), the channels'
+// 8-byte frames interleaved block by block. Decoded here directly - it is
+// plain integer ADPCM, fourteen samples to a frame.
+struct IdspChannel {
+    int16_t coef[16] = {};
+    int16_t hist1 = 0, hist2 = 0;
+};
+
+void idsp_decode_frame(const uint8_t* frame, IdspChannel& ch, int16_t* out14) {
+    int scale = 1 << (frame[0] & 0x0F);
+    int ci    = ((frame[0] >> 4) & 0x07) * 2;
+    int c1 = ch.coef[ci], c2 = ch.coef[ci + 1];
+    for (int i = 0; i < 14; i++) {
+        int nib = frame[1 + i / 2];
+        nib = (i & 1) ? (nib & 0x0F) : (nib >> 4);
+        if (nib > 7) nib -= 16;
+        int sample = (((nib * scale) << 11) + 1024 + c1 * ch.hist1 + c2 * ch.hist2) >> 11;
+        if (sample >  32767) sample =  32767;
+        if (sample < -32768) sample = -32768;
+        ch.hist2 = ch.hist1;
+        ch.hist1 = (int16_t)sample;
+        out14[i] = ch.hist1;
+    }
+}
+
+bool decode_idsp(const std::vector<uint8_t>& file, size_t pack, size_t pack_size,
+                 DecodedAudio& out) {
+    if (pack_size < 0x40) return false;
+    const uint8_t* p = file.data() + pack;
+
+    auto be = [&](size_t off) { return read_be32(p + off); };
+    int      channels   = (int)be(0x08);
+    int      rate       = (int)be(0x0C);
+    uint32_t samples    = be(0x10);
+    uint32_t interleave = be(0x1C);
+    uint32_t hdr_off    = be(0x20);
+    uint32_t hdr_size   = be(0x24);
+    uint32_t data_off   = be(0x28);
+    uint32_t data_size  = be(0x2C);   // per channel
+
+    if (channels < 1 || channels > 2 || rate <= 0 || samples == 0 ||
+        (size_t)hdr_off + (size_t)channels * hdr_size > pack_size ||
+        (size_t)data_off + (size_t)channels * data_size > pack_size) {
+        spdlog::warn("gen4 audio: IDSP stream shape not understood");
+        return false;
+    }
+    if (interleave == 0) interleave = data_size;   // planar: one block each
+
+    std::vector<IdspChannel> chans(channels);
+    for (int c = 0; c < channels; c++) {
+        const uint8_t* h = p + hdr_off + (size_t)c * hdr_size;
+        for (int i = 0; i < 16; i++)
+            chans[c].coef[i] = (int16_t)read_be16(h + 0x1C + i * 2);
+        chans[c].hist1 = (int16_t)read_be16(h + 0x40);
+        chans[c].hist2 = (int16_t)read_be16(h + 0x42);
+    }
+
+    out.channels    = channels;
+    out.sample_rate = rate;
+    out.samples.clear();
+    out.samples.reserve((size_t)samples * channels);
+
+    // Per-channel decode buffers, filled block by block and merged.
+    const uint32_t frames_per_block  = interleave / 8;
+    const uint32_t samples_per_block = frames_per_block * 14;
+    std::vector<std::vector<int16_t>> pcm(channels,
+                                          std::vector<int16_t>(samples_per_block));
+
+    uint32_t blocks = (data_size + interleave - 1) / interleave;
+    for (uint32_t b = 0; b < blocks; b++) {
+        uint32_t block_bytes = std::min<uint32_t>(interleave, data_size - b * interleave);
+        uint32_t block_frames = block_bytes / 8;
+        for (int c = 0; c < channels; c++) {
+            const uint8_t* src = p + data_off +
+                ((size_t)b * channels + c) * interleave;
+            for (uint32_t f = 0; f < block_frames; f++)
+                idsp_decode_frame(src + f * 8, chans[c], pcm[c].data() + f * 14);
+        }
+        for (uint32_t s = 0; s < block_frames * 14; s++)
+            for (int c = 0; c < channels; c++)
+                out.samples.push_back((float)pcm[c][s] / 32768.0f);
+    }
+
+    // The header's sample count is the real length; the rest is frame padding.
+    if ((size_t)samples * channels < out.samples.size())
+        out.samples.resize((size_t)samples * channels);
+
+    return !out.samples.empty();
+}
+
 }  // namespace
 
 bool audio_supported() {
@@ -148,12 +245,6 @@ bool audio_supported() {
 }
 
 bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
-#ifndef YATAIDON_G719
-    (void)path; (void)out;
-    spdlog::warn("gen4 audio: {} needs G.719 support, which this build does not have",
-                 path.filename().string());
-    return false;
-#else
     std::ifstream f(path, std::ios::binary);
     if (!f) {
         spdlog::warn("gen4 audio: cannot open {}", path.string());
@@ -162,8 +253,29 @@ bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
     std::vector<uint8_t> file((std::istreambuf_iterator<char>(f)),
                               std::istreambuf_iterator<char>());
 
+    size_t pack = 0, pack_size = 0;
+    int    preview_ms = 0;
+    if (!find_pack(file, pack, pack_size, preview_ms)) return false;
+    out.preview_ms = preview_ms;
+
+    // The Japanese builds pack IDSP; the Chinese ones BNSF/G.719.
+    if (pack_size >= 4 && memcmp(file.data() + pack, "IDSP", 4) == 0) {
+        if (!decode_idsp(file, pack, pack_size, out)) {
+            spdlog::warn("gen4 audio: {} decoded to nothing", path.filename().string());
+            return false;
+        }
+        spdlog::debug("gen4 audio: {} decoded (IDSP), {} frames, {} Hz, {} ch",
+                      path.filename().string(), out.frame_count(), out.sample_rate, out.channels);
+        return true;
+    }
+
+#ifndef YATAIDON_G719
+    spdlog::warn("gen4 audio: {} needs G.719 support, which this build does not have",
+                 path.filename().string());
+    return false;
+#else
     Bnsf info;
-    if (!parse_container(file, info)) return false;
+    if (!parse_container(file, pack, pack_size, info)) return false;
 
     // One decoder per channel, each fed its own frames: the channels are
     // interleaved a whole frame at a time, not sample by sample.
@@ -180,7 +292,6 @@ bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
 
     out.channels    = info.channels;
     out.sample_rate = info.sample_rate;
-    out.preview_ms  = info.preview_ms;
     out.samples.clear();
     out.samples.reserve((size_t)info.num_samples * info.channels);
 

--- a/src/libs/gen4_audio.cpp
+++ b/src/libs/gen4_audio.cpp
@@ -5,11 +5,9 @@
 #include <cstring>
 #include <fstream>
 
-#ifdef YATAIDON_G719
 extern "C" {
 #include <g719.h>
 }
-#endif
 
 namespace gen4 {
 
@@ -237,11 +235,7 @@ bool decode_idsp(const std::vector<uint8_t>& file, size_t pack, size_t pack_size
 }  // namespace
 
 bool audio_supported() {
-#ifdef YATAIDON_G719
     return true;
-#else
-    return false;
-#endif
 }
 
 bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
@@ -269,11 +263,6 @@ bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
         return true;
     }
 
-#ifndef YATAIDON_G719
-    spdlog::warn("gen4 audio: {} needs G.719 support, which this build does not have",
-                 path.filename().string());
-    return false;
-#else
     Bnsf info;
     if (!parse_container(file, pack, pack_size, info)) return false;
 
@@ -329,7 +318,6 @@ bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
     spdlog::debug("gen4 audio: {} decoded, {} frames, {} Hz, {} ch",
                   path.filename().string(), out.frame_count(), out.sample_rate, out.channels);
     return true;
-#endif
 }
 
 }  // namespace gen4

--- a/src/libs/gen4_audio.cpp
+++ b/src/libs/gen4_audio.cpp
@@ -29,11 +29,31 @@ struct Bnsf {
     int    channels      = 0;
     int    sample_rate   = 0;
     int    num_samples   = 0;
+    int    preview_ms    = 0;   // from the TONE chunk, 0 when absent
     int    block_size    = 0;   // bytes per frame, all channels together
     int    block_samples = 0;   // samples per frame per channel, 960 for G.719
     size_t data_offset   = 0;
     size_t data_size     = 0;
 };
+
+// The tone entry carries the song-select preview point in milliseconds, laid
+// out as [preview u32][-1][sample rate][channel count]. The offset moves with
+// the length of the tone's name, so the row is found by its shape rather than
+// at a fixed place. (Established against TaikoNus3bankMake's templates, which
+// write the preview at exactly this spot.)
+int find_preview_ms(const uint8_t* tone, size_t size) {
+    if (size < 16) return 0;
+    for (size_t i = 4; i + 12 <= size; i += 4) {
+        if (read_le32(tone + i) != 0xFFFFFFFFu) continue;
+        uint32_t rate = read_le32(tone + i + 4);
+        uint32_t ch   = read_le32(tone + i + 8);
+        if (rate < 8000 || rate > 192000 || ch < 1 || ch > 8) continue;
+        uint32_t preview = read_le32(tone + i - 4);
+        if (preview > 30u * 60u * 1000u) continue;   // half an hour: not a time
+        return (int)preview;
+    }
+    return 0;
+}
 
 // Walks the outer container to the PACK chunk, then reads the first BNSF blob
 // in it. A song bank holds exactly one; effect banks hold several back to back
@@ -54,6 +74,9 @@ bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
     size_t pack = 0, pack_size = 0;
     while (pos + 8 <= file.size()) {
         uint32_t size = read_le32(file.data() + pos + 4);
+        if (memcmp(file.data() + pos, "TONE", 4) == 0 && pos + 8 + size <= file.size()) {
+            out.preview_ms = find_preview_ms(file.data() + pos + 8, size);
+        }
         if (memcmp(file.data() + pos, "PACK", 4) == 0) {
             pack      = pos + 8;
             pack_size = size;
@@ -157,6 +180,7 @@ bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
 
     out.channels    = info.channels;
     out.sample_rate = info.sample_rate;
+    out.preview_ms  = info.preview_ms;
     out.samples.clear();
     out.samples.reserve((size_t)info.num_samples * info.channels);
 

--- a/src/libs/gen4_audio.h
+++ b/src/libs/gen4_audio.h
@@ -19,6 +19,9 @@ namespace gen4 {
 struct DecodedAudio {
     int                channels    = 0;
     int                sample_rate = 0;
+    // Where the song-select preview starts, from the bank's TONE chunk, or 0
+    // when the bank does not carry one.
+    int                preview_ms  = 0;
     std::vector<float> samples;    // interleaved, -1..1
     int frame_count() const { return channels ? (int)(samples.size() / channels) : 0; }
 };

--- a/src/libs/gen4_audio.h
+++ b/src/libs/gen4_audio.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// The audio of the gen 4 arcade games: .nus3bank containers holding a BNSF
+// stream tagged IS22, which is ITU-T G.719 (Siren 22) at 48 kHz.
+//
+// FFmpeg and libsndfile both have no G.719 decoder, so this is only built when
+// YATAIDON_G719 is on, which fetches one at build time. Without it the
+// functions still exist and report that the format is not supported, so
+// callers need no conditional compilation of their own.
+
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace gen4 {
+
+struct DecodedAudio {
+    int                channels    = 0;
+    int                sample_rate = 0;
+    std::vector<float> samples;    // interleaved, -1..1
+    int frame_count() const { return channels ? (int)(samples.size() / channels) : 0; }
+};
+
+// True when this build can decode .nus3bank audio at all.
+bool audio_supported();
+
+// Decodes the first audio stream of a .nus3bank. Returns false and logs why on
+// a container it cannot read, an unsupported codec tag, or a build without
+// decoder support.
+bool decode_nus3bank(const fs::path& path, DecodedAudio& out);
+
+}  // namespace gen4

--- a/src/libs/gen4_audio.h
+++ b/src/libs/gen4_audio.h
@@ -3,10 +3,8 @@
 // The audio of the gen 4 arcade games: .nus3bank containers holding a BNSF
 // stream tagged IS22, which is ITU-T G.719 (Siren 22) at 48 kHz.
 //
-// FFmpeg and libsndfile both have no G.719 decoder, so this is only built when
-// YATAIDON_G719 is on, which fetches one at build time. Without it the
-// functions still exist and report that the format is not supported, so
-// callers need no conditional compilation of their own.
+// FFmpeg and libsndfile both have no G.719 decoder, so one is fetched at
+// build time (see cmake/deps.cmake) and linked in unconditionally.
 
 #include <cstdint>
 #include <filesystem>
@@ -29,9 +27,8 @@ struct DecodedAudio {
 // True when this build can decode .nus3bank audio at all.
 bool audio_supported();
 
-// Decodes the first audio stream of a .nus3bank. Returns false and logs why on
-// a container it cannot read, an unsupported codec tag, or a build without
-// decoder support.
+// Decodes the first audio stream of a .nus3bank. Returns false and logs why
+// on a container it cannot read or an unsupported codec tag.
 bool decode_nus3bank(const fs::path& path, DecodedAudio& out);
 
 }  // namespace gen4

--- a/src/libs/parsers/fumen.cpp
+++ b/src/libs/parsers/fumen.cpp
@@ -97,26 +97,83 @@ static bool is_balloon(uint32_t t) { return t == FUMEN_BALLOON || t == FUMEN_KUS
 static bool has_renda_padding(uint32_t t) { return t == FUMEN_RENDA || t == FUMEN_BIG_RENDA; }
 
 FumenParser::FumenParser(const fs::path& path) : file_path(path) {
-    metadata             = TJAMetadata();
-    ex_data              = TJAEXData();
-    metadata.title["en"] = path.stem().string();
-    metadata.course_data[0] = CourseData{};
+    metadata = TJAMetadata();
+    ex_data  = TJAEXData();
+
+    std::error_code ec;
+    if (fs::is_directory(path, ec)) {
+        song_id = path.filename().string();
+        library = gen4::library_for(path);
+    }
+
+    const gen4::SongEntry* entry = library ? library->find(song_id) : nullptr;
+    if (!entry) {
+        // A bare chart file, or a folder the datatable does not list: all that
+        // can be said about it is its name, and that it has one chart.
+        metadata.title["en"] = path.stem().string();
+        metadata.course_data[0] = CourseData{};
+        return;
+    }
+
+    for (const auto& [lang, text] : entry->title)
+        if (!text.empty()) metadata.title[lang] = text;
+    for (const auto& [lang, text] : entry->subtitle)
+        if (!text.empty()) metadata.subtitle[lang] = text;
+    if (metadata.title.find("en") == metadata.title.end())
+        metadata.title["en"] = song_id;
+
+    // Only the difficulties that actually ship a chart, so the wheel does not
+    // offer one that cannot be played.
+    for (int d = 0; d < 5; d++) {
+        if (!library->has_difficulty(song_id, d)) continue;
+        CourseData course;
+        course.level        = entry->stars[d];
+        course.is_branching = entry->branch[d];
+        metadata.course_data[d] = course;
+    }
+
+    if (!entry->sound_file.empty())
+        metadata.wave = library->root() / (entry->sound_file + ".nus3bank");
 }
 
-void FumenParser::build_notes() {
-    if (parsed) return;
-    parsed = true;
+std::vector<uint8_t> FumenParser::read_chart(int diff) {
+    if (library) return library->load_chart(song_id, diff);
+
+    // A chart taken straight from the game data is encrypted; one that has
+    // already been unpacked is not. Trying the key tells the two apart: a
+    // plain file fails its padding check and is then used as it is.
+    static const std::vector<uint8_t> key = gen4::derive_key(gen4::FUMEN_SEED);
+    std::vector<uint8_t> plain = gen4::load_encrypted(file_path, key);
+    if (!plain.empty()) return plain;
 
     std::ifstream f(file_path, std::ios::binary);
     if (!f) {
         spdlog::warn("FumenParser: cannot open {}", file_path.string());
-        return;
+        return {};
     }
+    return std::vector<uint8_t>((std::istreambuf_iterator<char>(f)),
+                                std::istreambuf_iterator<char>());
+}
+
+void FumenParser::build_notes(int diff) {
+    if (cached_diff == diff) return;
+    cached_diff  = diff;
+    cached_notes = NoteList();
+
+    std::vector<uint8_t> data = read_chart(diff);
+    size_t pos = 0;
+    auto take = [&](void* dst, size_t n) {
+        if (pos + n > data.size()) return false;
+        memcpy(dst, data.data() + pos, n);
+        pos += n;
+        return true;
+    };
 
     FumenHeader hdr{};
-    f.read(reinterpret_cast<char*>(&hdr), sizeof(FumenHeader));
-    if (!f || hdr.number_of_measures == 0 || hdr.number_of_measures > 100000) {
-        spdlog::warn("FumenParser: invalid header in {}", file_path.string());
+    if (!take(&hdr, sizeof(FumenHeader)) ||
+        hdr.number_of_measures == 0 || hdr.number_of_measures > 100000) {
+        spdlog::warn("FumenParser: no readable chart in {} difficulty {}",
+                     file_path.string(), diff);
         return;
     }
 
@@ -126,8 +183,7 @@ void FumenParser::build_notes() {
 
     for (uint32_t m = 0; m < hdr.number_of_measures; m++) {
         FumenMeasureData mdata{};
-        f.read(reinterpret_cast<char*>(&mdata), sizeof(FumenMeasureData));
-        if (!f) break;
+        if (!take(&mdata, sizeof(FumenMeasureData))) break;
 
         double measure_ms = static_cast<double>(mdata.measure_offset);
         double bpm        = static_cast<double>(mdata.bpm);
@@ -160,21 +216,19 @@ void FumenParser::build_notes() {
             uint16_t branch_unk  = 0;
             float    scroll      = 1.0f;
 
-            f.read(reinterpret_cast<char*>(&note_count), sizeof(note_count));
-            f.read(reinterpret_cast<char*>(&branch_unk), sizeof(branch_unk));
-            f.read(reinterpret_cast<char*>(&scroll),     sizeof(scroll));
-            if (!f) break;
+            if (!take(&note_count, sizeof(note_count)) ||
+                !take(&branch_unk, sizeof(branch_unk)) ||
+                !take(&scroll,     sizeof(scroll))) break;
 
             if (b == 0) normal_scroll = scroll;
 
             for (uint16_t n = 0; n < note_count; n++) {
                 FumenNoteBase nb{};
-                f.read(reinterpret_cast<char*>(&nb), sizeof(FumenNoteBase));
-                if (!f) break;
+                if (!take(&nb, sizeof(FumenNoteBase))) break;
 
                 if (has_renda_padding(nb.type)) {
                     uint32_t extra[2]{};
-                    f.read(reinterpret_cast<char*>(extra), 8);
+                    take(extra, 8);
                 }
 
                 if (b != 0) continue;
@@ -251,13 +305,13 @@ void FumenParser::build_notes() {
 }
 
 std::tuple<NoteList, std::deque<NoteList>, std::deque<NoteList>, std::deque<NoteList>>
-FumenParser::notes_to_position(int /*diff*/) {
-    build_notes();
+FumenParser::notes_to_position(int diff) {
+    build_notes(diff);
     return {cached_notes, {}, {}, {}};
 }
 
-std::string FumenParser::get_diff_hash(int /*difficulty*/) {
-    build_notes();
+std::string FumenParser::get_diff_hash(int difficulty) {
+    build_notes(difficulty);
     if (cached_notes.notes.empty()) return "";
     std::vector<unsigned char> buffer;
     for (const Note& n : cached_notes.notes) {
@@ -269,5 +323,7 @@ std::string FumenParser::get_diff_hash(int /*difficulty*/) {
 }
 
 std::string FumenParser::get_song_hash() {
-    return get_diff_hash(0);
+    // The oni chart stands in for the song: every song has one, and it is the
+    // one difficulty that is never a cut-down arrangement of another.
+    return get_diff_hash(3);
 }

--- a/src/libs/parsers/fumen.cpp
+++ b/src/libs/parsers/fumen.cpp
@@ -1,4 +1,5 @@
 #include "fumen.h"
+#include <algorithm>
 #include <fstream>
 
 #pragma pack(push, 1)
@@ -96,7 +97,8 @@ static bool is_roll(uint32_t t)    { return t == FUMEN_RENDA || t == FUMEN_BIG_R
 static bool is_balloon(uint32_t t) { return t == FUMEN_BALLOON || t == FUMEN_KUSUDAMA; }
 static bool has_renda_padding(uint32_t t) { return t == FUMEN_RENDA || t == FUMEN_BIG_RENDA; }
 
-FumenParser::FumenParser(const fs::path& path) : file_path(path) {
+FumenParser::FumenParser(const fs::path& path, int start_delay)
+    : file_path(path), start_delay(static_cast<double>(start_delay)) {
     metadata = TJAMetadata();
     ex_data  = TJAEXData();
 
@@ -185,8 +187,14 @@ void FumenParser::build_notes(int diff) {
         FumenMeasureData mdata{};
         if (!take(&mdata, sizeof(FumenMeasureData))) break;
 
-        double measure_ms = static_cast<double>(mdata.measure_offset);
         double bpm        = static_cast<double>(mdata.bpm);
+
+        // The engine does not play a measure at the time the file gives it: it
+        // adds one whole 4/4 measure at that measure's own BPM. Chart-native
+        // times are that much too early, and since the term depends on the
+        // BPM of each measure it cannot be corrected with one fixed offset.
+        double lead_in    = bpm > 0.0 ? 60000.0 / bpm * 4.0 : 0.0;
+        double measure_ms = static_cast<double>(mdata.measure_offset) + lead_in + start_delay;
         bool   gogo       = mdata.is_gogo_time != 0;
         bool   show_bar   = mdata.is_bar_line_visible != 0;
 
@@ -233,8 +241,7 @@ void FumenParser::build_notes(int diff) {
 
                 if (b != 0) continue;
 
-                double hit_ms = static_cast<double>(mdata.measure_offset)
-                                + static_cast<double>(nb.note_offset);
+                double hit_ms = measure_ms + static_cast<double>(nb.note_offset);
                 NoteType nt = map_note_type(nb.type);
 
                 Note note;
@@ -265,7 +272,11 @@ void FumenParser::build_notes(int diff) {
                     cached_notes.notes.push_back(tail);
 
                 } else if (is_balloon(nb.type)) {
-                    note.count = 20;
+                    // The hit count is the first half of the word at offset 16,
+                    // which the simple note types use for their score value
+                    // instead. Twenty was a placeholder.
+                    int hits = (int)(uint16_t)(nb.unknown2 & 0xFFFF);
+                    note.count = hits > 0 ? hits : 20;
                     cached_notes.notes.push_back(note);
 
                     Note tail;
@@ -300,6 +311,13 @@ void FumenParser::build_notes(int diff) {
             }
         }
     }
+
+    // The added measure is worth less at a higher BPM, so a tempo change can
+    // put a later measure's note ahead of an earlier one in wall time.
+    std::stable_sort(cached_notes.notes.begin(), cached_notes.notes.end(),
+                     [](const Note& a, const Note& b) { return a.hit_ms < b.hit_ms; });
+    for (size_t i = 0; i < cached_notes.notes.size(); i++)
+        cached_notes.notes[i].index = (int)i;
 
     modifier_moji(cached_notes);
 }

--- a/src/libs/parsers/fumen.h
+++ b/src/libs/parsers/fumen.h
@@ -16,7 +16,7 @@ public:
     TJAEXData   ex_data;
 
     FumenParser() = default;
-    explicit FumenParser(const fs::path& path);
+    explicit FumenParser(const fs::path& path, int start_delay = 0);
     void get_metadata() {}
     std::string get_difficulty_name() { return ""; }
 
@@ -32,6 +32,10 @@ public:
 private:
     const gen4::Library* library = nullptr;
     std::string          song_id;
+    // The lead-in the game plays before the chart starts. TJA charts carry it
+    // in their note times, and the engine starts the music by it, so a chart
+    // without it runs a second ahead of its music.
+    double               start_delay = 0.0;
 
     int      cached_diff = -1;
     NoteList cached_notes;

--- a/src/libs/parsers/fumen.h
+++ b/src/libs/parsers/fumen.h
@@ -1,6 +1,14 @@
 #pragma once
 #include "tja.h"
+#include "../gen4.h"
 
+// The chart format of the gen 4 arcade games. A song is a folder of up to five
+// chart files, one per difficulty, and everything else about it -- title, star
+// ratings, which difficulties exist -- comes from the game's datatable rather
+// than from the charts themselves.
+//
+// A path to a single chart file also works, for looking at one chart on its
+// own; there is no metadata to be had that way.
 class FumenParser {
 public:
     fs::path   file_path;
@@ -18,9 +26,16 @@ public:
     std::string get_song_hash();
     std::string get_diff_hash(int difficulty);
 
+    // True when the path was a song folder that the datatable knows about.
+    bool is_library_song() const { return library != nullptr; }
+
 private:
-    bool     parsed = false;
+    const gen4::Library* library = nullptr;
+    std::string          song_id;
+
+    int      cached_diff = -1;
     NoteList cached_notes;
 
-    void build_notes();
+    void build_notes(int diff);
+    std::vector<uint8_t> read_chart(int diff);
 };

--- a/src/libs/scores.cpp
+++ b/src/libs/scores.cpp
@@ -123,6 +123,7 @@ ScoresManager::ScoresManager(const fs::path& db_path) {
 }
 
 void ScoresManager::load_score_cache() {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     score_cache.clear();
 
     sqlite3_stmt* stmt;
@@ -337,6 +338,7 @@ void ScoresManager::export_to_hiroba(const std::string& access_code, int player_
 }
 
 std::optional<Score> ScoresManager::get_score(std::string& hash, int difficulty, int player_id) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     auto it = score_cache.find(std::make_tuple(hash, difficulty, player_id));
     if (it != score_cache.end()) return it->second;
     return std::nullopt;
@@ -372,6 +374,7 @@ Score ScoresManager::save_score(std::string& hash, int difficulty, int player_id
     spdlog::info("Saved score for hash: {} score: {} crown: {}", hash, score.score, (int)score.crown);
 
     auto key = std::make_tuple(hash, difficulty, player_id);
+    std::lock_guard<std::mutex> lock(maps_mutex);
     auto it = score_cache.find(key);
     bool is_better = it == score_cache.end() ||
         score.crown > it->second.crown ||
@@ -382,6 +385,7 @@ Score ScoresManager::save_score(std::string& hash, int difficulty, int player_id
 }
 
 void ScoresManager::add_path_binding(const fs::path& path, const std::array<std::string, 5>& hashes) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     path_to_hashes[path] = hashes;
     std::string single = std::accumulate(hashes.begin(), hashes.end(), std::string{});
     single_hash_to_path[single] = path;
@@ -391,23 +395,30 @@ void ScoresManager::add_path_binding(const fs::path& path, const std::array<std:
 }
 
 std::optional<fs::path> ScoresManager::get_path_by_hash(const std::string& single_hash) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     auto it = single_hash_to_path.find(single_hash);
     if (it != single_hash_to_path.end()) return it->second;
     return std::nullopt;
 }
 
 std::optional<fs::path> ScoresManager::get_path_by_diff_hash(const std::string& diff_hash) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     auto it = diff_hash_to_path.find(diff_hash);
     if (it != diff_hash_to_path.end()) return it->second;
     return std::nullopt;
 }
 
-std::array<std::string, 5>& ScoresManager::get_hashes(const fs::path& path) {
-    return path_to_hashes[path];
+std::array<std::string, 5> ScoresManager::get_hashes(const fs::path& path) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
+    auto it = path_to_hashes.find(path);
+    return it != path_to_hashes.end() ? it->second : std::array<std::string, 5>{};
 }
 
 std::string ScoresManager::get_single_hash(const fs::path& path) {
-    return std::accumulate(path_to_hashes[path].begin(), path_to_hashes[path].end(), std::string{});
+    std::lock_guard<std::mutex> lock(maps_mutex);
+    auto it = path_to_hashes.find(path);
+    if (it == path_to_hashes.end()) return "";
+    return std::accumulate(it->second.begin(), it->second.end(), std::string{});
 }
 
 void ScoresManager::add_song(const std::array<std::string, 5>& hashes, const std::string& title, const std::string& subtitle) {

--- a/src/libs/scores.h
+++ b/src/libs/scores.h
@@ -2,6 +2,7 @@
 
 #include "global_data.h"
 #include <sqlite3.h>
+#include <mutex>
 
 struct PlayerData {
     int player_id;
@@ -43,6 +44,10 @@ struct Score {
 class ScoresManager {
 private:
     sqlite3* db_fsd;
+    // Guards the four lookup maps below: read by the loader thread for every
+    // box, written by the main thread when a hash is computed or a score
+    // saved.
+    mutable std::mutex maps_mutex;
     std::unordered_map<fs::path, std::array<std::string, 5>> path_to_hashes;
     std::unordered_map<std::string, fs::path> single_hash_to_path;
     std::unordered_map<std::string, fs::path> diff_hash_to_path;
@@ -59,7 +64,11 @@ public:
     std::optional<Score> get_score(std::string& hash, int difficulty, int player_id);
     Score save_score(std::string& hash, int difficulty, int player_id, Score score);
     void add_path_binding(const fs::path& path, const std::array<std::string, 5>& hashes);
-    std::array<std::string, 5>& get_hashes(const fs::path& path);
+    // By value on purpose: the maps below are written from the song select
+    // (recording a freshly computed hash) while the loader thread reads them
+    // for every box it builds, and a reference into an unordered_map does not
+    // survive the rehash an insert can cause.
+    std::array<std::string, 5> get_hashes(const fs::path& path);
     std::string get_single_hash(const fs::path& path);
     std::optional<fs::path> get_path_by_hash(const std::string& single_hash);
     std::optional<fs::path> get_path_by_diff_hash(const std::string& diff_hash);

--- a/src/libs/song_parser.cpp
+++ b/src/libs/song_parser.cpp
@@ -1,7 +1,12 @@
 #include "song_parser.h"
+#include <system_error>
 
 SongParser::SongParser(const fs::path& path, int start_delay, PlayerNum player_num) {
-    if (path.extension() == ".osu")
+    // A gen 4 song is a folder of chart files rather than a single file.
+    std::error_code dir_ec;
+    if (fs::is_directory(path, dir_ec))
+        impl = FumenParser(path);
+    else if (path.extension() == ".osu")
         impl = OsuParser(path);
     else if (path.extension() == ".bin")
         impl = FumenParser(path);

--- a/src/libs/song_parser.cpp
+++ b/src/libs/song_parser.cpp
@@ -5,11 +5,11 @@ SongParser::SongParser(const fs::path& path, int start_delay, PlayerNum player_n
     // A gen 4 song is a folder of chart files rather than a single file.
     std::error_code dir_ec;
     if (fs::is_directory(path, dir_ec))
-        impl = FumenParser(path);
+        impl = FumenParser(path, start_delay);
     else if (path.extension() == ".osu")
         impl = OsuParser(path);
     else if (path.extension() == ".bin")
-        impl = FumenParser(path);
+        impl = FumenParser(path, start_delay);
     else
         impl = TJAParser(path, start_delay, player_num);
     sync();

--- a/src/objects/song_select/file_navigator/box_folder.cpp
+++ b/src/objects/song_select/file_navigator/box_folder.cpp
@@ -1,4 +1,5 @@
 #include "box_folder.h"
+#include "../../../libs/gen4.h"
 #include "../../../libs/filesystem.h"
 #include "../../../libs/scores.h"
 #include "../../../libs/audio.h"
@@ -68,13 +69,32 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
         }
     };
 
-    for (const auto& entry : fs::recursive_directory_iterator(path)) {
+    // A game data root holds thousands of files that are not songs, and its
+    // song count is known without looking at the disk at all.
+    if (const gen4::Library* library = gen4::library_for(path)) {
+        int genre_no = gen4::genre_of_path(path);
+        for (const gen4::OrderEntry& listing : library->order())
+            if (genre_no < 0 || listing.genre_no == genre_no) tja_count++;
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        scan_cache[path] = {crown, tja_count};
+        return;
+    }
+
+    // Errors are stepped over rather than thrown: one unreadable entry deep in
+    // a tree should not take the folder box down with it.
+    std::error_code scan_ec;
+    auto scan = fs::recursive_directory_iterator(
+        path, fs::directory_options::skip_permission_denied, scan_ec);
+    while (scan != fs::end(scan)) {
+        const fs::directory_entry& entry = *scan;
         if (entry.path().filename() == "song_list.txt") {
             auto entries = read_song_list(entry.path());
             tja_count += (int)entries.size();
             for (const auto& e : entries)
                 if (auto found = scores_manager.get_path_by_hash(e.hash))
                     update_crown(*found);
+            scan.increment(scan_ec);
+            if (scan_ec) scan_ec.clear();
             continue;
         }
         auto ext = entry.path().extension();
@@ -82,6 +102,9 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
             tja_count++;
             update_crown(entry.path());
         }
+
+        scan.increment(scan_ec);
+        if (scan_ec) scan_ec.clear();
     }
 
     {

--- a/src/objects/song_select/file_navigator/box_folder.cpp
+++ b/src/objects/song_select/file_navigator/box_folder.cpp
@@ -49,7 +49,7 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
     std::set<int> disqualified;
 
     auto update_crown = [&](const fs::path& file_path) {
-        auto& hashes = scores_manager.get_hashes(file_path);
+        auto hashes = scores_manager.get_hashes(file_path);
         for (int diff = 0; diff < 5; diff++) {
             if (hashes[diff].empty()) continue;
             auto score = scores_manager.get_score(hashes[diff], diff, global_data.config->general.player_1_id);

--- a/src/objects/song_select/file_navigator/box_song.cpp
+++ b/src/objects/song_select/file_navigator/box_song.cpp
@@ -1,5 +1,6 @@
 #include "box_song.h"
 #include "../../../libs/audio.h"
+#include <thread>
 
 SongBox::SongBox(const fs::path& path, const BoxDef& box_def, SongParser parser)
     : BaseBox(path, box_def)
@@ -48,6 +49,8 @@ void SongBox::reset() {
         audio.unload_music_stream("preview");
     }
     music_playing = false;
+    preview_load.reset();
+    preview_attempted = false;
     score_history.reset();
     box_opened_at = 0.0;
 }
@@ -84,13 +87,53 @@ void SongBox::update(double current_time) {
     BaseBox::update(current_time);
     diff_fade_in->update(current_time);
 
-    if (yellow_box.has_value() && (yellow_box->left_out != nullptr) && yellow_box->left_out->is_finished && fs::exists(parser.metadata.wave) && !music_playing) {
+    bool is_bank = parser.metadata.wave.extension() == ".nus3bank";
+
+    // A bank has to be decoded whole, which takes over a second: done on this
+    // thread it is a frozen wheel, and started when the box has finished
+    // opening it is a second of silence on top of the opening. So the decode
+    // runs on its own thread, kicked off as soon as the cursor has rested
+    // here for a moment, overlapping the animation it used to wait behind.
+    if (is_bank && yellow_box.has_value() && !music_playing && !preview_load &&
+        !preview_attempted && get_current_ms() - bar_open_started_at > 250 &&
+        fs::exists(parser.metadata.wave)) {
+        preview_attempted = true;
+        preview_load = std::make_shared<PreviewLoad>();
+        std::thread([state = preview_load, wave = parser.metadata.wave] {
+            state->ok = audio.prepare_nus3bank_pcm(wave, state->pcm, true);
+            state->done.store(true, std::memory_order_release);
+        }).detach();
+    }
+
+    if (!is_bank && yellow_box.has_value() && (yellow_box->left_out != nullptr) && yellow_box->left_out->is_finished && fs::exists(parser.metadata.wave) && !music_playing) {
         music_playing = true;
         audio.stop_sound("bgm");
         audio.load_music_stream(parser.metadata.wave, "preview");
         if (audio.is_music_stream_valid("preview")) {
             audio.play_music_stream("preview", VolumePreset::MUSIC);
             audio.seek_music_stream("preview", parser.metadata.demostart);
+        }
+    }
+
+    // The decoded preview starts once the box has also finished opening, the
+    // same moment the synchronous path above starts its music.
+    if (preview_load && preview_load->done.load(std::memory_order_acquire) &&
+        yellow_box.has_value() && (yellow_box->left_out != nullptr) &&
+        yellow_box->left_out->is_finished && !music_playing) {
+        auto state = std::move(preview_load);
+        if (state->ok) {
+            music_playing = true;
+            audio.stop_sound("bgm");
+            // The bank names its own preview point; the chart has no
+            // DEMOSTART to fall back on beyond zero.
+            float demo_start = state->pcm.preview_ms > 0
+                             ? state->pcm.preview_ms / 1000.0f
+                             : parser.metadata.demostart;
+            audio.load_music_stream_prepared(std::move(state->pcm), "preview");
+            if (audio.is_music_stream_valid("preview")) {
+                audio.play_music_stream("preview", VolumePreset::MUSIC);
+                audio.seek_music_stream("preview", demo_start);
+            }
         }
     }
 
@@ -115,6 +158,8 @@ void SongBox::expand_box() {
 void SongBox::close_box() {
     BaseBox::close_box();
     box_opened_at = 0.0;
+    preview_load.reset();
+    preview_attempted = false;
     if (music_playing) {
         if (audio.is_music_stream_valid("preview")) {
             audio.stop_music_stream("preview");

--- a/src/objects/song_select/file_navigator/box_song.cpp
+++ b/src/objects/song_select/file_navigator/box_song.cpp
@@ -30,16 +30,32 @@ SongBox::SongBox(const fs::path& path, const BoxDef& box_def, SongParser parser)
 
 void SongBox::refresh_scores() {
     hashes = scores_manager.get_hashes(path);
+    // An arcade chart's hash means parsing and digesting the whole chart, and
+    // this runs for every difficulty of every box a genre opens - hundreds of
+    // file reads for a wheel that is just being looked at. No stored hash
+    // means the song was never played, so there is no score to find anyway;
+    // playing it once computes and records the real hash.
+    bool cheap_hash = !std::holds_alternative<FumenParser>(parser.impl);
     for (const auto& [course, course_data] : parser.metadata.course_data) {
         if (course < 0 || course >= static_cast<int>(hashes.size()))
             continue;
-        if (hashes[course].empty())
+        if (hashes[course].empty() && cheap_hash)
             hashes[course] = parser.get_diff_hash(course);
     }
     for (int i = 0; i < 5; i++) {
         scores[i] = scores_manager.get_score(hashes[i], i, global_data.config->general.player_1_id);
     }
     score_history.reset();
+}
+
+std::string SongBox::hash_for(int difficulty) {
+    if (difficulty < 0 || difficulty >= (int)hashes.size()) return "";
+    if (hashes[difficulty].empty()) {
+        hashes[difficulty] = parser.get_diff_hash(difficulty);
+        if (!hashes[difficulty].empty())
+            scores_manager.add_path_binding(path, hashes);
+    }
+    return hashes[difficulty];
 }
 
 void SongBox::reset() {

--- a/src/objects/song_select/file_navigator/box_song.h
+++ b/src/objects/song_select/file_navigator/box_song.h
@@ -55,6 +55,11 @@ public:
     std::vector<Difficulty> get_diffs();
 
     void refresh_scores();
+    // The chart hash for one difficulty, computed on first use. Arcade charts
+    // skip hashing when the box is built (it means parsing the whole chart),
+    // so the moment a song is actually picked the hash is filled in here and
+    // recorded, and every later lookup finds it stored.
+    std::string hash_for(int difficulty);
 
     const char* lua_kind() const override { return "song"; }
     OutlinedText* horizontal_subtitle() {

--- a/src/objects/song_select/file_navigator/box_song.h
+++ b/src/objects/song_select/file_navigator/box_song.h
@@ -3,6 +3,8 @@
 #include "box_base.h"
 #include "score_history.h"
 #include "../../../libs/song_parser.h"
+#include "../../../libs/audio.h"
+#include <atomic>
 #include <cmath>
 
 class SongBox : public BaseBox {
@@ -17,6 +19,19 @@ public:
     std::unique_ptr<OutlinedText> bpm_text;
     std::optional<ray::Texture2D> preimage;
     bool music_playing = false;
+    // Decoding a .nus3bank preview takes over a second, so it runs on its own
+    // thread; the box polls this in update and starts the stream when it is
+    // ready. Dropping the pointer abandons a load whose result is not wanted
+    // any more - the worker holds its own reference and finishes harmlessly.
+    struct PreviewLoad {
+        std::atomic<bool>       done{false};
+        bool                    ok = false;
+        AudioEngine::PreparedPCM pcm;
+    };
+    std::shared_ptr<PreviewLoad> preview_load;
+    // One decode per opening: a failed bank would otherwise be retried every
+    // frame for as long as the cursor sits on it.
+    bool preview_attempted = false;
     std::unique_ptr<ScoreHistory> score_history;
     double box_opened_at = 0.0;
     FadeAnimation* diff_fade_in;

--- a/src/objects/song_select/file_navigator/color_utils.cpp
+++ b/src/objects/song_select/file_navigator/color_utils.cpp
@@ -48,19 +48,22 @@ ray::Color darken_color(const ray::Color& rgb) {
 }
 
 
+// Alpha is spelled out on every colour: ray::Color is a plain aggregate, so a
+// three-value initialisation quietly leaves alpha at 0 and anything drawn with
+// it - a text outline, say - is painted fully transparent.
 const std::map<GenreIndex, std::array<std::optional<ray::Color>, 2>> DEFAULT_COLORS = {
-    { GenreIndex::JPOP,        { ray::Color(32,  160, 186), ray::Color(0,   77,  104) } },
-    { GenreIndex::ANIME,       { ray::Color(255, 152, 0),   ray::Color(156, 64,  2)   } },
-    { GenreIndex::VOCALOID,    { std::nullopt,        ray::Color(84,  101, 126) } },
-    { GenreIndex::CHILDREN,    { ray::Color(255, 82,  134), ray::Color(153, 4,   46)  } },
-    { GenreIndex::VARIETY,     { ray::Color(142, 212, 30),  ray::Color(60,  104, 0)   } },
-    { GenreIndex::CLASSICAL,   { ray::Color(209, 162, 19),  ray::Color(134, 88,  0)   } },
-    { GenreIndex::GAME,        { ray::Color(156, 117, 189), ray::Color(79,  40,  134) } },
-    { GenreIndex::NAMCO,       { ray::Color(255, 90,  19),  ray::Color(148, 24,  0)   } },
-    { GenreIndex::DEFAULT,     { std::nullopt,        ray::Color(101, 0,   82)  } },
-    { GenreIndex::RECOMMENDED, { std::nullopt,        ray::Color(140, 39,  92)  } },
-    { GenreIndex::FAVORITE,    { std::nullopt,        ray::Color(151, 57,  30)  } },
-    { GenreIndex::RECENT,      { std::nullopt,        ray::Color(35,  123, 103) } },
-    { GenreIndex::DAN,         { ray::Color(35,  102, 170), ray::Color(25,  68,  137) } },
-    { GenreIndex::DIFFICULTY,  { ray::Color(255, 85,  95),  ray::Color(157, 13,  31)  } },
+    { GenreIndex::JPOP,        { ray::Color(32,  160, 186, 255), ray::Color(0,   77,  104, 255) } },
+    { GenreIndex::ANIME,       { ray::Color(255, 152, 0,   255), ray::Color(156, 64,  2,   255) } },
+    { GenreIndex::VOCALOID,    { std::nullopt,             ray::Color(84,  101, 126, 255) } },
+    { GenreIndex::CHILDREN,    { ray::Color(255, 82,  134, 255), ray::Color(153, 4,   46,  255) } },
+    { GenreIndex::VARIETY,     { ray::Color(142, 212, 30,  255), ray::Color(60,  104, 0,   255) } },
+    { GenreIndex::CLASSICAL,   { ray::Color(209, 162, 19,  255), ray::Color(134, 88,  0,   255) } },
+    { GenreIndex::GAME,        { ray::Color(156, 117, 189, 255), ray::Color(79,  40,  134, 255) } },
+    { GenreIndex::NAMCO,       { ray::Color(255, 90,  19,  255), ray::Color(148, 24,  0,   255) } },
+    { GenreIndex::DEFAULT,     { std::nullopt,             ray::Color(101, 0,   82,  255) } },
+    { GenreIndex::RECOMMENDED, { std::nullopt,             ray::Color(140, 39,  92,  255) } },
+    { GenreIndex::FAVORITE,    { std::nullopt,             ray::Color(151, 57,  30,  255) } },
+    { GenreIndex::RECENT,      { std::nullopt,             ray::Color(35,  123, 103, 255) } },
+    { GenreIndex::DAN,         { ray::Color(35,  102, 170, 255), ray::Color(25,  68,  137, 255) } },
+    { GenreIndex::DIFFICULTY,  { ray::Color(255, 85,  95,  255), ray::Color(157, 13,  31,  255) } },
 };

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -1355,12 +1355,21 @@ void Navigator::load_gen4_genres(const fs::path& data_root) {
         BoxDef def;
         if (const BoxDef* like = box_def_for_genre(genre)) {
             def = *like;
-        } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
-            // Nothing in the library uses this genre, so fall back to the
-            // built-in colours.
-            def.texture_index = TextureIndex::NONE;
-            def.back_color    = colors->second[0];
-            def.fore_color    = colors->second[1];
+        } else {
+            // Nothing in the library defines this genre - a game on its own,
+            // with no TJA songs beside it - so the look a box.def would give
+            // it is spelled out here instead: the same colours, and the same
+            // texture, which is the plain genre art for everything except
+            // vocaloid, which has art of its own.
+            // NONE means "tint the plain box with these colours", which is
+            // what gives each genre its own look; vocaloid is the one genre
+            // the skin has art for, and its box.def uses that instead.
+            def.texture_index = (genre == GenreIndex::VOCALOID)
+                              ? TextureIndex::VOCALOID : TextureIndex::NONE;
+            if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
+                def.back_color = colors->second[0];
+                def.fore_color = colors->second[1];
+            }
         }
         def.name        = gen4::genre_name(genre_no, lang);
         def.genre_index = genre;
@@ -1387,10 +1396,13 @@ bool Navigator::load_gen4_genre_songs(const fs::path& path, const BoxDef& box_de
     if (const BoxDef* like = box_def_for_genre(genre)) {
         def = *like;
     } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
-        // NONE means "tint the plain box art with these colours", which is what
-        // a box.def genre does to its songs; any other value draws fixed art
-        // and ignores the colours.
-        def.texture_index = TextureIndex::NONE;
+        // NONE means "tint the plain box art with these colours", which is
+        // what a box.def genre does to its songs. Vocaloid is the exception:
+        // it has no colour to tint to, only art of its own, and asking for a
+        // tint that cannot happen leaves the untinted art showing through -
+        // which is a green box under a genre that is not green.
+        def.texture_index = (genre == GenreIndex::VOCALOID)
+                          ? TextureIndex::VOCALOID : TextureIndex::NONE;
         def.back_color    = colors->second[0];
         def.fore_color    = colors->second[1];
     }

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -107,6 +107,33 @@ void Navigator::wait_for_song_files() {
         song_files_thread.join();
 }
 
+void Navigator::load_all_roots() {
+    join_loader();
+    items.clear();
+    open_index = 0;
+    def_file_cache.clear();
+    box_def_cache.clear();
+    is_processing    = true;
+    loading_complete = false;
+    reloading_roots  = true;
+
+    auto walk_roots = [this] {
+        for (const fs::path& root : root_paths) {
+            if (abort_loading) break;
+            loading_complete = false;
+            load_current_directory_async(root);
+        }
+        reloading_roots  = false;
+        loading_complete = true;
+    };
+
+#ifndef __EMSCRIPTEN__
+    loader_thread = std::thread(walk_roots);
+#else
+    walk_roots();
+#endif
+}
+
 void Navigator::preload(std::vector<fs::path> songs_paths) {
     if (is_preloaded) return;
     root_paths = songs_paths;
@@ -160,9 +187,7 @@ void Navigator::init(std::vector<fs::path> songs_paths) {
             preload(songs_paths);
         }
 
-        for (const fs::path& root_path : root_paths) {
-            load_current_directory(root_path);
-        }
+        load_all_roots();
         is_init = true;
     } else {
         if (global_data.config->general.song_limit > 0) {
@@ -206,13 +231,18 @@ void Navigator::join_loader() {
 }
 
 void Navigator::enqueue_box(std::unique_ptr<BaseBox> box) {
-    auto last_write = fs::last_write_time(box->path);
-    auto last_write_sys = ch::system_clock::now() +
-        std::chrono::duration_cast<ch::system_clock::duration>(
-            last_write - std::filesystem::file_time_type::clock::now());
-    auto two_weeks_ago = ch::system_clock::now() - ch::weeks(2);
-    if (last_write_sys < two_weeks_ago)
-        box->is_new = true;
+    // Not every box stands for something on disk: a gen 4 genre is a property
+    // of a song, not a folder, so it has no file time and simply is not new.
+    std::error_code ec;
+    auto last_write = fs::last_write_time(box->path, ec);
+    if (!ec) {
+        auto last_write_sys = ch::system_clock::now() +
+            std::chrono::duration_cast<ch::system_clock::duration>(
+                last_write - std::filesystem::file_time_type::clock::now());
+        auto two_weeks_ago = ch::system_clock::now() - ch::weeks(2);
+        if (last_write_sys < two_weeks_ago)
+            box->is_new = true;
+    }
 
     std::lock_guard<std::mutex> lock(pending_mutex);
     if (auto* song = dynamic_cast<SongBox*>(box.get())) {
@@ -389,6 +419,21 @@ void Navigator::load_current_directory_async(const fs::path path) {
 
     setup_back_box(path, true);
 
+    // A data root lists its own genres and nothing else, so the songs of this
+    // game replace the ones that were on the wheel until the back box is used.
+    if (is_gen4_root(path)) {
+        try {
+            load_gen4_genres(path);
+        } catch (const std::exception& e) {
+            spdlog::error("Error listing gen4 genres of {}: {}", path.string(), e.what());
+        } catch (...) {
+            spdlog::error("Unknown error listing gen4 genres of {}", path.string());
+        }
+        loading_complete = true;
+        current_path = path;
+        return;
+    }
+
     // Pre-parse the level's song files on a worker pool (see
     // parse_songs_parallel) so the streaming loop below only assembles boxes.
     std::vector<fs::path> song_paths;
@@ -414,6 +459,13 @@ void Navigator::load_current_directory_async(const fs::path path) {
                     }
                     if (is_song_file(curr_path))
                         enqueue_box(make_song_box(curr_path, box_def, take_parser(preparsed, curr_path)));
+                    continue;
+                }
+                if (is_gen4_root(curr_path)) {
+                    BoxDef gen4_def = box_def;
+                    gen4_def.name        = curr_path.filename().string();
+                    gen4_def.genre_index = GenreIndex::DEFAULT;
+                    enqueue_box(std::make_unique<FolderBox>(curr_path, gen4_def, song_files));
                     continue;
                 }
                 if (is_gen4_song_folder(curr_path)) {
@@ -466,6 +518,12 @@ void Navigator::load_current_directory_async(const fs::path path) {
         }
     } catch (const fs::filesystem_error& e) {
         spdlog::error("Error loading directory: {}", e.what());
+    } catch (const std::exception& e) {
+        // This runs on the loader thread, where an escaping exception takes
+        // the process down instead of failing one directory.
+        spdlog::error("Error loading directory {}: {}", path.string(), e.what());
+    } catch (...) {
+        spdlog::error("Unknown error loading directory {}", path.string());
     }
     loading_complete = true;
     current_path = path;
@@ -708,6 +766,11 @@ void Navigator::load_collection_search(const fs::path& path, const BoxDef& box_d
 }
 
 void Navigator::load_songs_inline_async(const fs::path path, BoxDef box_def) {
+    if (load_gen4_genre_songs(path, box_def)) {
+        loading_complete = true;
+        return;
+    }
+
     wait_for_song_files();
     int songs_added = 0;
     std::unordered_map<std::string, std::unique_ptr<SongParser>> preparsed;
@@ -960,6 +1023,15 @@ void Navigator::load_current_directory(const fs::path path) {
     BoxDef box_def = parse_box_def(path);
     bool has_children = has_child_folders(path);
 
+    // Coming back out to a root rebuilds every root together: the top of the
+    // wheel is all of them, and each load cancels the one before it, so
+    // reloading just this one would leave only its own songs on the wheel.
+    if (has_children && root_paths.size() > 1 && !reloading_roots &&
+        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end()) {
+        load_all_roots();
+        return;
+    }
+
     if (!has_children && !items.empty()) {
         InlineState state;
         state.folder_index     = open_index;
@@ -1131,7 +1203,9 @@ bool Navigator::jump_to_song(const std::string& hash) {
 
 void Navigator::setup_back_box(const fs::path& path, bool has_children) {
     if (has_children) {
-        items.clear();
+        // While every root is being walked in turn, the wheel was already
+        // emptied once and each root adds to it.
+        if (!reloading_roots) items.clear();
         // A root level has no folder to close: the box would point at the
         // songs dir's parent and selecting it does nothing sensible.
         if (std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end())
@@ -1146,15 +1220,27 @@ void Navigator::setup_back_box(const fs::path& path, bool has_children) {
 }
 
 bool Navigator::has_child_folders(const fs::path& path) {
-    for (const auto& entry : fs::directory_iterator(path))
+    // A data root opens into its genres, which replaces the wheel; a genre
+    // opens into songs, which expands in place like any other genre folder.
+    if (gen4::genre_of_path(path) >= 0) return false;
+    if (is_gen4_root(path)) return true;
+
+    for (const auto& entry : fs::directory_iterator(path)) {
         if (fs::is_directory(entry.path()) && has_def_file(entry.path()) || is_osu_song_folder(entry.path()))
             return true;
+        // A folder holding a game data root is a level of its own too, or
+        // coming back out of that game tries to expand this folder as a song.
+        if (is_gen4_root(entry.path()))
+            return true;
+    }
     return false;
 }
 
 bool Navigator::is_directory(BaseBox* item) {
     // Not simply "the path is a folder": a gen 4 song is a folder of chart
-    // files, and treating one as a directory opens it instead of playing it.
+    // files, and treating one as a directory opens it instead of playing it,
+    // while a gen 4 genre is a folder whose path is not on disk at all.
+    if (dynamic_cast<FolderBox*>(item) != nullptr) return true;
     return !is_song(item) && fs::is_directory(item->path);
 }
 
@@ -1162,6 +1248,111 @@ bool Navigator::is_song_file(const fs::path& path) {
     if (!fs::is_regular_file(path)) return false;
     auto ext = path.extension();
     return ext == ".tja" || ext == ".osu";
+}
+
+// A gen 4 genre has no box.def of its own, so it borrows the one the library
+// already has for that genre: same colours, same folder art, same text
+// outline, rather than a second set that only nearly matches.
+const BoxDef* Navigator::box_def_for_genre(GenreIndex genre) {
+    if (!genre_box_defs_built) {
+        genre_box_defs_built = true;
+        for (const fs::path& root : root_paths) {
+            std::error_code ec;
+            if (!fs::is_directory(root, ec)) continue;
+            for (const auto& entry : fs::directory_iterator(root, ec)) {
+                if (abort_loading) return nullptr;
+                if (!fs::is_directory(entry.path(), ec)) continue;
+                if (!has_def_file(entry.path())) continue;
+                BoxDef def = parse_box_def(entry.path());
+                genre_box_defs.emplace(def.genre_index, def);
+            }
+        }
+    }
+    auto it = genre_box_defs.find(genre);
+    return it != genre_box_defs.end() ? &it->second : nullptr;
+}
+
+// The folder holding a game's datatable, fumen and sound. It stands in the
+// wheel as one box: opening it puts the wheel into that game's own genres, and
+// the back box leads out again.
+bool Navigator::is_gen4_root(const fs::path& path) {
+    std::error_code ec;
+    if (!fs::is_directory(path, ec)) return false;
+    return gen4::find_data_root(path) == path && gen4::library_for(path) != nullptr;
+}
+
+void Navigator::load_gen4_genres(const fs::path& data_root) {
+    const gen4::Library* library = gen4::library_for(data_root);
+    if (!library) return;
+
+    const std::string& lang = global_data.config->general.language;
+    for (int genre_no : gen4::genres_present(*library)) {
+        if (abort_loading) break;
+        GenreIndex genre = (GenreIndex)gen4::genre_index_for(genre_no);
+
+        BoxDef def;
+        if (const BoxDef* like = box_def_for_genre(genre)) {
+            def = *like;
+        } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
+            // Nothing in the library uses this genre, so fall back to the
+            // built-in colours.
+            def.texture_index = TextureIndex::NONE;
+            def.back_color    = colors->second[0];
+            def.fore_color    = colors->second[1];
+        }
+        def.name        = gen4::genre_name(genre_no, lang);
+        def.genre_index = genre;
+        auto folder = std::make_unique<FolderBox>(gen4::genre_path(data_root, genre_no),
+                                                  def, song_files);
+        folder->tja_count = 0;
+        for (const gen4::OrderEntry& listing : library->order())
+            if (listing.genre_no == genre_no) folder->tja_count++;
+        enqueue_box(std::move(folder));
+    }
+}
+
+bool Navigator::load_gen4_genre_songs(const fs::path& path, const BoxDef& box_def) {
+    int genre_no = gen4::genre_of_path(path);
+    if (genre_no < 0) return false;
+
+    fs::path data_root = gen4::find_data_root(path);
+    const gen4::Library* library = gen4::library_for(data_root);
+    if (!library) return false;
+
+    GenreIndex genre = (GenreIndex)gen4::genre_index_for(genre_no);
+
+    BoxDef def = box_def;
+    if (const BoxDef* like = box_def_for_genre(genre)) {
+        def = *like;
+    } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
+        // NONE means "tint the plain box art with these colours", which is what
+        // a box.def genre does to its songs; any other value draws fixed art
+        // and ignores the colours.
+        def.texture_index = TextureIndex::NONE;
+        def.back_color    = colors->second[0];
+        def.fore_color    = colors->second[1];
+    }
+    def.name        = box_def.name;
+    def.genre_index = genre;
+
+    int songs_added = 0;
+    for (const gen4::OrderEntry& listing : library->order()) {
+        if (abort_loading) break;
+        if (listing.genre_no != genre_no) continue;
+        fs::path song_folder = data_root / "fumen" / listing.id;
+        std::error_code ec;
+        if (!fs::is_directory(song_folder, ec)) continue;
+        if (songs_added > 0 && songs_added % 10 == 0)
+            enqueue_inline_box(make_back_box(data_root));
+        auto box = make_song_box(song_folder, def, SongParser(song_folder));
+        // The running order is the order: leave it alone rather than sorting
+        // these by title the way a folder of files is sorted.
+        box->preserve_order = true;
+        box->fade_in(266);
+        enqueue_inline_box(std::move(box));
+        songs_added++;
+    }
+    return true;
 }
 
 // A gen 4 song folder is named after the song id and holds that id's chart

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -419,6 +419,21 @@ void Navigator::load_current_directory_async(const fs::path path) {
 
     setup_back_box(path, true);
 
+    // A song path pointing into a game - at its data root, or at the fumen
+    // folder inside it - lists that game's genres straight away.
+    fs::path own_root = gen4::find_data_root(path);
+    if (!own_root.empty() && own_root != path && gen4::library_for(own_root) &&
+        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end()) {
+        try {
+            load_gen4_genres(own_root);
+        } catch (const std::exception& e) {
+            spdlog::error("Error listing gen4 genres of {}: {}", own_root.string(), e.what());
+        }
+        loading_complete = true;
+        current_path = path;
+        return;
+    }
+
     // A data root lists its own genres and nothing else, so the songs of this
     // game replace the ones that were on the wheel until the back box is used.
     if (is_gen4_root(path)) {
@@ -462,6 +477,10 @@ void Navigator::load_current_directory_async(const fs::path path) {
                     continue;
                 }
                 if (is_gen4_root(curr_path)) {
+                    if (only_gen4_songs()) {
+                        load_gen4_genres(curr_path);
+                        continue;
+                    }
                     BoxDef gen4_def = box_def;
                     gen4_def.name        = curr_path.filename().string();
                     gen4_def.genre_index = GenreIndex::DEFAULT;
@@ -1279,6 +1298,25 @@ bool Navigator::is_gen4_root(const fs::path& path) {
     std::error_code ec;
     if (!fs::is_directory(path, ec)) return false;
     return gen4::find_data_root(path) == path && gen4::library_for(path) != nullptr;
+}
+
+// True when the song paths hold nothing but game data. There is then nothing
+// to switch back to, so the genres of that game are the top of the wheel
+// rather than sitting inside a folder of their own.
+bool Navigator::only_gen4_songs() {
+    bool found_gen4 = false;
+    std::error_code ec;
+    for (const fs::path& root : root_paths) {
+        if (!gen4::find_data_root(root).empty()) { found_gen4 = true; continue; }
+        if (!fs::is_directory(root, ec)) continue;
+        for (const auto& entry : fs::directory_iterator(root, ec)) {
+            if (is_gen4_root(entry.path())) { found_gen4 = true; continue; }
+            // Anything else at all - a genre folder, an osu folder, a loose
+            // chart - means the wheel has somewhere else to go.
+            return false;
+        }
+    }
+    return found_gen4;
 }
 
 void Navigator::load_gen4_genres(const fs::path& data_root) {

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -419,11 +419,31 @@ void Navigator::load_current_directory_async(const fs::path path) {
 
     setup_back_box(path, true);
 
-    // A song path pointing into a game - at its data root, or at the fumen
-    // folder inside it - lists that game's genres straight away.
+    // A song path pointing at a game, either at its data root or at the fumen
+    // folder inside it. While the roots are being walked this is a level of
+    // the wheel like any other, so it gets a box to open - unless the game is
+    // all there is, when its genres are the wheel itself. Opening that box
+    // comes back here with reloading_roots clear and lists the genres.
     fs::path own_root = gen4::find_data_root(path);
-    if (!own_root.empty() && own_root != path && gen4::library_for(own_root) &&
-        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end()) {
+    bool is_a_root = std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end();
+    if (!own_root.empty() && is_a_root && gen4::library_for(own_root)) {
+        if (reloading_roots && !only_gen4_songs()) {
+            BoxDef gen4_def = box_def;
+            gen4_def.name        = own_root.filename().string();
+            gen4_def.genre_index = GenreIndex::DEFAULT;
+            enqueue_box(std::make_unique<FolderBox>(own_root, gen4_def, song_files));
+            loading_complete = true;
+            current_path = path;
+            return;
+        }
+        // setup_back_box gives a root level no way out, since a root has no
+        // folder above it. This one does: the rest of the library. The box
+        // points at another root, and opening a root rebuilds them all.
+        for (const fs::path& root : root_paths) {
+            if (!gen4::find_data_root(root).empty()) continue;
+            items.push_back(make_back_box(root));
+            break;
+        }
         try {
             load_gen4_genres(own_root);
         } catch (const std::exception& e) {
@@ -1046,7 +1066,11 @@ void Navigator::load_current_directory(const fs::path path) {
     // wheel is all of them, and each load cancels the one before it, so
     // reloading just this one would leave only its own songs on the wheel.
     if (has_children && root_paths.size() > 1 && !reloading_roots &&
-        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end()) {
+        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end() &&
+        // A song path can point straight at a game, and then its box carries
+        // that same path. Opening it is going in, not coming back out, so it
+        // must not be read as a return to the top of the wheel.
+        gen4::find_data_root(path).empty()) {
         load_all_roots();
         return;
     }

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -4,6 +4,7 @@
 #include "color_utils.h"
 #include "../song_select_script.h"
 #include "../../../libs/filesystem.h"
+#include "../../../libs/gen4.h"
 #include <random>
 #include <cmath>
 
@@ -413,6 +414,10 @@ void Navigator::load_current_directory_async(const fs::path path) {
                     }
                     if (is_song_file(curr_path))
                         enqueue_box(make_song_box(curr_path, box_def, take_parser(preparsed, curr_path)));
+                    continue;
+                }
+                if (is_gen4_song_folder(curr_path)) {
+                    enqueue_box(make_song_box(curr_path, box_def, SongParser(curr_path)));
                     continue;
                 }
                 if (has_def_file(curr_path)) {
@@ -1148,13 +1153,33 @@ bool Navigator::has_child_folders(const fs::path& path) {
 }
 
 bool Navigator::is_directory(BaseBox* item) {
-    return fs::is_directory(item->path);
+    // Not simply "the path is a folder": a gen 4 song is a folder of chart
+    // files, and treating one as a directory opens it instead of playing it.
+    return !is_song(item) && fs::is_directory(item->path);
 }
 
 bool Navigator::is_song_file(const fs::path& path) {
     if (!fs::is_regular_file(path)) return false;
     auto ext = path.extension();
     return ext == ".tja" || ext == ".osu";
+}
+
+// A gen 4 song folder is named after the song id and holds that id's chart
+// files, one per difficulty. It only counts as a song when the game data it
+// belongs to can be read, since the folder alone carries no title or ratings.
+bool Navigator::is_gen4_song_folder(const fs::path& path) {
+    std::error_code ec;
+    if (!fs::is_directory(path, ec)) return false;
+
+    std::string id = path.filename().string();
+    static const char* suffixes[] = { "_e", "_n", "_h", "_m", "_x" };
+    bool has_chart = false;
+    for (const char* suffix : suffixes) {
+        if (fs::exists(path / (id + suffix + ".bin"), ec)) { has_chart = true; break; }
+    }
+    if (!has_chart) return false;
+
+    return gen4::library_for(path) != nullptr;
 }
 
 bool Navigator::is_osu_song_folder(const fs::path& path) {
@@ -1170,7 +1195,8 @@ bool Navigator::is_osu_song_folder(const fs::path& path) {
 
 
 bool Navigator::is_song(BaseBox* item) {
-    return is_song_file(item->path);
+    // What the box is, not what its path looks like.
+    return dynamic_cast<SongBox*>(item) != nullptr;
 }
 
 BaseBox* Navigator::get_current_item() {

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -77,6 +77,7 @@ private:
     bool is_osu_song_folder(const fs::path& path);
     bool is_gen4_song_folder(const fs::path& path);
     bool is_gen4_root(const fs::path& path);
+    bool only_gen4_songs();
     const BoxDef* box_def_for_genre(GenreIndex genre);
     void load_gen4_genres(const fs::path& data_root);
     bool load_gen4_genre_songs(const fs::path& genre_path, const BoxDef& box_def);

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -72,6 +72,7 @@ private:
     void set_positions(bool init, float duration);
     bool is_song_file(const fs::path& path);
     bool is_osu_song_folder(const fs::path& path);
+    bool is_gen4_song_folder(const fs::path& path);
     bool has_def_file(const std::filesystem::path& path);
     fs::path find_box_def_folder(const fs::path& song_path);
     void setup_back_box(const fs::path& path, bool has_children);

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -31,6 +31,9 @@ private:
     int open_index;
     bool is_init      = false;
     bool is_preloaded = false;
+    bool reloading_roots = false;
+    bool genre_box_defs_built = false;
+    std::map<GenreIndex, BoxDef> genre_box_defs;
 
     std::optional<InlineState>  inline_state;
     std::optional<fs::path>     pending_inline_path;
@@ -73,6 +76,10 @@ private:
     bool is_song_file(const fs::path& path);
     bool is_osu_song_folder(const fs::path& path);
     bool is_gen4_song_folder(const fs::path& path);
+    bool is_gen4_root(const fs::path& path);
+    const BoxDef* box_def_for_genre(GenreIndex genre);
+    void load_gen4_genres(const fs::path& data_root);
+    bool load_gen4_genre_songs(const fs::path& genre_path, const BoxDef& box_def);
     bool has_def_file(const std::filesystem::path& path);
     fs::path find_box_def_folder(const fs::path& song_path);
     void setup_back_box(const fs::path& path, bool has_children);
@@ -83,6 +90,7 @@ private:
     void enqueue_inline_box(std::unique_ptr<BaseBox> box);
     void parse_song_list(const fs::path& path, BoxDef box_def, bool inline_mode);
     void load_current_directory_async(const fs::path path);
+    void load_all_roots();
     void load_collection_difficulty(const fs::path& path, const BoxDef& box_def, int course, int level);
     void load_from_song_list(const fs::path& path, const BoxDef& box_def, bool mark_favorite);
     void load_collection_new(const fs::path& path, const BoxDef& box_def);

--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -45,7 +45,11 @@ void PracticeGameScreen::init_tja_practice(const fs::path& song) {
     // Extract bars and note list for scrobbling from the already-parsed TJA
     int difficulty = global_data.session_data[(int)global_data.player_num].selected_difficulty;
     auto [notes, bm, be, bn] = parser->notes_to_position(difficulty);
-    std::get<TJAParser>(parser->impl).scroll_disabled = true;
+    // Only a TJA has scroll commands to disable; asking the variant for one
+    // when an arcade chart is loaded threw and kept practice mode out of
+    // those songs entirely.
+    if (auto* tja = std::get_if<TJAParser>(&parser->impl))
+        tja->scroll_disabled = true;
     apply_modifiers(notes, get_player_modifiers(global_data.player_num));
 
     bars.clear();

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -42,7 +42,7 @@ void SongSelectScreen::select_song(SongBox* song) {
     SessionData& session_data = global_data.session_data[(int)global_data.player_num];
     session_data.selected_song = song->path;
     session_data.selected_difficulty = (int)player->selected_difficulty;
-    session_data.song_hash = song->hashes[session_data.selected_difficulty];
+    session_data.song_hash = song->hash_for(session_data.selected_difficulty);
     session_data.genre_index = (int)song->song_genre_index - 1;
     global_data.last_difficulty[(int)global_data.player_num] = session_data.selected_difficulty;
     game_transition.emplace(song->text_name, song->text_subtitle, false);

--- a/src/scenes/song_select_2p.cpp
+++ b/src/scenes/song_select_2p.cpp
@@ -57,13 +57,13 @@ void SongSelect2PScreen::select_song(SongBox* song) {
     auto& sd1 = global_data.session_data[(int)PlayerNum::P1];
     sd1.selected_song = song->path;
     sd1.selected_difficulty = (int)player->selected_difficulty;
-    sd1.song_hash = song->hashes[sd1.selected_difficulty];
+    sd1.song_hash = song->hash_for(sd1.selected_difficulty);
     sd1.genre_index = (int)song->song_genre_index - 1;
 
     auto& sd2 = global_data.session_data[(int)PlayerNum::P2];
     sd2.selected_song = song->path;
     sd2.selected_difficulty = (int)player_2->selected_difficulty;
-    sd2.song_hash = song->hashes[sd2.selected_difficulty];
+    sd2.song_hash = song->hash_for(sd2.selected_difficulty);
     sd2.genre_index = (int)song->song_genre_index - 1;
 
     global_data.last_difficulty[(int)PlayerNum::P1] = sd1.selected_difficulty;


### PR DESCRIPTION
Closes #24 for the arcade side (`Data\x64`). Tested against a CHN dump: 1143 songs, listed in the game's own genres and order, charts play, audio plays.

**Charts.** `FumenParser` was already here and its layout is right, but it was unreachable: it read a plain file, while the games ship charts AES-256-CBC encrypted then gzipped, and nothing recognised them as songs. `gen4.cpp` derives the two keys the game derives — one for the datatable, one for the charts — and decrypts and inflates with either. Verified by walking 378 chart files (five difficulties plus the `_1`/`_2` two player variants across 30 songs) with the parser's own struct layout: every one lands exactly on EOF, no trailing bytes.

**Song list, genres and order.** `musicinfo.bin` gives ids, star ratings per difficulty and audio file names; `wordlist.bin` gives titles and subtitles in all five languages it carries; `music_order.bin` decides what each genre holds and in what order. That last one matters: a song can be listed under more than one genre (189 of them are, in this dump), six songs are in no genre at all and are not shown, and the position in that table *is* the running order, so these are not sorted by title.

A game data root stands in the wheel as one box. Opening it puts the wheel into that game's genres and the back box leads out again. Each genre borrows the `box.def` of the same genre in the user's library, so it carries the colours, folder art and text outline already defined there rather than a second set that only nearly matches.

Because a song is a folder rather than a file, `is_song`/`is_directory` decide from what the box *is* rather than what its path looks like, and a genre — which is a property of a song, not a directory — is a box with no path on disk at all.

**Timing.** Two corrections, both needed. The engine does not play a measure when the file says: it adds one whole 4/4 measure at *that measure's own* BPM, so a chart that changes tempo cannot be corrected with a single offset. Chart times must also carry the lead-in the engine starts the music by, as TJA charts do, or the song runs a second early. Notes are re-sorted afterwards, since the added measure is worth less at a higher BPM and a tempo change can reorder two notes in wall time.

**Balloons** used a placeholder of twenty hits; the real count is the first half of the word at offset 16, which the simple note types use for their score value instead.

**Audio.** The banks are ITU-T G.719 (Siren 22) inside a NUS3 container — no G.719 decoder exists in FFmpeg or libsndfile. `gen4_audio.cpp` walks NUS3 → PACK → BNSF/`IS22` and decodes with one decoder instance per channel, since channels are interleaved a frame at a time.

**On the decoder dependency, which is a decision for you rather than for me.** No decoder is vendored in this tree. `-DYATAIDON_G719=ON` fetches [kode54/libg719_decode](https://github.com/kode54/libg719_decode) at build time, the same library vgmstream depends on. That repository has no license file and its `reference_code/` carries `© 2008 Ericsson AB. and Polycom Inc. All rights reserved.`, which is why it is fetched rather than copied in. The option is **off by default**; with it off the songs still load and play, silently. There may also be patent claims on G.719 independent of copyright.

A clean-room decoder is not a practical alternative: ITU publishes no free text of Recommendation G.719 — the only free item on its page is the reference source code — so the tables a decoder needs cannot be had from permitted sources. Happy to drop the audio half entirely if you would rather not carry the dependency; the chart and song-list half stands on its own.

**Known gap.** Song select previews these songs from the start rather than from the game's preview point. I could not find where that point is stored: it is in no field of any of the 38 datatable files, and in the bank itself every value in `PROP`, `BINF`, `GRP `, `DTON` and `TONE` is either constant across songs or an internal offset, with one BNSF stream per bank. Left as it is rather than guessed at.

To use it, point `tja_path` at the folder holding the game's `Data\x64`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)