### PR TITLE
Keep the happy face on a balloon that was burst

### DIFF
--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -1172,10 +1172,6 @@ void Player::drumroll_counter_manager(double current_ms) {
 
 void Player::balloon_counter_manager(double current_ms) {
     if (!is_balloon && balloon_counter.has_value()) {
-        // A balloon that ran out of note is only a failure if it was not
-        // filled. Popping it on the last frame of the note ends both at once,
-        // and reading this as "the note ended" alone put the miss face on a
-        // balloon the player had just burst.
         bool popped = balloon_counter->is_finished();
         balloon_counter.reset();
         chara->set_anim(AnimIndex::DON_NORMAL);

--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -1172,9 +1172,15 @@ void Player::drumroll_counter_manager(double current_ms) {
 
 void Player::balloon_counter_manager(double current_ms) {
     if (!is_balloon && balloon_counter.has_value()) {
+        // A balloon that ran out of note is only a failure if it was not
+        // filled. Popping it on the last frame of the note ends both at once,
+        // and reading this as "the note ended" alone put the miss face on a
+        // balloon the player had just burst.
+        bool popped = balloon_counter->is_finished();
         balloon_counter.reset();
         chara->set_anim(AnimIndex::DON_NORMAL);
-        chara->set_anim(AnimIndex::DON_BALLOON_FAILURE);
+        chara->set_anim(popped ? AnimIndex::DON_BALLOON_SUCCESS
+                               : AnimIndex::DON_BALLOON_FAILURE);
     }
     if (balloon_counter.has_value()) {
         balloon_counter->update(current_ms, curr_balloon_count);


### PR DESCRIPTION
Bursting a balloon put the 3D don's *missed it* face on screen.

`Player::balloon_counter_manager` runs two checks in order each frame: "the note ended while the counter is still up" plays the failure animation, and "the counter filled" plays the success one. Bursting a balloon on the last frame of its note satisfies both, and since the first check runs first — and resets the counter — the success branch never gets the chance.

Whether the balloon filled is what decides this, not which frame it happened to end on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)