### PR TITLE
Only close the folders after a song is finished

### DIFF
--- a/src/libs/global_data.h
+++ b/src/libs/global_data.h
@@ -122,6 +122,9 @@ struct CameraConfig {
 
 struct GlobalData {
     int songs_played = 0;
+    // Set when a song was played through to its results, cleared when song
+    // select acts on it. Leaving a song early does not set it.
+    bool returned_from_result = false;
     CameraConfig camera;
     Config* config = nullptr;  // Using pointer, initialize appropriately
     int total_songs = 0;

--- a/src/libs/global_data.h
+++ b/src/libs/global_data.h
@@ -122,8 +122,6 @@ struct CameraConfig {
 
 struct GlobalData {
     int songs_played = 0;
-    // Set when a song was played through to its results, cleared when song
-    // select acts on it. Leaving a song early does not set it.
     bool returned_from_result = false;
     CameraConfig camera;
     Config* config = nullptr;  // Using pointer, initialize appropriately

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -163,10 +163,6 @@ void Navigator::init(std::vector<fs::path> songs_paths) {
                 load_current_directory(root_path);
             }
         } else {
-            // A song played through to its results comes back to closed
-            // folders, cursor on the folder that was open, and remembers the
-            // song so reopening it lands there. Leaving a song early is not
-            // finishing with it, so that case keeps the folder open.
             bool from_result = global_data.returned_from_result;
             global_data.returned_from_result = false;
             if (from_result && inline_state.has_value()) {

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -163,10 +163,13 @@ void Navigator::init(std::vector<fs::path> songs_paths) {
                 load_current_directory(root_path);
             }
         } else {
-            // A song was played (or the screen was left) with a folder open:
-            // come back to closed folders, cursor on the folder that was
-            // open, and remember the song so reopening it lands there.
-            if (inline_state.has_value()) {
+            // A song played through to its results comes back to closed
+            // folders, cursor on the folder that was open, and remembers the
+            // song so reopening it lands there. Leaving a song early is not
+            // finishing with it, so that case keeps the folder open.
+            bool from_result = global_data.returned_from_result;
+            global_data.returned_from_result = false;
+            if (from_result && inline_state.has_value()) {
                 if (open_index >= 0 && open_index < (int)items.size()) {
                     if (dynamic_cast<SongBox*>(items[open_index].get()))
                         reopen_song_path = items[open_index]->path;

--- a/src/scenes/result.cpp
+++ b/src/scenes/result.cpp
@@ -58,6 +58,7 @@ std::optional<Screens> ResultScreen::update() {
                 global_data.songs_played = 0;
                 return on_screen_end(Screens::GAME_OVER);
             }
+            global_data.returned_from_result = true;
             return on_screen_end(Screens::SONG_SELECT);
         }
     }

--- a/src/scenes/result_2p.cpp
+++ b/src/scenes/result_2p.cpp
@@ -27,6 +27,7 @@ std::optional<Screens> Result2PScreen::update() {
         fade_out->update(current_time);
         if (fade_out->is_finished) {
             fade_out->update(current_time);
+            global_data.returned_from_result = true;
             return on_screen_end(Screens::SONG_SELECT_2P);
         }
     }


### PR DESCRIPTION
Coming back from a song closed the folders whether the song had been played or abandoned. Leaving early is not finishing with a folder, and having it shut and the wheel jump back to it is the opposite of what that player asked for.

The results screen marks the way back, so only that route closes them.