### PR TITLE
Let the play option values wrap in both directions

### DIFF
--- a/src/objects/song_select/modifier.cpp
+++ b/src/objects/song_select/modifier.cpp
@@ -118,8 +118,6 @@ void ModifierSelector::start_text_animation(int dir) {
     }
 }
 
-// はやさ walks 0.1 to 2.0 by tenths, then jumps 3.0 and 4.0, and wraps round
-// in both directions. Stored in tenths, so 1..20, then 30 and 40.
 static int speed_step(int value, int dir) {
     if (dir > 0) {
         if (value >= 40) return 1;
@@ -137,13 +135,10 @@ void ModifierSelector::left() {
     if (is_confirmed) return;
     const std::string& mod_name = MOD_NAMES[current_mod_index];
 
-    // dir is the on-screen slide direction (see NeiroSelector): pressing left
-    // scrolls the content rightward so the previous value enters from the left.
     if (mod_name == "speed") {
         player->modifier_speed = speed_step(player->modifier_speed, -1);
         start_text_animation(1);
     } else if (mod_name == "random") {
-        // Wraps like right() does: off, backed into, comes around to ??.
         player->modifier_random = (player->modifier_random + 2) % 3;
         start_text_animation(1);
     } else {

--- a/src/objects/song_select/modifier.cpp
+++ b/src/objects/song_select/modifier.cpp
@@ -118,6 +118,21 @@ void ModifierSelector::start_text_animation(int dir) {
     }
 }
 
+// はやさ walks 0.1 to 2.0 by tenths, then jumps 3.0 and 4.0, and wraps round
+// in both directions. Stored in tenths, so 1..20, then 30 and 40.
+static int speed_step(int value, int dir) {
+    if (dir > 0) {
+        if (value >= 40) return 1;
+        if (value >= 30) return 40;
+        if (value >= 20) return 30;
+        return value + 1;
+    }
+    if (value <= 1)  return 40;
+    if (value <= 20) return value - 1;
+    if (value <= 30) return 20;
+    return 30;
+}
+
 void ModifierSelector::left() {
     if (is_confirmed) return;
     const std::string& mod_name = MOD_NAMES[current_mod_index];
@@ -125,10 +140,11 @@ void ModifierSelector::left() {
     // dir is the on-screen slide direction (see NeiroSelector): pressing left
     // scrolls the content rightward so the previous value enters from the left.
     if (mod_name == "speed") {
-        player->modifier_speed = std::max(1, player->modifier_speed - 1);
+        player->modifier_speed = speed_step(player->modifier_speed, -1);
         start_text_animation(1);
     } else if (mod_name == "random") {
-        player->modifier_random = std::max(0, player->modifier_random - 1);
+        // Wraps like right() does: off, backed into, comes around to ??.
+        player->modifier_random = (player->modifier_random + 2) % 3;
         start_text_animation(1);
     } else {
         set_bool(current_mod_index, !get_bool(current_mod_index));
@@ -141,7 +157,7 @@ void ModifierSelector::right() {
     const std::string& mod_name = MOD_NAMES[current_mod_index];
 
     if (mod_name == "speed") {
-        player->modifier_speed += 1;
+        player->modifier_speed = speed_step(player->modifier_speed, +1);
         start_text_animation(-1);
     } else if (mod_name == "random") {
         player->modifier_random = (player->modifier_random + 1) % 3;


### PR DESCRIPTION
Two directional gaps in the 1P play options:

- **Random** cycled off → ? → ?? → off going right, but pressing left from off did nothing: the value clamped at 0 instead of wrapping. Left now walks the same cycle backwards (off → ?? → ? → off).
- **Speed** clamped at both ends. It now follows the arcade steps - 0.1 up to 2.0 by tenths, then 3.0 and 4.0 - and wraps round in both directions, so backing left from 0.1 lands on 4.0 and stepping right from 4.0 lands on 0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)