### PR TITLE
Read the PS3 arcade song data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,13 @@ if(NOT ANDROID AND NOT EMSCRIPTEN)
 endif()
 target_link_libraries(${PROJECT_NAME} PRIVATE portaudio)
 
+# G.719 support is optional: without it the gen 4 arcade songs still load and
+# play, they are simply silent.
+if(YATAIDON_G719)
+  target_link_libraries(${PROJECT_NAME} PRIVATE g719)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE YATAIDON_G719)
+endif()
+
 include(cmake/platform.cmake)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -130,8 +130,16 @@ FetchContent_MakeAvailable(sol2)
 if(NOT ANDROID AND NOT EMSCRIPTEN)
   set(ZLIB_USE_STATIC_LIBS ON)
   if(WIN32)
-    set(CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE ON CACHE BOOL "" FORCE)
-    set(CPPTRACE_UNWIND_WITH_DBGHELP        ON CACHE BOOL "" FORCE)
+    # dbghelp, not addr2line: with addr2line on the PATH its location is baked
+    # into a define whose quoting does not survive this toolchain, and dbghelp
+    # resolves mingw symbols fine.
+    set(CPPTRACE_GET_SYMBOLS_WITH_ADDR2LINE OFF CACHE BOOL "" FORCE)
+    # dbghelp resolves the system DLLs' pdb symbols, libdwarf resolves our own
+    # mingw DWARF ones - without it a crash inside the game prints bare
+    # addresses for exactly the frames that matter.
+    set(CPPTRACE_GET_SYMBOLS_WITH_LIBDWARF  ON  CACHE BOOL "" FORCE)
+    set(CPPTRACE_GET_SYMBOLS_WITH_DBGHELP   ON  CACHE BOOL "" FORCE)
+    set(CPPTRACE_UNWIND_WITH_DBGHELP        ON  CACHE BOOL "" FORCE)
   endif()
   FetchContent_Declare(
       cpptrace

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -454,3 +454,40 @@ if(WIN32)
 else()
   add_library(portaudio INTERFACE IMPORTED)
 endif()
+
+# G.719 (Siren 22) -- the codec inside the .nus3bank audio of the gen 4 arcade
+# games. No decoder for it exists in FFmpeg, and the only working one is
+# kode54's library, which wraps the ITU reference sources. Those carry an
+# Ericsson/Polycom copyright, so they are fetched at build time and never
+# vendored into this tree; the repository has no CMake build of its own, so the
+# targets are declared here.
+option(YATAIDON_G719 "Build G.719 audio support for gen 4 arcade data" OFF)
+if(YATAIDON_G719)
+  FetchContent_Declare(
+    libg719
+    GIT_REPOSITORY https://github.com/kode54/libg719_decode.git
+    GIT_TAG master
+    GIT_SHALLOW TRUE
+  )
+  FetchContent_Populate(libg719)
+
+  file(GLOB G719_SOURCES
+       ${libg719_SOURCE_DIR}/g719.c
+       ${libg719_SOURCE_DIR}/reference_code/common/*.c
+       ${libg719_SOURCE_DIR}/reference_code/decoder/*.c)
+
+  add_library(g719 STATIC ${G719_SOURCES})
+  target_include_directories(g719 PUBLIC
+                             ${libg719_SOURCE_DIR}
+                             ${libg719_SOURCE_DIR}/reference_code/include)
+  set_target_properties(g719 PROPERTIES C_STANDARD 99)
+  # Its stack_alloc.h refuses to compile until one of the two temporary
+  # allocation modes is picked. VAR_ARRAYS uses C99 variable length arrays,
+  # which every compiler we target has, and unlike alloca it needs no
+  # platform header.
+  target_compile_definitions(g719 PRIVATE VAR_ARRAYS)
+  if(NOT MSVC)
+    # Reference code, not ours to tidy: keep its warnings out of our build log.
+    target_compile_options(g719 PRIVATE -w)
+  endif()
+endif()

--- a/src/libs/audio.cpp
+++ b/src/libs/audio.cpp
@@ -1,4 +1,5 @@
 #include "audio.h"
+#include "gen4_audio.h"
 #include "texture.h"
 #ifdef __ANDROID__
 extern "C" {
@@ -641,8 +642,73 @@ std::string AudioEngine::path_to_string(const fs::path& path) const {
     return path.string();
 }
 
+// A decoded buffer handed over as raw float PCM, resampled to the device rate
+// if it does not already match. Returns null on failure; frames and rate are
+// updated in place.
+static float* adopt_decoded_pcm(std::vector<float>& samples, int channels,
+                                unsigned int& frames, unsigned int& rate,
+                                double target_rate) {
+    float* data = new float[samples.size()];
+    std::memcpy(data, samples.data(), samples.size() * sizeof(float));
+
+    if ((double)rate == target_rate) return data;
+
+    double ratio = target_rate / (double)rate;
+    long out_frames = (long)(frames * ratio) + 1;
+    float* resampled = new float[(size_t)out_frames * channels];
+    SRC_DATA sd{};
+    sd.data_in = data;          sd.input_frames = frames;
+    sd.data_out = resampled;    sd.output_frames = out_frames;
+    sd.src_ratio = ratio;       sd.end_of_input = 1;
+    int err = src_simple(&sd, SRC_SINC_FASTEST, channels);
+    delete[] data;
+    if (err) {
+        delete[] resampled;
+        spdlog::error("Resampling a decoded stream failed: {}", src_strerror(err));
+        return nullptr;
+    }
+    frames = (unsigned int)sd.output_frames_gen;
+    rate   = (unsigned int)target_rate;
+    return resampled;
+}
+
 std::string AudioEngine::load_sound(const fs::path& file_path, const std::string& name) {
     try {
+        // The gen 4 arcade banks hold G.719, which neither libsndfile nor
+        // FFmpeg reads, so they are decoded here before the usual path.
+        if (file_path.extension() == ".nus3bank") {
+            gen4::DecodedAudio decoded;
+            if (!gen4::decode_nus3bank(file_path, decoded)) return "";
+
+            unsigned int frames = (unsigned int)decoded.frame_count();
+            unsigned int rate   = (unsigned int)decoded.sample_rate;
+            float* data = adopt_decoded_pcm(decoded.samples, decoded.channels,
+                                            frames, rate, target_sample_rate);
+            if (!data) return "";
+
+            sound snd;
+            snd.data            = data;
+            snd.frame_count     = frames;
+            snd.sample_rate     = rate;
+            snd.channels        = decoded.channels;
+            snd.is_playing      = false;
+            snd.current_frame   = 0;
+            snd.loop            = false;
+            snd.volume          = 1.0f;
+            snd.pan             = 0.5f;
+            snd.pitch           = 1.0f;
+            snd.frame_frac      = 0.0f;
+            snd.resampler       = nullptr;
+            snd.resample_buffer = nullptr;
+            {
+                std::unique_lock<std::shared_mutex> guard(rw_lock);
+                sounds[name] = snd;
+            }
+            spdlog::info("Loaded sound (G.719): {} ({} frames, {} Hz, {} ch)",
+                         name, frames, rate, snd.channels);
+            return name;
+        }
+
         SF_INFO file_info;
         std::memset(&file_info, 0, sizeof(SF_INFO));
 
@@ -977,6 +1043,47 @@ void AudioEngine::seek_sound(const std::string& name, float position) {
 
 std::string AudioEngine::load_music_stream(const fs::path& file_path, const std::string& name) {
     try {
+        // As in load_sound: G.719 is decoded here, and the result is kept in
+        // memory rather than streamed, since there is no file handle to read
+        // from once it has been decoded.
+        if (file_path.extension() == ".nus3bank") {
+            gen4::DecodedAudio decoded;
+            if (!gen4::decode_nus3bank(file_path, decoded)) return "";
+
+            unsigned int frames = (unsigned int)decoded.frame_count();
+            unsigned int rate   = (unsigned int)decoded.sample_rate;
+            float* data = adopt_decoded_pcm(decoded.samples, decoded.channels,
+                                            frames, rate, target_sample_rate);
+            if (!data) return "";
+
+            music mus{};
+            mus.file_handle        = nullptr;
+            mus.file_info.channels = decoded.channels;
+            mus.file_info.samplerate = (int)rate;
+            mus.file_path          = file_path.string();
+            mus.pcm_data           = data;
+            mus.pcm_total_frames   = frames;
+            mus.buffer_size        = 4096;
+            mus.stream_buffer      = new float[mus.buffer_size * decoded.channels];
+            mus.buffer_position    = 0;
+            mus.frames_in_buffer   = 0;
+            mus.is_playing         = false;
+            mus.current_frame      = 0;
+            mus.loop               = false;
+            mus.volume             = 1.0f;
+            mus.pan                = 0.5f;
+            mus.pitch              = 1.0f;
+            mus.resampler          = nullptr;
+            mus.resample_buffer    = nullptr;
+            {
+                std::unique_lock<std::shared_mutex> guard(rw_lock);
+                music_streams[name] = mus;
+            }
+            spdlog::info("Loaded music stream (G.719): {} ({} frames, {} Hz, {} ch)",
+                         name, frames, rate, decoded.channels);
+            return name;
+        }
+
         SF_INFO file_info;
         std::memset(&file_info, 0, sizeof(SF_INFO));
 

--- a/src/libs/audio.cpp
+++ b/src/libs/audio.cpp
@@ -647,7 +647,8 @@ std::string AudioEngine::path_to_string(const fs::path& path) const {
 // updated in place.
 static float* adopt_decoded_pcm(std::vector<float>& samples, int channels,
                                 unsigned int& frames, unsigned int& rate,
-                                double target_rate) {
+                                double target_rate,
+                                int converter = SRC_SINC_FASTEST) {
     float* data = new float[samples.size()];
     std::memcpy(data, samples.data(), samples.size() * sizeof(float));
 
@@ -660,7 +661,7 @@ static float* adopt_decoded_pcm(std::vector<float>& samples, int channels,
     sd.data_in = data;          sd.input_frames = frames;
     sd.data_out = resampled;    sd.output_frames = out_frames;
     sd.src_ratio = ratio;       sd.end_of_input = 1;
-    int err = src_simple(&sd, SRC_SINC_FASTEST, channels);
+    int err = src_simple(&sd, converter, channels);
     delete[] data;
     if (err) {
         delete[] resampled;
@@ -1041,47 +1042,70 @@ void AudioEngine::seek_sound(const std::string& name, float position) {
     }
 }
 
+bool AudioEngine::prepare_nus3bank_pcm(const fs::path& file_path, PreparedPCM& out,
+                                       bool quick_resample) {
+    gen4::DecodedAudio decoded;
+    if (!gen4::decode_nus3bank(file_path, decoded)) return false;
+
+    unsigned int frames = (unsigned int)decoded.frame_count();
+    unsigned int rate   = (unsigned int)decoded.sample_rate;
+    // A preview is listened to for a few seconds through wheel movement, and
+    // the sinc pass costs more than the whole G.719 decode: linear is not
+    // audibly worse there, while the song loaded for play keeps the quality.
+    float* data = adopt_decoded_pcm(decoded.samples, decoded.channels,
+                                    frames, rate, target_sample_rate,
+                                    quick_resample ? SRC_LINEAR : SRC_SINC_FASTEST);
+    if (!data) return false;
+
+    out.data.reset(data);
+    out.frames      = frames;
+    out.rate        = rate;
+    out.channels    = decoded.channels;
+    out.preview_ms  = decoded.preview_ms;
+    out.source_path = file_path.string();
+    return true;
+}
+
+std::string AudioEngine::load_music_stream_prepared(PreparedPCM&& pcm, const std::string& name) {
+    if (!pcm.data || pcm.frames == 0 || pcm.channels <= 0) return "";
+
+    music mus{};
+    mus.file_handle        = nullptr;
+    mus.file_info.channels = pcm.channels;
+    mus.file_info.samplerate = (int)pcm.rate;
+    mus.file_path          = pcm.source_path;
+    mus.pcm_data           = pcm.data.release();
+    mus.pcm_total_frames   = pcm.frames;
+    mus.buffer_size        = 4096;
+    mus.stream_buffer      = new float[mus.buffer_size * pcm.channels];
+    mus.buffer_position    = 0;
+    mus.frames_in_buffer   = 0;
+    mus.is_playing         = false;
+    mus.current_frame      = 0;
+    mus.loop               = false;
+    mus.volume             = 1.0f;
+    mus.pan                = 0.5f;
+    mus.pitch              = 1.0f;
+    mus.resampler          = nullptr;
+    mus.resample_buffer    = nullptr;
+    {
+        std::unique_lock<std::shared_mutex> guard(rw_lock);
+        music_streams[name] = mus;
+    }
+    spdlog::info("Loaded music stream (G.719): {} ({} frames, {} Hz, {} ch)",
+                 name, pcm.frames, pcm.rate, pcm.channels);
+    return name;
+}
+
 std::string AudioEngine::load_music_stream(const fs::path& file_path, const std::string& name) {
     try {
         // As in load_sound: G.719 is decoded here, and the result is kept in
         // memory rather than streamed, since there is no file handle to read
         // from once it has been decoded.
         if (file_path.extension() == ".nus3bank") {
-            gen4::DecodedAudio decoded;
-            if (!gen4::decode_nus3bank(file_path, decoded)) return "";
-
-            unsigned int frames = (unsigned int)decoded.frame_count();
-            unsigned int rate   = (unsigned int)decoded.sample_rate;
-            float* data = adopt_decoded_pcm(decoded.samples, decoded.channels,
-                                            frames, rate, target_sample_rate);
-            if (!data) return "";
-
-            music mus{};
-            mus.file_handle        = nullptr;
-            mus.file_info.channels = decoded.channels;
-            mus.file_info.samplerate = (int)rate;
-            mus.file_path          = file_path.string();
-            mus.pcm_data           = data;
-            mus.pcm_total_frames   = frames;
-            mus.buffer_size        = 4096;
-            mus.stream_buffer      = new float[mus.buffer_size * decoded.channels];
-            mus.buffer_position    = 0;
-            mus.frames_in_buffer   = 0;
-            mus.is_playing         = false;
-            mus.current_frame      = 0;
-            mus.loop               = false;
-            mus.volume             = 1.0f;
-            mus.pan                = 0.5f;
-            mus.pitch              = 1.0f;
-            mus.resampler          = nullptr;
-            mus.resample_buffer    = nullptr;
-            {
-                std::unique_lock<std::shared_mutex> guard(rw_lock);
-                music_streams[name] = mus;
-            }
-            spdlog::info("Loaded music stream (G.719): {} ({} frames, {} Hz, {} ch)",
-                         name, frames, rate, decoded.channels);
-            return name;
+            PreparedPCM pcm;
+            if (!prepare_nus3bank_pcm(file_path, pcm)) return "";
+            return load_music_stream_prepared(std::move(pcm), name);
         }
 
         SF_INFO file_info;

--- a/src/libs/audio.cpp
+++ b/src/libs/audio.cpp
@@ -1,6 +1,18 @@
 #include "audio.h"
 #include "gen4_audio.h"
+#include "green_audio.h"
 #include "texture.h"
+
+// Both arcade bank formats decode to the same shape; the extension says which
+// era the container is from.
+static bool is_bank_file(const fs::path& p) {
+    auto ext = p.extension();
+    return ext == ".nus3bank" || ext == ".nub";
+}
+static bool decode_bank(const fs::path& p, gen4::DecodedAudio& out) {
+    return p.extension() == ".nub" ? green::decode_nub(p, out)
+                                   : gen4::decode_nus3bank(p, out);
+}
 #ifdef __ANDROID__
 extern "C" {
 #include <libavformat/avformat.h>
@@ -677,9 +689,9 @@ std::string AudioEngine::load_sound(const fs::path& file_path, const std::string
     try {
         // The gen 4 arcade banks hold G.719, which neither libsndfile nor
         // FFmpeg reads, so they are decoded here before the usual path.
-        if (file_path.extension() == ".nus3bank") {
+        if (is_bank_file(file_path)) {
             gen4::DecodedAudio decoded;
-            if (!gen4::decode_nus3bank(file_path, decoded)) return "";
+            if (!decode_bank(file_path, decoded)) return "";
 
             unsigned int frames = (unsigned int)decoded.frame_count();
             unsigned int rate   = (unsigned int)decoded.sample_rate;
@@ -1045,7 +1057,7 @@ void AudioEngine::seek_sound(const std::string& name, float position) {
 bool AudioEngine::prepare_nus3bank_pcm(const fs::path& file_path, PreparedPCM& out,
                                        bool quick_resample) {
     gen4::DecodedAudio decoded;
-    if (!gen4::decode_nus3bank(file_path, decoded)) return false;
+    if (!decode_bank(file_path, decoded)) return false;
 
     unsigned int frames = (unsigned int)decoded.frame_count();
     unsigned int rate   = (unsigned int)decoded.sample_rate;
@@ -1102,7 +1114,7 @@ std::string AudioEngine::load_music_stream(const fs::path& file_path, const std:
         // As in load_sound: G.719 is decoded here, and the result is kept in
         // memory rather than streamed, since there is no file handle to read
         // from once it has been decoded.
-        if (file_path.extension() == ".nus3bank") {
+        if (is_bank_file(file_path)) {
             PreparedPCM pcm;
             if (!prepare_nus3bank_pcm(file_path, pcm)) return "";
             return load_music_stream_prepared(std::move(pcm), name);

--- a/src/libs/audio.h
+++ b/src/libs/audio.h
@@ -130,6 +130,22 @@ public:
     float get_sound_time_played(const std::string& name) const;
     void  seek_sound(const std::string& name, float position);
 
+    // The two halves of loading a .nus3bank as a music stream. Decoding and
+    // resampling one takes over a second, so the heavy half touches no engine
+    // state and can run on a worker thread; the cheap half hands the finished
+    // buffer to the engine.
+    struct PreparedPCM {
+        std::unique_ptr<float[]> data;      // interleaved, at the device rate
+        unsigned int frames     = 0;
+        unsigned int rate       = 0;
+        int          channels   = 0;
+        int          preview_ms = 0;        // the bank's own preview point
+        std::string  source_path;
+    };
+    bool prepare_nus3bank_pcm(const fs::path& file_path, PreparedPCM& out,
+                              bool quick_resample = false);
+    std::string load_music_stream_prepared(PreparedPCM&& pcm, const std::string& name);
+
     std::string load_music_stream(const fs::path& file_path, const std::string& name);
 #ifndef __EMSCRIPTEN__
     std::string load_music_stream_memory(const av::AVAudioStream& audio_stream, const std::string& name);

--- a/src/libs/filesystem.cpp
+++ b/src/libs/filesystem.cpp
@@ -96,11 +96,21 @@ std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
         if (!gen4::find_data_root(path).empty() || !green::find_data_root(path).empty())
             continue;
 
-        // First pass: extract any .osz archives
+        // First pass: extract any .osz archives. Game data roots are stepped
+        // over here just like below - there are no .osz files inside one,
+        // only tens of thousands of chart files to crawl through.
         try {
             std::vector<fs::path> osz_files;
-            for (const auto& entry : fs::recursive_directory_iterator(
-                     path, fs::directory_options::skip_permission_denied | fs::directory_options::follow_directory_symlink)) {
+            auto it = fs::recursive_directory_iterator(
+                path, fs::directory_options::skip_permission_denied | fs::directory_options::follow_directory_symlink);
+            for (; it != fs::end(it); ++it) {
+                const auto& entry = *it;
+                if (entry.is_directory() &&
+                    (gen4::find_data_root(entry.path()) == entry.path() ||
+                     green::find_data_root(entry.path()) == entry.path())) {
+                    it.disable_recursion_pending();
+                    continue;
+                }
                 if (entry.path().extension() == ".osz")
                     osz_files.push_back(entry.path());
             }

--- a/src/libs/filesystem.cpp
+++ b/src/libs/filesystem.cpp
@@ -121,8 +121,19 @@ std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
                 }
 
                 auto ext = entry.path().extension();
-                if (ext == ".tja" || ext == ".osu" || ext == ".bin")
+                if (ext == ".tja" || ext == ".osu") {
                     songs.push_back(entry.path());
+                } else if (ext == ".bin") {
+                    // Charts only ever live under a fumen folder. Everywhere
+                    // else .bin is the extension of the games' data tables,
+                    // and trying to read one as a chart is just noise.
+                    bool under_fumen = false;
+                    for (fs::path dir = entry.path().parent_path();
+                         !dir.empty() && dir != dir.parent_path(); dir = dir.parent_path()) {
+                        if (dir.filename() == "fumen") { under_fumen = true; break; }
+                    }
+                    if (under_fumen) songs.push_back(entry.path());
+                }
             }
         } catch (const std::filesystem::filesystem_error& e) {
             spdlog::error("Error scanning song directory: {}", e.what());

--- a/src/libs/filesystem.cpp
+++ b/src/libs/filesystem.cpp
@@ -1,5 +1,6 @@
 #include "filesystem.h"
 #include "miniz/miniz.h"
+#include "gen4.h"
 #include <fstream>
 #include <spdlog/spdlog.h>
 #include <unistd.h>
@@ -104,12 +105,24 @@ std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
 
         // Second pass: collect .tja and .osu files
         try {
-            for (const auto& entry : std::filesystem::recursive_directory_iterator(
-                     path, std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink)) {
-                auto ext = entry.path().extension();
-                if (ext == ".tja" || ext == ".osu" || ext == ".bin") {
-                    songs.push_back(entry.path());
+            auto it = std::filesystem::recursive_directory_iterator(
+                path, std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink);
+            for (; it != std::filesystem::end(it); ++it) {
+                const auto& entry = *it;
+
+                // A game data root is walked by the song wheel itself, which
+                // reads the game's tables. Descending into it here would mean
+                // tens of thousands of files that are chart data and tables
+                // rather than songs, and every one of them opened.
+                if (entry.is_directory() && !gen4::find_data_root(entry.path()).empty() &&
+                    gen4::find_data_root(entry.path()) == entry.path()) {
+                    it.disable_recursion_pending();
+                    continue;
                 }
+
+                auto ext = entry.path().extension();
+                if (ext == ".tja" || ext == ".osu" || ext == ".bin")
+                    songs.push_back(entry.path());
             }
         } catch (const std::filesystem::filesystem_error& e) {
             spdlog::error("Error scanning song directory: {}", e.what());

--- a/src/libs/filesystem.cpp
+++ b/src/libs/filesystem.cpp
@@ -1,6 +1,7 @@
 #include "filesystem.h"
 #include "miniz/miniz.h"
 #include "gen4.h"
+#include "green.h"
 #include <fstream>
 #include <spdlog/spdlog.h>
 #include <unistd.h>
@@ -89,6 +90,12 @@ void extract_osz(const fs::path& osz_path) {
 std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
     std::vector<fs::path> songs;
     for (const fs::path& path : root_path) {
+        // A song path pointing at - or into - a game's data root belongs to
+        // the song wheel, which reads the game's own tables. Scanning it here
+        // walks thousands of files and reads every chart as a loose one.
+        if (!gen4::find_data_root(path).empty() || !green::find_data_root(path).empty())
+            continue;
+
         // First pass: extract any .osz archives
         try {
             std::vector<fs::path> osz_files;
@@ -114,8 +121,9 @@ std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
                 // reads the game's tables. Descending into it here would mean
                 // tens of thousands of files that are chart data and tables
                 // rather than songs, and every one of them opened.
-                if (entry.is_directory() && !gen4::find_data_root(entry.path()).empty() &&
-                    gen4::find_data_root(entry.path()) == entry.path()) {
+                if (entry.is_directory() &&
+                    (gen4::find_data_root(entry.path()) == entry.path() ||
+                     green::find_data_root(entry.path()) == entry.path())) {
                     it.disable_recursion_pending();
                     continue;
                 }

--- a/src/libs/gen4.cpp
+++ b/src/libs/gen4.cpp
@@ -1,0 +1,556 @@
+#include "gen4.h"
+
+#include <spdlog/spdlog.h>
+#include <rapidjson/document.h>
+#include <cstring>
+#include <fstream>
+#include <mutex>
+
+#include "miniz/miniz.h"
+
+
+namespace gen4 {
+
+const char* DATATABLE_SEED = "WX`Eo9yQLRJ9qsqGty`RqPCqgwBjMRbr";
+const char* FUMEN_SEED     = "[ohk39bYp7FbRRd{cPhToxBeP23W9GK{";
+
+// ---------------------------------------------------------------- SHA-256
+
+namespace {
+
+const uint32_t SHA_K[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2,
+};
+
+// -------------------------------------------------------------------- MD5
+//
+// The last step of the key derivation is an MD5 of the hex text. The TJA
+// parser has its own copy for chart hashes, but that one has internal linkage,
+// so this is a second one rather than a change to its visibility.
+
+const uint32_t MD5_SHIFT[64] = {
+    7,12,17,22, 7,12,17,22, 7,12,17,22, 7,12,17,22,
+    5, 9,14,20, 5, 9,14,20, 5, 9,14,20, 5, 9,14,20,
+    4,11,16,23, 4,11,16,23, 4,11,16,23, 4,11,16,23,
+    6,10,15,21, 6,10,15,21, 6,10,15,21, 6,10,15,21 };
+
+const uint32_t MD5_K[64] = {
+    0xd76aa478,0xe8c7b756,0x242070db,0xc1bdceee,0xf57c0faf,0x4787c62a,0xa8304613,0xfd469501,
+    0x698098d8,0x8b44f7af,0xffff5bb1,0x895cd7be,0x6b901122,0xfd987193,0xa679438e,0x49b40821,
+    0xf61e2562,0xc040b340,0x265e5a51,0xe9b6c7aa,0xd62f105d,0x02441453,0xd8a1e681,0xe7d3fbc8,
+    0x21e1cde6,0xc33707d6,0xf4d50d87,0x455a14ed,0xa9e3e905,0xfcefa3f8,0x676f02d9,0x8d2a4c8a,
+    0xfffa3942,0x8771f681,0x6d9d6122,0xfde5380c,0xa4beea44,0x4bdecfa9,0xf6bb4b60,0xbebfbc70,
+    0x289b7ec6,0xeaa127fa,0xd4ef3085,0x04881d05,0xd9d4d039,0xe6db99e5,0x1fa27cf8,0xc4ac5665,
+    0xf4292244,0x432aff97,0xab9423a7,0xfc93a039,0x655b59c3,0x8f0ccc92,0xffeff47d,0x85845dd1,
+    0x6fa87e4f,0xfe2ce6e0,0xa3014314,0x4e0811a1,0xf7537e82,0xbd3af235,0x2ad7d2bb,0xeb86d391 };
+
+void md5(const uint8_t* data, size_t len, uint32_t out[4]) {
+    out[0] = 0x67452301; out[1] = 0xefcdab89;
+    out[2] = 0x98badcfe; out[3] = 0x10325476;
+
+    size_t padded = ((len + 8) / 64 + 1) * 64 - 8;
+    std::vector<uint8_t> msg(padded + 8, 0);
+    memcpy(msg.data(), data, len);
+    msg[len] = 0x80;
+    uint64_t bits = (uint64_t)len * 8;
+    for (int i = 0; i < 8; i++) msg[padded + i] = (uint8_t)(bits >> (i * 8));
+
+    for (size_t off = 0; off < msg.size(); off += 64) {
+        uint32_t w[16];
+        for (int i = 0; i < 16; i++)
+            w[i] = (uint32_t)msg[off + i * 4] | ((uint32_t)msg[off + i * 4 + 1] << 8) |
+                   ((uint32_t)msg[off + i * 4 + 2] << 16) | ((uint32_t)msg[off + i * 4 + 3] << 24);
+
+        uint32_t a = out[0], b = out[1], c = out[2], d = out[3];
+        for (int i = 0; i < 64; i++) {
+            uint32_t f, g;
+            if (i < 16)      { f = (b & c) | (~b & d);  g = i; }
+            else if (i < 32) { f = (d & b) | (~d & c);  g = (5 * i + 1) % 16; }
+            else if (i < 48) { f = b ^ c ^ d;           g = (3 * i + 5) % 16; }
+            else             { f = c ^ (b | ~d);        g = (7 * i) % 16; }
+            uint32_t tmp = d;
+            d = c;
+            c = b;
+            uint32_t x = a + f + MD5_K[i] + w[g];
+            b = b + ((x << MD5_SHIFT[i]) | (x >> (32 - MD5_SHIFT[i])));
+            a = tmp;
+        }
+        out[0] += a; out[1] += b; out[2] += c; out[3] += d;
+    }
+}
+
+inline uint32_t rotr(uint32_t x, int n) { return (x >> n) | (x << (32 - n)); }
+
+void sha256_block(uint32_t state[8], const uint8_t* p) {
+    uint32_t w[64];
+    for (int i = 0; i < 16; i++)
+        w[i] = ((uint32_t)p[i * 4] << 24) | ((uint32_t)p[i * 4 + 1] << 16) |
+               ((uint32_t)p[i * 4 + 2] << 8) | (uint32_t)p[i * 4 + 3];
+    for (int i = 16; i < 64; i++) {
+        uint32_t s0 = rotr(w[i - 15], 7) ^ rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+        uint32_t s1 = rotr(w[i - 2], 17) ^ rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+        w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+
+    uint32_t a = state[0], b = state[1], c = state[2], d = state[3];
+    uint32_t e = state[4], f = state[5], g = state[6], h = state[7];
+
+    for (int i = 0; i < 64; i++) {
+        uint32_t s1 = rotr(e, 6) ^ rotr(e, 11) ^ rotr(e, 25);
+        uint32_t ch = (e & f) ^ (~e & g);
+        uint32_t t1 = h + s1 + ch + SHA_K[i] + w[i];
+        uint32_t s0 = rotr(a, 2) ^ rotr(a, 13) ^ rotr(a, 22);
+        uint32_t maj = (a & b) ^ (a & c) ^ (b & c);
+        uint32_t t2 = s0 + maj;
+        h = g; g = f; f = e; e = d + t1;
+        d = c; c = b; b = a; a = t1 + t2;
+    }
+
+    state[0] += a; state[1] += b; state[2] += c; state[3] += d;
+    state[4] += e; state[5] += f; state[6] += g; state[7] += h;
+}
+
+std::string to_hex_upper(const std::vector<uint8_t>& bytes) {
+    static const char* digits = "0123456789ABCDEF";
+    std::string out;
+    out.reserve(bytes.size() * 2);
+    for (uint8_t b : bytes) {
+        out.push_back(digits[b >> 4]);
+        out.push_back(digits[b & 0x0F]);
+    }
+    return out;
+}
+
+// ------------------------------------------------------------------- AES
+
+const uint8_t AES_SBOX[256] = {
+    0x63,0x7c,0x77,0x7b,0xf2,0x6b,0x6f,0xc5,0x30,0x01,0x67,0x2b,0xfe,0xd7,0xab,0x76,
+    0xca,0x82,0xc9,0x7d,0xfa,0x59,0x47,0xf0,0xad,0xd4,0xa2,0xaf,0x9c,0xa4,0x72,0xc0,
+    0xb7,0xfd,0x93,0x26,0x36,0x3f,0xf7,0xcc,0x34,0xa5,0xe5,0xf1,0x71,0xd8,0x31,0x15,
+    0x04,0xc7,0x23,0xc3,0x18,0x96,0x05,0x9a,0x07,0x12,0x80,0xe2,0xeb,0x27,0xb2,0x75,
+    0x09,0x83,0x2c,0x1a,0x1b,0x6e,0x5a,0xa0,0x52,0x3b,0xd6,0xb3,0x29,0xe3,0x2f,0x84,
+    0x53,0xd1,0x00,0xed,0x20,0xfc,0xb1,0x5b,0x6a,0xcb,0xbe,0x39,0x4a,0x4c,0x58,0xcf,
+    0xd0,0xef,0xaa,0xfb,0x43,0x4d,0x33,0x85,0x45,0xf9,0x02,0x7f,0x50,0x3c,0x9f,0xa8,
+    0x51,0xa3,0x40,0x8f,0x92,0x9d,0x38,0xf5,0xbc,0xb6,0xda,0x21,0x10,0xff,0xf3,0xd2,
+    0xcd,0x0c,0x13,0xec,0x5f,0x97,0x44,0x17,0xc4,0xa7,0x7e,0x3d,0x64,0x5d,0x19,0x73,
+    0x60,0x81,0x4f,0xdc,0x22,0x2a,0x90,0x88,0x46,0xee,0xb8,0x14,0xde,0x5e,0x0b,0xdb,
+    0xe0,0x32,0x3a,0x0a,0x49,0x06,0x24,0x5c,0xc2,0xd3,0xac,0x62,0x91,0x95,0xe4,0x79,
+    0xe7,0xc8,0x37,0x6d,0x8d,0xd5,0x4e,0xa9,0x6c,0x56,0xf4,0xea,0x65,0x7a,0xae,0x08,
+    0xba,0x78,0x25,0x2e,0x1c,0xa6,0xb4,0xc6,0xe8,0xdd,0x74,0x1f,0x4b,0xbd,0x8b,0x8a,
+    0x70,0x3e,0xb5,0x66,0x48,0x03,0xf6,0x0e,0x61,0x35,0x57,0xb9,0x86,0xc1,0x1d,0x9e,
+    0xe1,0xf8,0x98,0x11,0x69,0xd9,0x8e,0x94,0x9b,0x1e,0x87,0xe9,0xce,0x55,0x28,0xdf,
+    0x8c,0xa1,0x89,0x0d,0xbf,0xe6,0x42,0x68,0x41,0x99,0x2d,0x0f,0xb0,0x54,0xbb,0x16,
+};
+
+uint8_t AES_INV_SBOX[256];
+
+void build_inv_sbox() {
+    static bool built = false;
+    if (built) return;
+    for (int i = 0; i < 256; i++) AES_INV_SBOX[AES_SBOX[i]] = (uint8_t)i;
+    built = true;
+}
+
+inline uint8_t xtime(uint8_t x) { return (uint8_t)((x << 1) ^ ((x >> 7) * 0x1B)); }
+
+uint8_t gmul(uint8_t a, uint8_t b) {
+    uint8_t p = 0;
+    for (int i = 0; i < 8; i++) {
+        if (b & 1) p ^= a;
+        a = xtime(a);
+        b >>= 1;
+    }
+    return p;
+}
+
+// AES-256: 14 rounds, 60 words of round key.
+void expand_key(const uint8_t key[32], uint8_t round_keys[240]) {
+    memcpy(round_keys, key, 32);
+    uint8_t rcon = 1;
+    for (int i = 8; i < 60; i++) {
+        uint8_t t[4];
+        memcpy(t, round_keys + (i - 1) * 4, 4);
+        if (i % 8 == 0) {
+            uint8_t tmp = t[0];
+            t[0] = (uint8_t)(AES_SBOX[t[1]] ^ rcon);
+            t[1] = AES_SBOX[t[2]];
+            t[2] = AES_SBOX[t[3]];
+            t[3] = AES_SBOX[tmp];
+            rcon = xtime(rcon);
+        } else if (i % 8 == 4) {
+            for (int j = 0; j < 4; j++) t[j] = AES_SBOX[t[j]];
+        }
+        for (int j = 0; j < 4; j++)
+            round_keys[i * 4 + j] = (uint8_t)(round_keys[(i - 8) * 4 + j] ^ t[j]);
+    }
+}
+
+void add_round_key(uint8_t s[16], const uint8_t* rk) {
+    for (int i = 0; i < 16; i++) s[i] ^= rk[i];
+}
+
+void inv_shift_rows(uint8_t s[16]) {
+    uint8_t t;
+    t = s[13]; s[13] = s[9];  s[9]  = s[5];  s[5]  = s[1];  s[1]  = t;
+    t = s[2];  s[2]  = s[10]; s[10] = t;     t     = s[6];  s[6]  = s[14]; s[14] = t;
+    t = s[3];  s[3]  = s[7];  s[7]  = s[11]; s[11] = s[15]; s[15] = t;
+}
+
+void inv_sub_bytes(uint8_t s[16]) {
+    for (int i = 0; i < 16; i++) s[i] = AES_INV_SBOX[s[i]];
+}
+
+void inv_mix_columns(uint8_t s[16]) {
+    for (int c = 0; c < 4; c++) {
+        uint8_t* p = s + c * 4;
+        uint8_t a0 = p[0], a1 = p[1], a2 = p[2], a3 = p[3];
+        p[0] = (uint8_t)(gmul(a0, 14) ^ gmul(a1, 11) ^ gmul(a2, 13) ^ gmul(a3, 9));
+        p[1] = (uint8_t)(gmul(a0, 9)  ^ gmul(a1, 14) ^ gmul(a2, 11) ^ gmul(a3, 13));
+        p[2] = (uint8_t)(gmul(a0, 13) ^ gmul(a1, 9)  ^ gmul(a2, 14) ^ gmul(a3, 11));
+        p[3] = (uint8_t)(gmul(a0, 11) ^ gmul(a1, 13) ^ gmul(a2, 9)  ^ gmul(a3, 14));
+    }
+}
+
+void decrypt_block(const uint8_t round_keys[240], uint8_t block[16]) {
+    add_round_key(block, round_keys + 14 * 16);
+    for (int round = 13; round >= 1; round--) {
+        inv_shift_rows(block);
+        inv_sub_bytes(block);
+        add_round_key(block, round_keys + round * 16);
+        inv_mix_columns(block);
+    }
+    inv_shift_rows(block);
+    inv_sub_bytes(block);
+    add_round_key(block, round_keys);
+}
+
+}  // namespace
+
+std::vector<uint8_t> sha256(const uint8_t* data, size_t len) {
+    uint32_t state[8] = { 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a,
+                          0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 };
+
+    size_t full = len / 64;
+    for (size_t i = 0; i < full; i++) sha256_block(state, data + i * 64);
+
+    uint8_t tail[128] = {};
+    size_t rest = len - full * 64;
+    memcpy(tail, data + full * 64, rest);
+    tail[rest] = 0x80;
+    size_t tail_len = (rest < 56) ? 64 : 128;
+    uint64_t bits = (uint64_t)len * 8;
+    for (int i = 0; i < 8; i++)
+        tail[tail_len - 1 - i] = (uint8_t)(bits >> (i * 8));
+    for (size_t i = 0; i < tail_len; i += 64) sha256_block(state, tail + i);
+
+    std::vector<uint8_t> out(32);
+    for (int i = 0; i < 8; i++) {
+        out[i * 4]     = (uint8_t)(state[i] >> 24);
+        out[i * 4 + 1] = (uint8_t)(state[i] >> 16);
+        out[i * 4 + 2] = (uint8_t)(state[i] >> 8);
+        out[i * 4 + 3] = (uint8_t)(state[i]);
+    }
+    return out;
+}
+
+std::vector<uint8_t> aes256_cbc_decrypt(const std::vector<uint8_t>& key,
+                                        const uint8_t* iv,
+                                        const uint8_t* data, size_t len) {
+    if (key.size() != 32 || len == 0 || len % 16 != 0) return {};
+    build_inv_sbox();
+
+    uint8_t round_keys[240];
+    expand_key(key.data(), round_keys);
+
+    std::vector<uint8_t> out(len);
+    uint8_t prev[16];
+    memcpy(prev, iv, 16);
+
+    for (size_t off = 0; off < len; off += 16) {
+        uint8_t block[16], cipher[16];
+        memcpy(cipher, data + off, 16);
+        memcpy(block, cipher, 16);
+        decrypt_block(round_keys, block);
+        for (int i = 0; i < 16; i++) out[off + i] = (uint8_t)(block[i] ^ prev[i]);
+        memcpy(prev, cipher, 16);
+    }
+
+    // PKCS#7, unpadded by hand so that a wrong key is a clear failure rather
+    // than a buffer of noise handed on to the inflater.
+    uint8_t pad = out.back();
+    if (pad == 0 || pad > 16 || pad > out.size()) {
+        spdlog::warn("gen4: bad PKCS#7 padding ({}), wrong key?", (int)pad);
+        return {};
+    }
+    for (size_t i = out.size() - pad; i < out.size(); i++) {
+        if (out[i] != pad) {
+            spdlog::warn("gen4: PKCS#7 padding not uniform, wrong key?");
+            return {};
+        }
+    }
+    out.resize(out.size() - pad);
+    return out;
+}
+
+std::vector<uint8_t> gzip_inflate(const uint8_t* data, size_t len) {
+    // Both the tables and the charts are gzip, not bare zlib, so the member
+    // header is stepped over and the deflate stream fed in raw.
+    if (len < 18 || data[0] != 0x1F || data[1] != 0x8B) {
+        spdlog::warn("gen4: not a gzip stream");
+        return {};
+    }
+
+    size_t pos = 10;
+    uint8_t flags = data[3];
+    if (flags & 0x04) {                       // FEXTRA
+        if (pos + 2 > len) return {};
+        size_t extra = (size_t)data[pos] | ((size_t)data[pos + 1] << 8);
+        pos += 2 + extra;
+    }
+    if (flags & 0x08) while (pos < len && data[pos++]) {}   // FNAME
+    if (flags & 0x10) while (pos < len && data[pos++]) {}   // FCOMMENT
+    if (flags & 0x02) pos += 2;                             // FHCRC
+    if (pos >= len) return {};
+
+    // The gzip trailer carries the uncompressed size, which saves growing the
+    // output buffer blindly.
+    uint32_t isize = (uint32_t)data[len - 4] | ((uint32_t)data[len - 3] << 8) |
+                     ((uint32_t)data[len - 2] << 16) | ((uint32_t)data[len - 1] << 24);
+
+    std::vector<uint8_t> out(isize ? isize : (len * 4));
+    mz_stream stream = {};
+    stream.next_in   = data + pos;
+    stream.avail_in  = (unsigned int)(len - pos - 8);
+    stream.next_out  = out.data();
+    stream.avail_out = (unsigned int)out.size();
+
+    if (mz_inflateInit2(&stream, -MZ_DEFAULT_WINDOW_BITS) != MZ_OK) {
+        spdlog::warn("gen4: inflate init failed");
+        return {};
+    }
+    int status = mz_inflate(&stream, MZ_FINISH);
+    mz_inflateEnd(&stream);
+    if (status != MZ_STREAM_END && status != MZ_OK) {
+        spdlog::warn("gen4: inflate failed ({})", status);
+        return {};
+    }
+    out.resize(stream.total_out);
+    return out;
+}
+
+std::vector<uint8_t> derive_key(const std::string& seed) {
+    std::vector<uint8_t> buf(seed.begin(), seed.end());
+    for (uint8_t& b : buf) b ^= 0x01;
+
+    std::string hex = to_hex_upper(sha256(buf.data(), buf.size()));
+    for (int i = 0; i < 1000; i++)
+        hex = to_hex_upper(sha256((const uint8_t*)hex.data(), hex.size()));
+
+    uint32_t digest_words[4];
+    md5((const uint8_t*)hex.data(), hex.size(), digest_words);
+
+    std::vector<uint8_t> digest(16);
+    for (int i = 0; i < 4; i++)
+        for (int j = 0; j < 4; j++)
+            digest[i * 4 + j] = (uint8_t)(digest_words[i] >> (j * 8));
+
+    std::string key_text = to_hex_upper(digest);
+    return std::vector<uint8_t>(key_text.begin(), key_text.end());
+}
+
+bool looks_encrypted(const std::vector<uint8_t>& raw) {
+    return raw.size() >= 32 && raw.size() % 16 == 0;
+}
+
+// ------------------------------------------------------------- Library
+
+namespace {
+
+// The suffix each difficulty's chart file carries, in the game's difficulty
+// order. Ura is a separate file rather than a flag on oni.
+const char* DIFF_SUFFIX[5] = { "_e", "_n", "_h", "_m", "_x" };
+
+// wordlist column -> the language codes this game uses.
+const struct { const char* field; const char* lang; } WORD_LANGS[] = {
+    { "japaneseText",  "ja"    },
+    { "englishUsText", "en"    },
+    { "chineseTText",  "zh-tw" },
+    { "koreanText",    "ko"    },
+    { "chineseSText",  "zh-cn" },
+};
+
+std::string json_string(const rapidjson::Value& v, const char* name) {
+    auto it = v.FindMember(name);
+    if (it == v.MemberEnd() || !it->value.IsString()) return "";
+    return it->value.GetString();
+}
+
+int json_int(const rapidjson::Value& v, const char* name) {
+    auto it = v.FindMember(name);
+    if (it == v.MemberEnd() || !it->value.IsInt()) return 0;
+    return it->value.GetInt();
+}
+
+bool json_bool(const rapidjson::Value& v, const char* name) {
+    auto it = v.FindMember(name);
+    if (it == v.MemberEnd() || !it->value.IsBool()) return false;
+    return it->value.GetBool();
+}
+
+}  // namespace
+
+bool Library::load(const fs::path& root) {
+    is_loaded = false;
+    entries.clear();
+    data_root = root;
+
+    std::vector<uint8_t> table_key = derive_key(DATATABLE_SEED);
+    fumen_key = derive_key(FUMEN_SEED);
+
+    std::vector<uint8_t> music = load_encrypted(root / "datatable" / "musicinfo.bin", table_key);
+    if (music.empty()) {
+        spdlog::warn("gen4: no readable musicinfo under {}", root.string());
+        return false;
+    }
+
+    rapidjson::Document doc;
+    doc.Parse(reinterpret_cast<const char*>(music.data()), music.size());
+    if (doc.HasParseError() || !doc.HasMember("items") || !doc["items"].IsArray()) {
+        spdlog::warn("gen4: musicinfo is not the expected JSON");
+        return false;
+    }
+
+    // Difficulty names as musicinfo spells them, in difficulty order.
+    static const char* STAR_FIELDS[5]   = { "starEasy", "starNormal", "starHard", "starMania", "starUra" };
+    static const char* BRANCH_FIELDS[5] = { "branchEasy", "branchNormal", "branchHard", "branchMania", "branchUra" };
+
+    for (const auto& item : doc["items"].GetArray()) {
+        if (!item.IsObject()) continue;
+        SongEntry e;
+        e.id         = json_string(item, "id");
+        if (e.id.empty()) continue;
+        e.unique_id  = json_int(item, "uniqueId");
+        e.genre_no   = json_int(item, "genreNo");
+        e.sound_file = json_string(item, "songFileName");
+        for (int d = 0; d < 5; d++) {
+            e.stars[d]  = json_int(item, STAR_FIELDS[d]);
+            e.branch[d] = json_bool(item, BRANCH_FIELDS[d]);
+        }
+        entries.push_back(std::move(e));
+    }
+
+    // Titles live in a separate table, keyed by the song id.
+    std::vector<uint8_t> words = load_encrypted(root / "datatable" / "wordlist.bin", table_key);
+    if (!words.empty()) {
+        rapidjson::Document wdoc;
+        wdoc.Parse(reinterpret_cast<const char*>(words.data()), words.size());
+        if (!wdoc.HasParseError() && wdoc.HasMember("items") && wdoc["items"].IsArray()) {
+            std::map<std::string, const rapidjson::Value*> by_key;
+            for (const auto& item : wdoc["items"].GetArray()) {
+                if (!item.IsObject()) continue;
+                std::string key = json_string(item, "key");
+                if (!key.empty()) by_key[key] = &item;
+            }
+            for (SongEntry& e : entries) {
+                auto title = by_key.find("song_" + e.id);
+                auto sub   = by_key.find("song_sub_" + e.id);
+                for (const auto& col : WORD_LANGS) {
+                    if (title != by_key.end())
+                        e.title[col.lang] = json_string(*title->second, col.field);
+                    if (sub != by_key.end())
+                        e.subtitle[col.lang] = json_string(*sub->second, col.field);
+                }
+            }
+        } else {
+            spdlog::warn("gen4: wordlist is not the expected JSON, songs will show their ids");
+        }
+    }
+
+    is_loaded = true;
+    spdlog::info("gen4: {} songs from {}", entries.size(), root.string());
+    return true;
+}
+
+const SongEntry* Library::find(const std::string& id) const {
+    for (const SongEntry& e : entries)
+        if (e.id == id) return &e;
+    return nullptr;
+}
+
+bool Library::has_difficulty(const std::string& id, int difficulty) const {
+    if (difficulty < 0 || difficulty > 4) return false;
+    std::error_code ec;
+    return fs::exists(data_root / "fumen" / id / (id + DIFF_SUFFIX[difficulty] + ".bin"), ec);
+}
+
+std::vector<uint8_t> Library::load_chart(const std::string& id, int difficulty) const {
+    if (difficulty < 0 || difficulty > 4) return {};
+    fs::path path = data_root / "fumen" / id / (id + DIFF_SUFFIX[difficulty] + ".bin");
+    std::error_code ec;
+    if (!fs::exists(path, ec)) return {};
+    return load_encrypted(path, fumen_key);
+}
+
+fs::path find_data_root(const fs::path& path) {
+    std::error_code ec;
+    for (fs::path dir = path; !dir.empty(); dir = dir.parent_path()) {
+        if (fs::exists(dir / "datatable" / "musicinfo.bin", ec) &&
+            fs::is_directory(dir / "fumen", ec))
+            return dir;
+        if (dir == dir.parent_path()) break;
+    }
+    return {};
+}
+
+const Library* library_for(const fs::path& path) {
+    fs::path root = find_data_root(path);
+    if (root.empty()) return nullptr;
+
+    // One library per root, kept for the life of the process: the tables are a
+    // couple of megabytes of JSON and every song box would otherwise re-read
+    // and re-decrypt them.
+    static std::map<std::string, Library> cache;
+    static std::mutex cache_mutex;
+
+    std::lock_guard<std::mutex> lock(cache_mutex);
+    auto it = cache.find(root.string());
+    if (it == cache.end()) {
+        Library lib;
+        lib.load(root);
+        it = cache.emplace(root.string(), std::move(lib)).first;
+    }
+    return it->second.loaded() ? &it->second : nullptr;
+}
+
+std::vector<uint8_t> load_encrypted(const fs::path& path, const std::vector<uint8_t>& key) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        spdlog::warn("gen4: cannot open {}", path.string());
+        return {};
+    }
+    std::vector<uint8_t> raw((std::istreambuf_iterator<char>(f)),
+                             std::istreambuf_iterator<char>());
+    if (!looks_encrypted(raw)) {
+        spdlog::warn("gen4: {} is not a whole number of blocks", path.string());
+        return {};
+    }
+
+    // The IV is the first block of the file, the rest is the ciphertext.
+    std::vector<uint8_t> plain =
+        aes256_cbc_decrypt(key, raw.data(), raw.data() + 16, raw.size() - 16);
+    if (plain.empty()) return {};
+
+    return gzip_inflate(plain.data(), plain.size());
+}
+
+}  // namespace gen4

--- a/src/libs/gen4.cpp
+++ b/src/libs/gen4.cpp
@@ -4,6 +4,7 @@
 #include <rapidjson/document.h>
 #include <cstring>
 #include <fstream>
+#include <algorithm>
 #include <mutex>
 
 #include "miniz/miniz.h"
@@ -476,8 +477,32 @@ bool Library::load(const fs::path& root) {
         }
     }
 
+    // The running order decides what each genre holds and in what order.
+    std::vector<uint8_t> order = load_encrypted(root / "datatable" / "music_order.bin", table_key);
+    if (!order.empty()) {
+        rapidjson::Document odoc;
+        odoc.Parse(reinterpret_cast<const char*>(order.data()), order.size());
+        if (!odoc.HasParseError() && odoc.HasMember("items") && odoc["items"].IsArray()) {
+            for (const auto& item : odoc["items"].GetArray()) {
+                if (!item.IsObject()) continue;
+                OrderEntry e;
+                e.id       = json_string(item, "id");
+                e.genre_no = json_int(item, "genreNo");
+                if (!e.id.empty()) order_entries.push_back(std::move(e));
+            }
+        }
+    }
+    if (order_entries.empty()) {
+        // No running order to go by: fall back to the genre on each song, in
+        // the order the song table lists them.
+        spdlog::warn("gen4: no music order, falling back to each song's own genre");
+        for (const SongEntry& e : entries)
+            order_entries.push_back({ e.genre_no, e.id });
+    }
+
     is_loaded = true;
-    spdlog::info("gen4: {} songs from {}", entries.size(), root.string());
+    spdlog::info("gen4: {} songs, {} listings from {}",
+                 entries.size(), order_entries.size(), root.string());
     return true;
 }
 
@@ -499,6 +524,68 @@ std::vector<uint8_t> Library::load_chart(const std::string& id, int difficulty) 
     std::error_code ec;
     if (!fs::exists(path, ec)) return {};
     return load_encrypted(path, fumen_key);
+}
+
+// Genre numbering, established by reading the titles filed under each number
+// rather than by assuming the older games' order:
+//   0 pops, 1 anime, 2 kids, 3 vocaloid, 4 game, 5 namco, 6 variety, 7 classic
+// The values on the right are GenreIndex, which orders them differently.
+int genre_index_for(int genre_no) {
+    static const int TO_GENRE_INDEX[8] = {
+        1,  // pops     -> JPOP
+        2,  // anime    -> ANIME
+        4,  // kids     -> CHILDREN
+        3,  // vocaloid -> VOCALOID
+        7,  // game     -> GAME
+        8,  // namco    -> NAMCO
+        5,  // variety  -> VARIETY
+        6,  // classic  -> CLASSICAL
+    };
+    if (genre_no < 0 || genre_no > 7) return 8;
+    return TO_GENRE_INDEX[genre_no];
+}
+
+std::string genre_name(int genre_no, const std::string& language) {
+    static const char* NAMES[8][3] = {
+        // ja                      en                  zh
+        { "ポップス",              "J-POP",            "流行" },
+        { "アニメ",                "Anime",            "動畫" },
+        { "キッズ",                "Kids",             "兒童" },
+        { "ボーカロイド",          "Vocaloid",         "VOCALOID" },
+        { "ゲームミュージック",    "Game Music",       "遊戲音樂" },
+        { "ナムコオリジナル",      "Namco Original",   "南夢宮原創" },
+        { "バラエティ",            "Variety",          "綜合" },
+        { "クラシック",            "Classical",        "古典" },
+    };
+    if (genre_no < 0 || genre_no > 7) return "";
+    int column = 0;
+    if (language.rfind("en", 0) == 0)      column = 1;
+    else if (language.rfind("zh", 0) == 0) column = 2;
+    return NAMES[genre_no][column];
+}
+
+std::vector<int> genres_present(const Library& library) {
+    std::vector<int> found;
+    for (const OrderEntry& e : library.order()) {
+        if (std::find(found.begin(), found.end(), e.genre_no) == found.end())
+            found.push_back(e.genre_no);
+    }
+    std::sort(found.begin(), found.end());
+    return found;
+}
+
+fs::path genre_path(const fs::path& data_root, int genre_no) {
+    return data_root / ("@genre_" + std::to_string(genre_no));
+}
+
+int genre_of_path(const fs::path& path) {
+    std::string name = path.filename().string();
+    if (name.rfind("@genre_", 0) != 0) return -1;
+    try {
+        return std::stoi(name.substr(7));
+    } catch (...) {
+        return -1;
+    }
 }
 
 fs::path find_data_root(const fs::path& path) {

--- a/src/libs/gen4.cpp
+++ b/src/libs/gen4.cpp
@@ -588,12 +588,28 @@ int genre_of_path(const fs::path& path) {
     }
 }
 
-fs::path find_data_root(const fs::path& path) {
+// Whether one directory is a data root, remembered: the walk below runs for
+// every directory the song scan meets, and the same ancestors come up over
+// and over, each check costing two disk lookups.
+static bool is_root_dir(const fs::path& dir) {
+    static std::mutex               mutex;
+    static std::map<fs::path, bool> cache;
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = cache.find(dir);
+        if (it != cache.end()) return it->second;
+    }
     std::error_code ec;
+    bool ok = fs::exists(dir / "datatable" / "musicinfo.bin", ec) &&
+              fs::is_directory(dir / "fumen", ec);
+    std::lock_guard<std::mutex> lock(mutex);
+    cache[dir] = ok;
+    return ok;
+}
+
+fs::path find_data_root(const fs::path& path) {
     for (fs::path dir = path; !dir.empty(); dir = dir.parent_path()) {
-        if (fs::exists(dir / "datatable" / "musicinfo.bin", ec) &&
-            fs::is_directory(dir / "fumen", ec))
-            return dir;
+        if (is_root_dir(dir)) return dir;
         if (dir == dir.parent_path()) break;
     }
     return {};

--- a/src/libs/gen4.h
+++ b/src/libs/gen4.h
@@ -1,0 +1,94 @@
+#pragma once
+
+// Reading the data of the arcade "gen 4" games (Nijiiro and its regional
+// builds). Their datatable and fumen files are AES-256-CBC encrypted and then
+// gzipped; the keys are derived from a string built into the executable, one
+// for the tables and one for the charts.
+//
+// See research notes in issue #24 for how the formats were established.
+
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace gen4 {
+
+// The seeds the game derives its two keys from.
+extern const char* DATATABLE_SEED;
+extern const char* FUMEN_SEED;
+
+// seed XOR 0x01 -> SHA256 -> uppercase hex -> (SHA256 -> uppercase hex) x1000
+// -> MD5 -> uppercase hex, and those 32 ASCII characters are the AES-256 key.
+std::vector<uint8_t> derive_key(const std::string& seed);
+
+// Decrypts and inflates one file. Returns an empty vector and logs why if the
+// file cannot be read, the padding is wrong (which means the wrong key) or the
+// gzip stream is damaged.
+std::vector<uint8_t> load_encrypted(const fs::path& path, const std::vector<uint8_t>& key);
+
+// True if the file looks like one of these containers rather than a plain one:
+// too short to hold an IV plus a block, or not a multiple of the block size,
+// and it cannot be.
+bool looks_encrypted(const std::vector<uint8_t>& raw);
+
+// One song as the game's own tables describe it. The five difficulty slots are
+// in the game's order: easy, normal, hard, oni, ura.
+struct SongEntry {
+    std::string id;                 // "10jiku", also the fumen folder name
+    int         unique_id = 0;
+    int         genre_no  = 0;
+    std::string sound_file;         // "sound/song_10jiku", no extension
+    int         stars[5]  = {};
+    bool        branch[5] = {};
+    std::map<std::string, std::string> title;     // YataiDON language code -> text
+    std::map<std::string, std::string> subtitle;
+};
+
+// The datatable of one game data root, ie. the folder holding datatable/,
+// fumen/ and sound/. Loading is all-or-nothing and happens once.
+class Library {
+public:
+    // Reads datatable/musicinfo.bin and datatable/wordlist.bin. Returns false
+    // and logs if either is missing or will not decrypt.
+    bool load(const fs::path& data_root);
+
+    bool loaded() const { return is_loaded; }
+    const fs::path& root() const { return data_root; }
+
+    const SongEntry* find(const std::string& id) const;
+    const std::vector<SongEntry>& songs() const { return entries; }
+
+    // The chart of one difficulty, decrypted and inflated, or empty if that
+    // difficulty does not exist.
+    std::vector<uint8_t> load_chart(const std::string& id, int difficulty) const;
+
+    // Which of the five difficulties this song actually ships a chart for.
+    bool has_difficulty(const std::string& id, int difficulty) const;
+
+private:
+    bool                   is_loaded = false;
+    fs::path               data_root;
+    std::vector<SongEntry> entries;
+    std::vector<uint8_t>   fumen_key;
+};
+
+// The library covering a path, loading it the first time it is asked for.
+// Returns null when the path is not inside a game data root.
+const Library* library_for(const fs::path& path);
+
+// The data root a path belongs to, or an empty path. A root is recognised by
+// holding datatable/musicinfo.bin next to a fumen/ folder.
+fs::path find_data_root(const fs::path& path);
+
+// Building blocks, exposed for tests.
+std::vector<uint8_t> sha256(const uint8_t* data, size_t len);
+std::vector<uint8_t> aes256_cbc_decrypt(const std::vector<uint8_t>& key,
+                                        const uint8_t* iv,
+                                        const uint8_t* data, size_t len);
+std::vector<uint8_t> gzip_inflate(const uint8_t* data, size_t len);
+
+}  // namespace gen4

--- a/src/libs/gen4.h
+++ b/src/libs/gen4.h
@@ -50,6 +50,14 @@ struct SongEntry {
 
 // The datatable of one game data root, ie. the folder holding datatable/,
 // fumen/ and sound/. Loading is all-or-nothing and happens once.
+// One line of the game's own running order. A song can be listed under more
+// than one genre, so this is what decides both what a genre contains and in
+// what order, rather than the single genre number on the song itself.
+struct OrderEntry {
+    int         genre_no = 0;
+    std::string id;
+};
+
 class Library {
 public:
     // Reads datatable/musicinfo.bin and datatable/wordlist.bin. Returns false
@@ -62,6 +70,10 @@ public:
     const SongEntry* find(const std::string& id) const;
     const std::vector<SongEntry>& songs() const { return entries; }
 
+    // The running order, in file order. Songs missing from it are not listed
+    // by the game and are not listed here either.
+    const std::vector<OrderEntry>& order() const { return order_entries; }
+
     // The chart of one difficulty, decrypted and inflated, or empty if that
     // difficulty does not exist.
     std::vector<uint8_t> load_chart(const std::string& id, int difficulty) const;
@@ -72,9 +84,29 @@ public:
 private:
     bool                   is_loaded = false;
     fs::path               data_root;
-    std::vector<SongEntry> entries;
-    std::vector<uint8_t>   fumen_key;
+    std::vector<SongEntry>  entries;
+    std::vector<OrderEntry> order_entries;
+    std::vector<uint8_t>    fumen_key;
 };
+
+// These games number their genres differently from the ones this project grew
+// up with, so the numbering is translated rather than used directly. Returns a
+// GenreIndex value.
+int genre_index_for(int genre_no);
+
+// The genre's own name, in the language given, falling back to Japanese.
+std::string genre_name(int genre_no, const std::string& language);
+
+// The genres that actually have songs, in the game's own order.
+std::vector<int> genres_present(const Library& library);
+
+// The path used for a genre inside a game data root. These do not exist on
+// disk: a genre is a property of a song, not a folder, and the wheel needs
+// something to hang the boxes on.
+fs::path genre_path(const fs::path& data_root, int genre_no);
+
+// The genre a path made by genre_path names, or -1.
+int genre_of_path(const fs::path& path);
 
 // The library covering a path, loading it the first time it is asked for.
 // Returns null when the path is not inside a game data root.

--- a/src/libs/gen4_audio.cpp
+++ b/src/libs/gen4_audio.cpp
@@ -1,0 +1,200 @@
+#include "gen4_audio.h"
+
+#include <spdlog/spdlog.h>
+#include <cstring>
+#include <fstream>
+
+#ifdef YATAIDON_G719
+extern "C" {
+#include <g719.h>
+}
+#endif
+
+namespace gen4 {
+
+namespace {
+
+uint32_t read_be32(const uint8_t* p) {
+    return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16) | ((uint32_t)p[2] << 8) | p[3];
+}
+uint16_t read_be16(const uint8_t* p) {
+    return (uint16_t)(((uint32_t)p[0] << 8) | p[1]);
+}
+uint32_t read_le32(const uint8_t* p) {
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+// What the BNSF stream says about itself, and where its payload starts.
+struct Bnsf {
+    int    channels      = 0;
+    int    sample_rate   = 0;
+    int    num_samples   = 0;
+    int    block_size    = 0;   // bytes per frame, all channels together
+    int    block_samples = 0;   // samples per frame per channel, 960 for G.719
+    size_t data_offset   = 0;
+    size_t data_size     = 0;
+};
+
+// Walks the outer container to the PACK chunk, then reads the first BNSF blob
+// in it. A song bank holds exactly one; effect banks hold several back to back
+// and only the first is wanted here.
+bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
+    if (file.size() < 0x18 || memcmp(file.data(), "NUS3", 4) != 0) {
+        spdlog::warn("gen4 audio: not a NUS3 container");
+        return false;
+    }
+    if (memcmp(file.data() + 8, "BANKTOC ", 8) != 0) {
+        spdlog::warn("gen4 audio: no BANKTOC where one is expected");
+        return false;
+    }
+
+    // The chunks follow the table of contents, each one named and sized, so
+    // the table itself does not have to be understood to find PACK.
+    size_t pos = 0x14 + read_le32(file.data() + 0x10);
+    size_t pack = 0, pack_size = 0;
+    while (pos + 8 <= file.size()) {
+        uint32_t size = read_le32(file.data() + pos + 4);
+        if (memcmp(file.data() + pos, "PACK", 4) == 0) {
+            pack      = pos + 8;
+            pack_size = size;
+            break;
+        }
+        pos += 8 + size;
+    }
+    if (!pack || pack + pack_size > file.size()) {
+        spdlog::warn("gen4 audio: no PACK chunk");
+        return false;
+    }
+
+    const uint8_t* p = file.data() + pack;
+    if (pack_size < 0x2C || memcmp(p, "BNSF", 4) != 0) {
+        spdlog::warn("gen4 audio: PACK does not start with a BNSF stream");
+        return false;
+    }
+    if (memcmp(p + 8, "IS22", 4) != 0) {
+        spdlog::warn("gen4 audio: codec tag is {:.4s}, only IS22 is supported",
+                     (const char*)(p + 8));
+        return false;
+    }
+    if (memcmp(p + 0x0C, "sfmt", 4) != 0) {
+        spdlog::warn("gen4 audio: no sfmt where one is expected");
+        return false;
+    }
+
+    const uint8_t* fmt = p + 0x14;
+    uint16_t flags     = read_be16(fmt);
+    out.channels       = read_be16(fmt + 2);
+    out.sample_rate    = (int)read_be32(fmt + 4);
+    out.num_samples    = (int)read_be32(fmt + 8);
+    out.block_size     = read_be16(fmt + 0x10);
+    out.block_samples  = read_be16(fmt + 0x12);
+
+    if (flags != 0) {
+        spdlog::warn("gen4 audio: stream is flagged {}, expected plain", flags);
+        return false;
+    }
+    if (out.channels < 1 || out.channels > 2 || out.block_size <= 0) {
+        spdlog::warn("gen4 audio: unsupported stream shape ({} ch, block {})",
+                     out.channels, out.block_size);
+        return false;
+    }
+
+    // sdat follows sfmt and holds the codec payload.
+    size_t sfmt_size = read_be32(p + 0x10);
+    size_t sdat = 0x0C + 4 + 4 + sfmt_size;
+    if (pack + sdat + 8 > file.size() || memcmp(p + sdat, "sdat", 4) != 0) {
+        spdlog::warn("gen4 audio: no sdat where one is expected");
+        return false;
+    }
+    out.data_size   = read_be32(p + sdat + 4);
+    out.data_offset = pack + sdat + 8;
+    if (out.data_offset + out.data_size > file.size())
+        out.data_size = file.size() - out.data_offset;
+
+    return true;
+}
+
+}  // namespace
+
+bool audio_supported() {
+#ifdef YATAIDON_G719
+    return true;
+#else
+    return false;
+#endif
+}
+
+bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
+#ifndef YATAIDON_G719
+    (void)path; (void)out;
+    spdlog::warn("gen4 audio: {} needs G.719 support, which this build does not have",
+                 path.filename().string());
+    return false;
+#else
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        spdlog::warn("gen4 audio: cannot open {}", path.string());
+        return false;
+    }
+    std::vector<uint8_t> file((std::istreambuf_iterator<char>(f)),
+                              std::istreambuf_iterator<char>());
+
+    Bnsf info;
+    if (!parse_container(file, info)) return false;
+
+    // One decoder per channel, each fed its own frames: the channels are
+    // interleaved a whole frame at a time, not sample by sample.
+    int frame_bytes = info.block_size / info.channels;
+    std::vector<g719_handle*> decoders(info.channels, nullptr);
+    for (int c = 0; c < info.channels; c++) {
+        decoders[c] = g719_init(frame_bytes);
+        if (!decoders[c]) {
+            spdlog::warn("gen4 audio: decoder would not start for {}", path.string());
+            for (g719_handle* h : decoders) if (h) g719_free(h);
+            return false;
+        }
+    }
+
+    out.channels    = info.channels;
+    out.sample_rate = info.sample_rate;
+    out.samples.clear();
+    out.samples.reserve((size_t)info.num_samples * info.channels);
+
+    const int    samples_per_frame = info.block_samples > 0 ? info.block_samples : 960;
+    const uint8_t* data = file.data() + info.data_offset;
+    size_t       pos    = 0;
+    std::vector<std::vector<int16_t>> pcm(info.channels,
+                                          std::vector<int16_t>(samples_per_frame));
+
+    while (pos + (size_t)info.block_size <= info.data_size) {
+        for (int c = 0; c < info.channels; c++) {
+            g719_decode_frame(decoders[c],
+                              (void*)(data + pos + (size_t)c * frame_bytes),
+                              pcm[c].data());
+        }
+        pos += info.block_size;
+
+        for (int s = 0; s < samples_per_frame; s++)
+            for (int c = 0; c < info.channels; c++)
+                out.samples.push_back((float)pcm[c][s] / 32768.0f);
+    }
+
+    for (g719_handle* h : decoders) g719_free(h);
+
+    // The header's sample count is the real length; the last frame is padding.
+    size_t wanted = (size_t)info.num_samples * info.channels;
+    if (info.num_samples > 0 && wanted < out.samples.size())
+        out.samples.resize(wanted);
+
+    if (out.samples.empty()) {
+        spdlog::warn("gen4 audio: {} decoded to nothing", path.filename().string());
+        return false;
+    }
+
+    spdlog::debug("gen4 audio: {} decoded, {} frames, {} Hz, {} ch",
+                  path.filename().string(), out.frame_count(), out.sample_rate, out.channels);
+    return true;
+#endif
+}
+
+}  // namespace gen4

--- a/src/libs/gen4_audio.cpp
+++ b/src/libs/gen4_audio.cpp
@@ -1,6 +1,7 @@
 #include "gen4_audio.h"
 
 #include <spdlog/spdlog.h>
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 
@@ -29,7 +30,6 @@ struct Bnsf {
     int    channels      = 0;
     int    sample_rate   = 0;
     int    num_samples   = 0;
-    int    preview_ms    = 0;   // from the TONE chunk, 0 when absent
     int    block_size    = 0;   // bytes per frame, all channels together
     int    block_samples = 0;   // samples per frame per channel, 960 for G.719
     size_t data_offset   = 0;
@@ -55,10 +55,10 @@ int find_preview_ms(const uint8_t* tone, size_t size) {
     return 0;
 }
 
-// Walks the outer container to the PACK chunk, then reads the first BNSF blob
-// in it. A song bank holds exactly one; effect banks hold several back to back
-// and only the first is wanted here.
-bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
+// Walks the outer container to the PACK chunk, picking the preview point out
+// of TONE on the way. A song bank holds exactly one stream.
+bool find_pack(const std::vector<uint8_t>& file, size_t& pack, size_t& pack_size,
+               int& preview_ms) {
     if (file.size() < 0x18 || memcmp(file.data(), "NUS3", 4) != 0) {
         spdlog::warn("gen4 audio: not a NUS3 container");
         return false;
@@ -71,11 +71,11 @@ bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
     // The chunks follow the table of contents, each one named and sized, so
     // the table itself does not have to be understood to find PACK.
     size_t pos = 0x14 + read_le32(file.data() + 0x10);
-    size_t pack = 0, pack_size = 0;
+    pack = 0; pack_size = 0;
     while (pos + 8 <= file.size()) {
         uint32_t size = read_le32(file.data() + pos + 4);
         if (memcmp(file.data() + pos, "TONE", 4) == 0 && pos + 8 + size <= file.size()) {
-            out.preview_ms = find_preview_ms(file.data() + pos + 8, size);
+            preview_ms = find_preview_ms(file.data() + pos + 8, size);
         }
         if (memcmp(file.data() + pos, "PACK", 4) == 0) {
             pack      = pos + 8;
@@ -88,7 +88,13 @@ bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
         spdlog::warn("gen4 audio: no PACK chunk");
         return false;
     }
+    return true;
+}
 
+// Reads the BNSF blob at the start of PACK (the G.719 stream of the Chinese
+// builds).
+bool parse_container(const std::vector<uint8_t>& file, size_t pack, size_t pack_size,
+                     Bnsf& out) {
     const uint8_t* p = file.data() + pack;
     if (pack_size < 0x2C || memcmp(p, "BNSF", 4) != 0) {
         spdlog::warn("gen4 audio: PACK does not start with a BNSF stream");
@@ -137,6 +143,97 @@ bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
     return true;
 }
 
+// The IDSP stream of the Japanese builds: Nintendo DSP-ADPCM, one standard
+// 0x60-byte channel header each (coefficients at +0x1C), the channels'
+// 8-byte frames interleaved block by block. Decoded here directly - it is
+// plain integer ADPCM, fourteen samples to a frame.
+struct IdspChannel {
+    int16_t coef[16] = {};
+    int16_t hist1 = 0, hist2 = 0;
+};
+
+void idsp_decode_frame(const uint8_t* frame, IdspChannel& ch, int16_t* out14) {
+    int scale = 1 << (frame[0] & 0x0F);
+    int ci    = ((frame[0] >> 4) & 0x07) * 2;
+    int c1 = ch.coef[ci], c2 = ch.coef[ci + 1];
+    for (int i = 0; i < 14; i++) {
+        int nib = frame[1 + i / 2];
+        nib = (i & 1) ? (nib & 0x0F) : (nib >> 4);
+        if (nib > 7) nib -= 16;
+        int sample = (((nib * scale) << 11) + 1024 + c1 * ch.hist1 + c2 * ch.hist2) >> 11;
+        if (sample >  32767) sample =  32767;
+        if (sample < -32768) sample = -32768;
+        ch.hist2 = ch.hist1;
+        ch.hist1 = (int16_t)sample;
+        out14[i] = ch.hist1;
+    }
+}
+
+bool decode_idsp(const std::vector<uint8_t>& file, size_t pack, size_t pack_size,
+                 DecodedAudio& out) {
+    if (pack_size < 0x40) return false;
+    const uint8_t* p = file.data() + pack;
+
+    auto be = [&](size_t off) { return read_be32(p + off); };
+    int      channels   = (int)be(0x08);
+    int      rate       = (int)be(0x0C);
+    uint32_t samples    = be(0x10);
+    uint32_t interleave = be(0x1C);
+    uint32_t hdr_off    = be(0x20);
+    uint32_t hdr_size   = be(0x24);
+    uint32_t data_off   = be(0x28);
+    uint32_t data_size  = be(0x2C);   // per channel
+
+    if (channels < 1 || channels > 2 || rate <= 0 || samples == 0 ||
+        (size_t)hdr_off + (size_t)channels * hdr_size > pack_size ||
+        (size_t)data_off + (size_t)channels * data_size > pack_size) {
+        spdlog::warn("gen4 audio: IDSP stream shape not understood");
+        return false;
+    }
+    if (interleave == 0) interleave = data_size;   // planar: one block each
+
+    std::vector<IdspChannel> chans(channels);
+    for (int c = 0; c < channels; c++) {
+        const uint8_t* h = p + hdr_off + (size_t)c * hdr_size;
+        for (int i = 0; i < 16; i++)
+            chans[c].coef[i] = (int16_t)read_be16(h + 0x1C + i * 2);
+        chans[c].hist1 = (int16_t)read_be16(h + 0x40);
+        chans[c].hist2 = (int16_t)read_be16(h + 0x42);
+    }
+
+    out.channels    = channels;
+    out.sample_rate = rate;
+    out.samples.clear();
+    out.samples.reserve((size_t)samples * channels);
+
+    // Per-channel decode buffers, filled block by block and merged.
+    const uint32_t frames_per_block  = interleave / 8;
+    const uint32_t samples_per_block = frames_per_block * 14;
+    std::vector<std::vector<int16_t>> pcm(channels,
+                                          std::vector<int16_t>(samples_per_block));
+
+    uint32_t blocks = (data_size + interleave - 1) / interleave;
+    for (uint32_t b = 0; b < blocks; b++) {
+        uint32_t block_bytes = std::min<uint32_t>(interleave, data_size - b * interleave);
+        uint32_t block_frames = block_bytes / 8;
+        for (int c = 0; c < channels; c++) {
+            const uint8_t* src = p + data_off +
+                ((size_t)b * channels + c) * interleave;
+            for (uint32_t f = 0; f < block_frames; f++)
+                idsp_decode_frame(src + f * 8, chans[c], pcm[c].data() + f * 14);
+        }
+        for (uint32_t s = 0; s < block_frames * 14; s++)
+            for (int c = 0; c < channels; c++)
+                out.samples.push_back((float)pcm[c][s] / 32768.0f);
+    }
+
+    // The header's sample count is the real length; the rest is frame padding.
+    if ((size_t)samples * channels < out.samples.size())
+        out.samples.resize((size_t)samples * channels);
+
+    return !out.samples.empty();
+}
+
 }  // namespace
 
 bool audio_supported() {
@@ -148,12 +245,6 @@ bool audio_supported() {
 }
 
 bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
-#ifndef YATAIDON_G719
-    (void)path; (void)out;
-    spdlog::warn("gen4 audio: {} needs G.719 support, which this build does not have",
-                 path.filename().string());
-    return false;
-#else
     std::ifstream f(path, std::ios::binary);
     if (!f) {
         spdlog::warn("gen4 audio: cannot open {}", path.string());
@@ -162,8 +253,29 @@ bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
     std::vector<uint8_t> file((std::istreambuf_iterator<char>(f)),
                               std::istreambuf_iterator<char>());
 
+    size_t pack = 0, pack_size = 0;
+    int    preview_ms = 0;
+    if (!find_pack(file, pack, pack_size, preview_ms)) return false;
+    out.preview_ms = preview_ms;
+
+    // The Japanese builds pack IDSP; the Chinese ones BNSF/G.719.
+    if (pack_size >= 4 && memcmp(file.data() + pack, "IDSP", 4) == 0) {
+        if (!decode_idsp(file, pack, pack_size, out)) {
+            spdlog::warn("gen4 audio: {} decoded to nothing", path.filename().string());
+            return false;
+        }
+        spdlog::debug("gen4 audio: {} decoded (IDSP), {} frames, {} Hz, {} ch",
+                      path.filename().string(), out.frame_count(), out.sample_rate, out.channels);
+        return true;
+    }
+
+#ifndef YATAIDON_G719
+    spdlog::warn("gen4 audio: {} needs G.719 support, which this build does not have",
+                 path.filename().string());
+    return false;
+#else
     Bnsf info;
-    if (!parse_container(file, info)) return false;
+    if (!parse_container(file, pack, pack_size, info)) return false;
 
     // One decoder per channel, each fed its own frames: the channels are
     // interleaved a whole frame at a time, not sample by sample.
@@ -180,7 +292,6 @@ bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
 
     out.channels    = info.channels;
     out.sample_rate = info.sample_rate;
-    out.preview_ms  = info.preview_ms;
     out.samples.clear();
     out.samples.reserve((size_t)info.num_samples * info.channels);
 

--- a/src/libs/gen4_audio.cpp
+++ b/src/libs/gen4_audio.cpp
@@ -29,11 +29,31 @@ struct Bnsf {
     int    channels      = 0;
     int    sample_rate   = 0;
     int    num_samples   = 0;
+    int    preview_ms    = 0;   // from the TONE chunk, 0 when absent
     int    block_size    = 0;   // bytes per frame, all channels together
     int    block_samples = 0;   // samples per frame per channel, 960 for G.719
     size_t data_offset   = 0;
     size_t data_size     = 0;
 };
+
+// The tone entry carries the song-select preview point in milliseconds, laid
+// out as [preview u32][-1][sample rate][channel count]. The offset moves with
+// the length of the tone's name, so the row is found by its shape rather than
+// at a fixed place. (Established against TaikoNus3bankMake's templates, which
+// write the preview at exactly this spot.)
+int find_preview_ms(const uint8_t* tone, size_t size) {
+    if (size < 16) return 0;
+    for (size_t i = 4; i + 12 <= size; i += 4) {
+        if (read_le32(tone + i) != 0xFFFFFFFFu) continue;
+        uint32_t rate = read_le32(tone + i + 4);
+        uint32_t ch   = read_le32(tone + i + 8);
+        if (rate < 8000 || rate > 192000 || ch < 1 || ch > 8) continue;
+        uint32_t preview = read_le32(tone + i - 4);
+        if (preview > 30u * 60u * 1000u) continue;   // half an hour: not a time
+        return (int)preview;
+    }
+    return 0;
+}
 
 // Walks the outer container to the PACK chunk, then reads the first BNSF blob
 // in it. A song bank holds exactly one; effect banks hold several back to back
@@ -54,6 +74,9 @@ bool parse_container(const std::vector<uint8_t>& file, Bnsf& out) {
     size_t pack = 0, pack_size = 0;
     while (pos + 8 <= file.size()) {
         uint32_t size = read_le32(file.data() + pos + 4);
+        if (memcmp(file.data() + pos, "TONE", 4) == 0 && pos + 8 + size <= file.size()) {
+            out.preview_ms = find_preview_ms(file.data() + pos + 8, size);
+        }
         if (memcmp(file.data() + pos, "PACK", 4) == 0) {
             pack      = pos + 8;
             pack_size = size;
@@ -157,6 +180,7 @@ bool decode_nus3bank(const fs::path& path, DecodedAudio& out) {
 
     out.channels    = info.channels;
     out.sample_rate = info.sample_rate;
+    out.preview_ms  = info.preview_ms;
     out.samples.clear();
     out.samples.reserve((size_t)info.num_samples * info.channels);
 

--- a/src/libs/gen4_audio.h
+++ b/src/libs/gen4_audio.h
@@ -19,6 +19,9 @@ namespace gen4 {
 struct DecodedAudio {
     int                channels    = 0;
     int                sample_rate = 0;
+    // Where the song-select preview starts, from the bank's TONE chunk, or 0
+    // when the bank does not carry one.
+    int                preview_ms  = 0;
     std::vector<float> samples;    // interleaved, -1..1
     int frame_count() const { return channels ? (int)(samples.size() / channels) : 0; }
 };

--- a/src/libs/gen4_audio.h
+++ b/src/libs/gen4_audio.h
@@ -1,0 +1,34 @@
+#pragma once
+
+// The audio of the gen 4 arcade games: .nus3bank containers holding a BNSF
+// stream tagged IS22, which is ITU-T G.719 (Siren 22) at 48 kHz.
+//
+// FFmpeg and libsndfile both have no G.719 decoder, so this is only built when
+// YATAIDON_G719 is on, which fetches one at build time. Without it the
+// functions still exist and report that the format is not supported, so
+// callers need no conditional compilation of their own.
+
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace gen4 {
+
+struct DecodedAudio {
+    int                channels    = 0;
+    int                sample_rate = 0;
+    std::vector<float> samples;    // interleaved, -1..1
+    int frame_count() const { return channels ? (int)(samples.size() / channels) : 0; }
+};
+
+// True when this build can decode .nus3bank audio at all.
+bool audio_supported();
+
+// Decodes the first audio stream of a .nus3bank. Returns false and logs why on
+// a container it cannot read, an unsupported codec tag, or a build without
+// decoder support.
+bool decode_nus3bank(const fs::path& path, DecodedAudio& out);
+
+}  // namespace gen4

--- a/src/libs/green.cpp
+++ b/src/libs/green.cpp
@@ -27,23 +27,67 @@ bool parse_config_version(const std::string& name, int& version, int& revision) 
     return true;
 }
 
-// The newest config folder that actually has a song list. Every version lists
-// the full library up to itself, so only the newest is worth reading.
+// The folder holding the newest song list. The later games keep one list per
+// game version under config/ - every version lists the full library up to
+// itself, so only the newest is worth reading - while the earlier ones keep a
+// single musicinfo.xml at the top of the data folder.
 fs::path newest_config(const fs::path& data_root) {
     fs::path best;
-    int best_ver = -1, best_rev = -1;
+    int best_ver = -1;
+    uintmax_t best_size = 0;
     std::error_code ec;
     for (const auto& entry : fs::directory_iterator(data_root / "config", ec)) {
         if (!entry.is_directory(ec)) continue;
         int ver = 0, rev = 0;
         if (!parse_config_version(entry.path().filename().string(), ver, rev)) continue;
-        if (!fs::exists(entry.path() / "musicinfo.xml", ec)) continue;
-        if (ver > best_ver || (ver == best_ver && rev > best_rev)) {
-            best_ver = ver; best_rev = rev;
+        uintmax_t size = fs::file_size(entry.path() / "musicinfo.xml", ec);
+        if (ec) { ec.clear(); continue; }
+        // The digit after the dash is a variant, not a revision - the "-1"
+        // list can be the larger one - so within the newest version the
+        // fuller song list wins.
+        if (ver > best_ver || (ver == best_ver && size > best_size)) {
+            best_ver  = ver;
+            best_size = size;
             best = entry.path();
         }
     }
+    if (best.empty() && fs::exists(data_root / "musicinfo.xml", ec))
+        best = data_root;
     return best;
+}
+
+// The game's own name, from the PARAM.SFO two levels above the data folder
+// (<game>/USRDIR/data). The file is a little-endian key table; TITLE is the
+// name the game declares for itself, version code and all.
+std::string sfo_title(const fs::path& data_root) {
+    std::ifstream f(data_root.parent_path().parent_path() / "PARAM.SFO", std::ios::binary);
+    if (!f) return "";
+    std::vector<uint8_t> d((std::istreambuf_iterator<char>(f)),
+                           std::istreambuf_iterator<char>());
+    auto le32 = [&](size_t o) -> uint32_t {
+        if (o + 4 > d.size()) return 0;
+        return (uint32_t)d[o] | ((uint32_t)d[o+1] << 8) |
+               ((uint32_t)d[o+2] << 16) | ((uint32_t)d[o+3] << 24);
+    };
+    auto le16 = [&](size_t o) -> uint16_t {
+        if (o + 2 > d.size()) return 0;
+        return (uint16_t)(d[o] | (d[o+1] << 8));
+    };
+    if (d.size() < 20 || memcmp(d.data(), "\0PSF", 4) != 0) return "";
+    uint32_t keys = le32(8), values = le32(12), count = le32(16);
+    for (uint32_t i = 0; i < count; i++) {
+        size_t e = 20 + (size_t)i * 16;
+        size_t k = keys + le16(e);
+        if (k >= d.size()) break;
+        size_t kend = k;
+        while (kend < d.size() && d[kend]) kend++;
+        if (std::string(d.begin() + k, d.begin() + kend) != "TITLE") continue;
+        size_t v = values + le32(e + 12), vmax = v + le32(e + 4);
+        size_t vend = v;
+        while (vend < d.size() && vend < vmax && d[vend]) vend++;
+        return std::string(d.begin() + v, d.begin() + vend);
+    }
+    return "";
 }
 
 // One tag's text content, from pos onward and before end. The XML is a
@@ -97,10 +141,17 @@ bool Library::load(const fs::path& root) {
 
     load_tuning(root / "fumen" / "tuning.bin");
 
+    // The game says what it is called; the folder name is the last resort.
+    name = sfo_title(root);
+    if (name.empty()) {
+        fs::path above = root.parent_path().parent_path();
+        name = above.empty() ? root.filename().string() : above.filename().string();
+    }
+
     is_loaded = !entries.empty();
     if (is_loaded)
-        spdlog::info("green: {} songs from {} ({})", entries.size(), root.string(),
-                     config.filename().string());
+        spdlog::info("green: {} songs from {} [{}] ({})", entries.size(), root.string(),
+                     name, config == root ? "musicinfo.xml" : config.filename().string());
     return is_loaded;
 }
 
@@ -153,16 +204,21 @@ void Library::load_tuning(const fs::path& path) {
             if (it == by_id.end()) continue;
             int32_t stars = be32(base + (3 + 3 * 32 + 1) * 4);
             if (stars > 0 && stars <= 10) it->second->stars[4] = (int)stars;
+            if (be32(base + (3 + 3 * 32) * 4) >= 0) it->second->has_chart[4] = true;
             continue;
         }
 
         auto it = by_id.find(id);
         if (it == by_id.end()) continue;
         // Player 1's five difficulty slots; ints 3.. are the charts, 32 ints
-        // each, and int 1 of a chart is the star rating.
+        // each. Int 0 is the chart's name offset (negative when the slot is
+        // empty) and int 1 its star rating.
+        it->second->charts_known = true;
         for (int d = 0; d < 5; d++) {
             int32_t stars = be32(base + (3 + d * 32 + 1) * 4);
             if (stars > 0 && stars <= 10) it->second->stars[d] = (int)stars;
+            if (d < 4 && be32(base + (3 + d * 32) * 4) >= 0)
+                it->second->has_chart[d] = true;
         }
     }
 }
@@ -175,10 +231,28 @@ const SongEntry* Library::find(const std::string& id) const {
 
 fs::path Library::chart_path(const std::string& id, int difficulty) const {
     if (difficulty < 0 || difficulty > 4) return {};
+
+    // Ura moved home between games: the earlier ones keep it as its own
+    // "ex_<id>" song folder with an oni-slot file, the later ones as the
+    // song's own "_x" chart. Whichever exists is the one.
+    if (difficulty == 4) {
+        fs::path x = data_root / "fumen" / id / "solo" / (id + "_x.bin");
+        std::error_code ec;
+        if (fs::exists(x, ec)) return x;
+        fs::path ex = data_root / "fumen" / ("ex_" + id) / "solo" / ("ex_" + id + "_m.bin");
+        if (fs::exists(ex, ec)) return ex;
+        return x;
+    }
+
     return data_root / "fumen" / id / "solo" / (id + DIFF_SUFFIX[difficulty] + ".bin");
 }
 
 bool Library::has_difficulty(const std::string& id, int difficulty) const {
+    if (difficulty < 0 || difficulty > 4) return false;
+    // The tables already say which charts a song ships; only a song the
+    // tuning file does not know needs the disk asked.
+    if (const SongEntry* e = find(id); e && e->charts_known)
+        return e->has_chart[difficulty];
     std::error_code ec;
     fs::path p = chart_path(id, difficulty);
     return !p.empty() && fs::exists(p, ec);
@@ -187,9 +261,9 @@ bool Library::has_difficulty(const std::string& id, int difficulty) const {
 fs::path Library::sound_path(const std::string& id) const {
     std::string upper = id;
     std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
-    fs::path p = data_root / "sound" / "bgm" / "nub" / ("SONG_" + upper + ".nub");
-    std::error_code ec;
-    return fs::exists(p, ec) ? p : fs::path();
+    // Just the name: the preview path checks existence when it matters, and
+    // checking here again would be one more disk lookup per listed song.
+    return data_root / "sound" / "bgm" / "nub" / ("SONG_" + upper + ".nub");
 }
 
 std::vector<std::string> genres_present(const Library& library) {
@@ -253,7 +327,6 @@ static bool is_root_dir(const fs::path& p) {
     }
     std::error_code ec;
     bool ok = fs::is_directory(p / "fumen", ec) &&
-              fs::is_directory(p / "config", ec) &&
               !newest_config(p).empty();
     std::lock_guard<std::mutex> lock(mutex);
     cache[p] = ok;

--- a/src/libs/green.cpp
+++ b/src/libs/green.cpp
@@ -1,0 +1,287 @@
+#include "green.h"
+#include "../objects/enums.h"
+
+#include <spdlog/spdlog.h>
+#include <algorithm>
+#include <fstream>
+#include <mutex>
+
+namespace green {
+
+namespace {
+
+// Chart file suffixes in difficulty order: easy, normal, hard, oni, ura.
+const char* DIFF_SUFFIX[5] = { "_e", "_n", "_h", "_m", "_x" };
+
+// "ST5100-1" -> {5, 1}, "S11100-1" -> {11, 1}. The digits before the fixed
+// "100" are the game version; the digit after the dash orders revisions.
+bool parse_config_version(const std::string& name, int& version, int& revision) {
+    size_t i = 0;
+    while (i < name.size() && !isdigit((unsigned char)name[i])) i++;
+    size_t hundred = name.find("100-", i);
+    if (i == 0 || hundred == std::string::npos || hundred == i) return false;
+    try {
+        version  = std::stoi(name.substr(i, hundred - i));
+        revision = std::stoi(name.substr(hundred + 4));
+    } catch (...) { return false; }
+    return true;
+}
+
+// The newest config folder that actually has a song list. Every version lists
+// the full library up to itself, so only the newest is worth reading.
+fs::path newest_config(const fs::path& data_root) {
+    fs::path best;
+    int best_ver = -1, best_rev = -1;
+    std::error_code ec;
+    for (const auto& entry : fs::directory_iterator(data_root / "config", ec)) {
+        if (!entry.is_directory(ec)) continue;
+        int ver = 0, rev = 0;
+        if (!parse_config_version(entry.path().filename().string(), ver, rev)) continue;
+        if (!fs::exists(entry.path() / "musicinfo.xml", ec)) continue;
+        if (ver > best_ver || (ver == best_ver && rev > best_rev)) {
+            best_ver = ver; best_rev = rev;
+            best = entry.path();
+        }
+    }
+    return best;
+}
+
+// One tag's text content, from pos onward and before end. The XML is a
+// machine-written boost serialization, so plain string search holds up.
+std::string tag_text(const std::string& xml, const char* tag, size_t pos, size_t end) {
+    std::string open = std::string("<") + tag + ">";
+    size_t a = xml.find(open, pos);
+    if (a == std::string::npos || a >= end) return "";
+    a += open.size();
+    size_t b = xml.find('<', a);
+    if (b == std::string::npos || b > end) return "";
+    return xml.substr(a, b - a);
+}
+
+}  // namespace
+
+bool Library::load(const fs::path& root) {
+    is_loaded = false;
+    entries.clear();
+    data_root = root;
+
+    fs::path config = newest_config(root);
+    if (config.empty()) {
+        spdlog::warn("green: no config folder with a musicinfo.xml under {}", root.string());
+        return false;
+    }
+
+    std::ifstream f(config / "musicinfo.xml", std::ios::binary);
+    if (!f) {
+        spdlog::warn("green: cannot open {}", (config / "musicinfo.xml").string());
+        return false;
+    }
+    std::string xml((std::istreambuf_iterator<char>(f)),
+                    std::istreambuf_iterator<char>());
+
+    size_t pos = 0;
+    while ((pos = xml.find("<musicid>", pos)) != std::string::npos) {
+        size_t end = xml.find("<musicid>", pos + 1);
+        if (end == std::string::npos) end = xml.size();
+
+        SongEntry e;
+        e.id     = tag_text(xml, "musicid", pos, end);
+        e.title  = tag_text(xml, "musicname", pos, end);
+        e.genre  = tag_text(xml, "genrename", pos, end);
+        e.secret = tag_text(xml, "secret", pos, end) == "1";
+        try { e.unique_id = std::stoi(tag_text(xml, "uniqueid", pos, end)); } catch (...) {}
+        if (!e.id.empty()) entries.push_back(std::move(e));
+
+        pos = end;
+    }
+
+    load_tuning(root / "fumen" / "tuning.bin");
+
+    is_loaded = !entries.empty();
+    if (is_loaded)
+        spdlog::info("green: {} songs from {} ({})", entries.size(), root.string(),
+                     config.filename().string());
+    return is_loaded;
+}
+
+// fumen/tuning.bin carries per-chart parameters, star ratings among them:
+// a big-endian count, then 2316-byte records of 579 ints - three string-pool
+// offsets (musicid first) and 2 players x 9 charts x 32 ints, where the
+// slots run easy, normal, hard, oni, ura and int 1 of a chart is its stars.
+// (Format established by TaikoGen3SongManager.)
+void Library::load_tuning(const fs::path& path) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        spdlog::warn("green: no tuning.bin, songs will show no star ratings");
+        return;
+    }
+    std::vector<uint8_t> data((std::istreambuf_iterator<char>(f)),
+                              std::istreambuf_iterator<char>());
+    auto be32 = [&](size_t off) -> int32_t {
+        if (off + 4 > data.size()) return -1;
+        return (int32_t)((data[off] << 24) | (data[off+1] << 16) |
+                         (data[off+2] << 8) | data[off+3]);
+    };
+
+    constexpr size_t RECORD_SIZE = 2316;
+    int32_t count = be32(0);
+    if (count <= 0 || 4 + (size_t)count * RECORD_SIZE > data.size()) {
+        spdlog::warn("green: tuning.bin does not look like itself, ignoring it");
+        return;
+    }
+    size_t pool = 4 + (size_t)count * RECORD_SIZE;
+
+    auto pool_string = [&](int32_t off) -> std::string {
+        if (off < 0 || pool + (size_t)off >= data.size()) return "";
+        size_t a = pool + (size_t)off, b = a;
+        while (b < data.size() && data[b] != 0) b++;
+        return std::string(data.begin() + a, data.begin() + b);
+    };
+
+    std::map<std::string, SongEntry*> by_id;
+    for (SongEntry& e : entries) by_id[e.id] = &e;
+
+    for (int32_t r = 0; r < count; r++) {
+        size_t base = 4 + (size_t)r * RECORD_SIZE;
+        std::string id = pool_string(be32(base));
+
+        // An ura chart is its own record, "ex_" + the song id, and its stars
+        // sit in that record's oni slot; the song's own record leaves the ura
+        // slot empty.
+        if (id.rfind("ex_", 0) == 0) {
+            auto it = by_id.find(id.substr(3));
+            if (it == by_id.end()) continue;
+            int32_t stars = be32(base + (3 + 3 * 32 + 1) * 4);
+            if (stars > 0 && stars <= 10) it->second->stars[4] = (int)stars;
+            continue;
+        }
+
+        auto it = by_id.find(id);
+        if (it == by_id.end()) continue;
+        // Player 1's five difficulty slots; ints 3.. are the charts, 32 ints
+        // each, and int 1 of a chart is the star rating.
+        for (int d = 0; d < 5; d++) {
+            int32_t stars = be32(base + (3 + d * 32 + 1) * 4);
+            if (stars > 0 && stars <= 10) it->second->stars[d] = (int)stars;
+        }
+    }
+}
+
+const SongEntry* Library::find(const std::string& id) const {
+    for (const SongEntry& e : entries)
+        if (e.id == id) return &e;
+    return nullptr;
+}
+
+fs::path Library::chart_path(const std::string& id, int difficulty) const {
+    if (difficulty < 0 || difficulty > 4) return {};
+    return data_root / "fumen" / id / "solo" / (id + DIFF_SUFFIX[difficulty] + ".bin");
+}
+
+bool Library::has_difficulty(const std::string& id, int difficulty) const {
+    std::error_code ec;
+    fs::path p = chart_path(id, difficulty);
+    return !p.empty() && fs::exists(p, ec);
+}
+
+fs::path Library::sound_path(const std::string& id) const {
+    std::string upper = id;
+    std::transform(upper.begin(), upper.end(), upper.begin(), ::toupper);
+    fs::path p = data_root / "sound" / "bgm" / "nub" / ("SONG_" + upper + ".nub");
+    std::error_code ec;
+    return fs::exists(p, ec) ? p : fs::path();
+}
+
+std::vector<std::string> genres_present(const Library& library) {
+    // The game's own genre order, as its song select shows them. メドレー is
+    // left out: those entries are the medley-mode assemblies, not songs.
+    static const char* ORDER[] = {
+        "J-POP", "アニメ", "ボーカロイド", "童謡", "バラエティ",
+        "クラシック", "ゲームミュージック", "ナムコオリジナル",
+    };
+    std::vector<std::string> found;
+    for (const char* genre : ORDER) {
+        for (const SongEntry& e : library.songs()) {
+            if (e.genre == genre) { found.push_back(genre); break; }
+        }
+    }
+    // Anything the fixed order does not know about still gets listed.
+    for (const SongEntry& e : library.songs()) {
+        if (e.genre == "メドレー") continue;
+        if (std::find(found.begin(), found.end(), e.genre) == found.end())
+            found.push_back(e.genre);
+    }
+    return found;
+}
+
+int genre_index_for(const std::string& genre) {
+    if (genre == "J-POP")            return (int)GenreIndex::JPOP;
+    if (genre == "アニメ")           return (int)GenreIndex::ANIME;
+    if (genre == "ボーカロイド")     return (int)GenreIndex::VOCALOID;
+    if (genre == "童謡")             return (int)GenreIndex::CHILDREN;
+    if (genre == "バラエティ")       return (int)GenreIndex::VARIETY;
+    if (genre == "メドレー")         return (int)GenreIndex::VARIETY;
+    if (genre == "クラシック")       return (int)GenreIndex::CLASSICAL;
+    if (genre == "ゲームミュージック") return (int)GenreIndex::GAME;
+    if (genre == "ナムコオリジナル") return (int)GenreIndex::NAMCO;
+    return (int)GenreIndex::DEFAULT;
+}
+
+// A genre inside a green root is spelled as a folder that does not exist:
+// <root>/@genre@<name>. The marker cannot collide with a real folder, since
+// @ never starts one in these dumps.
+fs::path genre_path(const fs::path& data_root, const std::string& genre) {
+    return data_root / ("@genre@" + genre);
+}
+
+std::string genre_of_path(const fs::path& path) {
+    std::string name = path.filename().string();
+    if (name.rfind("@genre@", 0) != 0) return "";
+    return name.substr(7);
+}
+
+// Whether one directory is a data root, remembered: the walk below runs for
+// every directory the song scan meets, and the same ancestors come up over
+// and over, each check costing real disk time.
+static bool is_root_dir(const fs::path& p) {
+    static std::mutex              mutex;
+    static std::map<fs::path, bool> cache;
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        auto it = cache.find(p);
+        if (it != cache.end()) return it->second;
+    }
+    std::error_code ec;
+    bool ok = fs::is_directory(p / "fumen", ec) &&
+              fs::is_directory(p / "config", ec) &&
+              !newest_config(p).empty();
+    std::lock_guard<std::mutex> lock(mutex);
+    cache[p] = ok;
+    return ok;
+}
+
+fs::path find_data_root(const fs::path& path) {
+    for (fs::path p = path; !p.empty() && p != p.root_path(); p = p.parent_path()) {
+        if (is_root_dir(p)) return p;
+        if (p.parent_path() == p) break;
+    }
+    return {};
+}
+
+const Library* library_for(const fs::path& path) {
+    fs::path root = find_data_root(path);
+    if (root.empty()) return nullptr;
+
+    static std::mutex           mutex;
+    static std::map<fs::path, Library> libraries;
+    std::lock_guard<std::mutex> lock(mutex);
+    auto it = libraries.find(root);
+    if (it == libraries.end()) {
+        Library lib;
+        lib.load(root);
+        it = libraries.emplace(root, std::move(lib)).first;
+    }
+    return it->second.loaded() ? &it->second : nullptr;
+}
+
+}  // namespace green

--- a/src/libs/green.h
+++ b/src/libs/green.h
@@ -1,0 +1,76 @@
+#pragma once
+
+// Reading the data of the PS3 arcade games (System 357, "Green" era). Unlike
+// the gen 4 games nothing here is encrypted: the song list is a plain XML
+// serialization, the charts are the same fumen structures written big-endian,
+// and the audio is ATRAC3+ inside .nub containers.
+
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace fs = std::filesystem;
+
+namespace green {
+
+// One song as musicinfo.xml lists it. The XML carries no star ratings; those
+// come from fumen/tuning.bin, matched up by the song id.
+struct SongEntry {
+    std::string id;          // "10jiku", also the fumen folder name
+    int         unique_id = 0;
+    std::string title;       // Japanese, the only language the file has
+    std::string genre;       // the genre's own name, e.g. "ナムコオリジナル"
+    bool        secret = false;
+    int         stars[5] = {};   // easy..ura, 0 when tuning.bin has no entry
+};
+
+// The library of one game data root, ie. the USRDIR/data folder holding
+// fumen/, sound/ and config/. The config folder holds one subfolder per game
+// version (ST5100-1 ... S11100-1) and only the newest is read: it lists every
+// song the older ones did.
+class Library {
+public:
+    bool load(const fs::path& data_root);
+
+    bool loaded() const { return is_loaded; }
+    const fs::path& root() const { return data_root; }
+
+    const SongEntry* find(const std::string& id) const;
+    const std::vector<SongEntry>& songs() const { return entries; }
+
+    // The chart of one difficulty (0..4 = easy..ura), or an empty path.
+    fs::path chart_path(const std::string& id, int difficulty) const;
+    bool has_difficulty(const std::string& id, int difficulty) const;
+
+    // The song's .nub audio bank, or an empty path when the sound is missing.
+    fs::path sound_path(const std::string& id) const;
+
+private:
+    bool                   is_loaded = false;
+    fs::path               data_root;
+    std::vector<SongEntry> entries;
+
+    void load_tuning(const fs::path& path);
+};
+
+// The genres that actually have songs, in a fixed sensible order.
+std::vector<std::string> genres_present(const Library& library);
+
+// GenreIndex value for one of the game's genre names.
+int genre_index_for(const std::string& genre);
+
+// The pseudo-path used for a genre inside a data root, and its inverse.
+fs::path    genre_path(const fs::path& data_root, const std::string& genre);
+std::string genre_of_path(const fs::path& path);
+
+// The library covering a path, loading it the first time it is asked for.
+// Returns null when the path is not inside a green data root.
+const Library* library_for(const fs::path& path);
+
+// The data root a path belongs to, or an empty path. A root is recognised by
+// holding a fumen/ folder next to config/ with at least one musicinfo.xml.
+fs::path find_data_root(const fs::path& path);
+
+}  // namespace green

--- a/src/libs/green.h
+++ b/src/libs/green.h
@@ -24,6 +24,11 @@ struct SongEntry {
     std::string genre;       // the genre's own name, e.g. "ナムコオリジナル"
     bool        secret = false;
     int         stars[5] = {};   // easy..ura, 0 when tuning.bin has no entry
+    // Which difficulties ship a chart, from tuning.bin's active slots - the
+    // wheel asks this for every song of a genre, and asking the disk instead
+    // is thousands of lookups on what may be a slow mount.
+    bool        has_chart[5] = {};
+    bool        charts_known = false;   // false when tuning.bin was absent
 };
 
 // The library of one game data root, ie. the USRDIR/data folder holding
@@ -36,6 +41,10 @@ public:
 
     bool loaded() const { return is_loaded; }
     const fs::path& root() const { return data_root; }
+
+    // What the game calls itself, from its PARAM.SFO - "Taiko no Tatsujin
+    // (ST91)" and the like - falling back to the folder name above USRDIR.
+    const std::string& game_name() const { return name; }
 
     const SongEntry* find(const std::string& id) const;
     const std::vector<SongEntry>& songs() const { return entries; }
@@ -50,6 +59,7 @@ public:
 private:
     bool                   is_loaded = false;
     fs::path               data_root;
+    std::string            name;
     std::vector<SongEntry> entries;
 
     void load_tuning(const fs::path& path);

--- a/src/libs/green_audio.cpp
+++ b/src/libs/green_audio.cpp
@@ -1,0 +1,224 @@
+#include "green_audio.h"
+
+#include <spdlog/spdlog.h>
+#include <cstring>
+#include <fstream>
+#include <vector>
+
+extern "C" {
+#include <libavformat/avformat.h>
+#include <libavcodec/avcodec.h>
+}
+
+namespace green {
+
+namespace {
+
+// The RIFF file sits whole inside the container, a little way in. The find is
+// bounded so a file that is not a nub at all fails fast.
+size_t find_riff(const std::vector<uint8_t>& file) {
+    size_t limit = std::min<size_t>(file.size(), 0x2000);
+    for (size_t i = 0; i + 4 <= limit; i += 4)
+        if (memcmp(file.data() + i, "RIFF", 4) == 0) return i;
+    return SIZE_MAX;
+}
+
+// avio read callback over the in-memory slice.
+struct MemReader {
+    const uint8_t* data;
+    size_t         size;
+    size_t         pos = 0;
+};
+
+int mem_read(void* opaque, uint8_t* buf, int buf_size) {
+    MemReader* r = static_cast<MemReader*>(opaque);
+    size_t left = r->size - r->pos;
+    size_t n = std::min<size_t>(left, (size_t)buf_size);
+    if (n == 0) return AVERROR_EOF;
+    memcpy(buf, r->data + r->pos, n);
+    r->pos += n;
+    return (int)n;
+}
+
+int64_t mem_seek(void* opaque, int64_t offset, int whence) {
+    MemReader* r = static_cast<MemReader*>(opaque);
+    if (whence == AVSEEK_SIZE) return (int64_t)r->size;
+    size_t base = whence == SEEK_CUR ? r->pos : whence == SEEK_END ? r->size : 0;
+    int64_t target = (int64_t)base + offset;
+    if (target < 0 || target > (int64_t)r->size) return AVERROR(EINVAL);
+    r->pos = (size_t)target;
+    return target;
+}
+
+// One decoded frame's samples appended as interleaved floats, whatever
+// packing the codec used.
+bool append_samples(const AVFrame* frame, int channels, std::vector<float>& out) {
+    switch (frame->format) {
+        case AV_SAMPLE_FMT_FLTP:
+            for (int s = 0; s < frame->nb_samples; s++)
+                for (int c = 0; c < channels; c++)
+                    out.push_back(reinterpret_cast<const float*>(frame->data[c])[s]);
+            return true;
+        case AV_SAMPLE_FMT_FLT: {
+            const float* p = reinterpret_cast<const float*>(frame->data[0]);
+            out.insert(out.end(), p, p + (size_t)frame->nb_samples * channels);
+            return true;
+        }
+        case AV_SAMPLE_FMT_S16P:
+            for (int s = 0; s < frame->nb_samples; s++)
+                for (int c = 0; c < channels; c++)
+                    out.push_back(reinterpret_cast<const int16_t*>(frame->data[c])[s] / 32768.0f);
+            return true;
+        case AV_SAMPLE_FMT_S16: {
+            const int16_t* p = reinterpret_cast<const int16_t*>(frame->data[0]);
+            for (int i = 0; i < frame->nb_samples * channels; i++)
+                out.push_back(p[i] / 32768.0f);
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+}  // namespace
+
+bool decode_nub(const fs::path& path, gen4::DecodedAudio& out) {
+    std::ifstream f(path, std::ios::binary);
+    if (!f) {
+        spdlog::warn("green audio: cannot open {}", path.string());
+        return false;
+    }
+    std::vector<uint8_t> file((std::istreambuf_iterator<char>(f)),
+                              std::istreambuf_iterator<char>());
+
+    size_t riff = find_riff(file);
+    if (riff == SIZE_MAX) {
+        spdlog::warn("green audio: no RIFF stream inside {}", path.filename().string());
+        return false;
+    }
+
+    // The container header carries the song-select preview point at 0xE0,
+    // big-endian milliseconds. (Verified against the same songs' gen 4 banks,
+    // whose TONE chunks name identical values.)
+    out.preview_ms = 0;
+    if (file.size() >= 0xE4) {
+        uint32_t preview = ((uint32_t)file[0xE0] << 24) | ((uint32_t)file[0xE1] << 16) |
+                           ((uint32_t)file[0xE2] << 8)  |  (uint32_t)file[0xE3];
+        if (preview <= 30u * 60u * 1000u) out.preview_ms = (int)preview;
+    }
+
+    // The RIFF's fact chunk: real sample count and the encoder's priming
+    // delay. FFmpeg hands back the delay samples as audio, which starts the
+    // whole song 50 ms late against the chart, so they are cut afterwards.
+    uint32_t fact_samples = 0, fact_delay = 0;
+    {
+        size_t pos = riff + 12;
+        while (pos + 8 < file.size()) {
+            uint32_t sz = (uint32_t)file[pos+4] | ((uint32_t)file[pos+5] << 8) |
+                          ((uint32_t)file[pos+6] << 16) | ((uint32_t)file[pos+7] << 24);
+            if (memcmp(file.data() + pos, "fact", 4) == 0 && sz >= 12 && pos + 8 + sz <= file.size()) {
+                auto le32 = [&](size_t o) {
+                    return (uint32_t)file[o] | ((uint32_t)file[o+1] << 8) |
+                           ((uint32_t)file[o+2] << 16) | ((uint32_t)file[o+3] << 24);
+                };
+                fact_samples = le32(pos + 8);
+                fact_delay   = le32(pos + 16);
+                break;
+            }
+            if (memcmp(file.data() + pos, "data", 4) == 0) break;
+            pos += 8 + sz + (sz & 1);
+        }
+    }
+
+    MemReader reader{ file.data() + riff, file.size() - riff };
+
+    // The buffer avio reads through; freed via the context below.
+    unsigned char* avio_buf = (unsigned char*)av_malloc(0x4000);
+    AVIOContext* avio = avio_alloc_context(avio_buf, 0x4000, 0, &reader,
+                                           mem_read, nullptr, mem_seek);
+    AVFormatContext* fmt = avformat_alloc_context();
+    if (!avio || !fmt) return false;
+    fmt->pb = avio;
+
+    bool ok = false;
+    AVCodecContext* codec_ctx = nullptr;
+    AVPacket* pkt = nullptr;
+    AVFrame*  frame = nullptr;
+
+    do {
+        if (avformat_open_input(&fmt, nullptr, nullptr, nullptr) < 0) {
+            spdlog::warn("green audio: FFmpeg will not open {}", path.filename().string());
+            fmt = nullptr;   // freed by the failed open
+            break;
+        }
+        if (avformat_find_stream_info(fmt, nullptr) < 0) break;
+
+        int idx = -1;
+        for (unsigned i = 0; i < fmt->nb_streams; i++)
+            if (fmt->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) { idx = (int)i; break; }
+        if (idx < 0) break;
+
+        const AVCodec* codec = avcodec_find_decoder(fmt->streams[idx]->codecpar->codec_id);
+        if (!codec) {
+            spdlog::warn("green audio: no decoder for the stream in {}", path.filename().string());
+            break;
+        }
+        codec_ctx = avcodec_alloc_context3(codec);
+        if (!codec_ctx ||
+            avcodec_parameters_to_context(codec_ctx, fmt->streams[idx]->codecpar) < 0 ||
+            avcodec_open2(codec_ctx, codec, nullptr) < 0)
+            break;
+
+        out.channels    = codec_ctx->ch_layout.nb_channels;
+        out.sample_rate = codec_ctx->sample_rate;
+        out.samples.clear();
+        if (out.channels < 1 || out.channels > 2) break;
+
+        pkt   = av_packet_alloc();
+        frame = av_frame_alloc();
+        if (!pkt || !frame) break;
+
+        bool bad_format = false;
+        while (av_read_frame(fmt, pkt) >= 0) {
+            if (pkt->stream_index == idx && avcodec_send_packet(codec_ctx, pkt) >= 0) {
+                while (avcodec_receive_frame(codec_ctx, frame) >= 0)
+                    if (!append_samples(frame, out.channels, out.samples)) { bad_format = true; break; }
+            }
+            av_packet_unref(pkt);
+            if (bad_format) break;
+        }
+        if (!bad_format) {
+            avcodec_send_packet(codec_ctx, nullptr);
+            while (avcodec_receive_frame(codec_ctx, frame) >= 0)
+                if (!append_samples(frame, out.channels, out.samples)) break;
+        }
+
+        // Cut the priming delay off the front and the padding off the end, so
+        // sample zero of the result is sample zero of the song.
+        if (fact_delay > 0 && (size_t)fact_delay * out.channels < out.samples.size())
+            out.samples.erase(out.samples.begin(),
+                              out.samples.begin() + (size_t)fact_delay * out.channels);
+        if (fact_samples > 0 && (size_t)fact_samples * out.channels < out.samples.size())
+            out.samples.resize((size_t)fact_samples * out.channels);
+
+        ok = !bad_format && !out.samples.empty();
+        if (!ok)
+            spdlog::warn("green audio: {} decoded to nothing", path.filename().string());
+    } while (false);
+
+    if (frame) av_frame_free(&frame);
+    if (pkt) av_packet_free(&pkt);
+    if (codec_ctx) avcodec_free_context(&codec_ctx);
+    if (fmt) avformat_close_input(&fmt);
+    if (avio) {
+        av_freep(&avio->buffer);
+        avio_context_free(&avio);
+    }
+
+    if (ok)
+        spdlog::debug("green audio: {} decoded, {} frames, {} Hz, {} ch",
+                      path.filename().string(), out.frame_count(), out.sample_rate, out.channels);
+    return ok;
+}
+
+}  // namespace green

--- a/src/libs/green_audio.h
+++ b/src/libs/green_audio.h
@@ -1,0 +1,16 @@
+#pragma once
+
+// The audio of the PS3 arcade games: a .nub container holding one complete
+// RIFF/WAVE ATRAC3+ file, which the bundled FFmpeg decodes. The result is
+// returned in the same shape as the gen 4 decoder's, so everything downstream
+// treats the two eras alike.
+
+#include "gen4_audio.h"
+
+namespace green {
+
+// Decodes the ATRAC3+ stream of a .nub. Returns false and logs why on a file
+// it cannot read or a stream FFmpeg will not decode.
+bool decode_nub(const fs::path& path, gen4::DecodedAudio& out);
+
+}  // namespace green

--- a/src/libs/logging.cpp
+++ b/src/libs/logging.cpp
@@ -150,6 +150,10 @@ void setup_logging(const std::string& log_level_str) {
         logger->set_level(level);
         spdlog::set_default_logger(logger);
         spdlog::flush_on(spdlog::level::critical);
+        // Without a periodic flush the file trails several seconds behind
+        // the game, which reads like a freeze wherever the log happens to
+        // stop mid-line.
+        spdlog::flush_every(std::chrono::seconds(1));
 
         std::set_terminate(handle_exception);
         std::signal(SIGINT, signal_handler);

--- a/src/libs/parsers/fumen.cpp
+++ b/src/libs/parsers/fumen.cpp
@@ -97,6 +97,55 @@ static bool is_roll(uint32_t t)    { return t == FUMEN_RENDA || t == FUMEN_BIG_R
 static bool is_balloon(uint32_t t) { return t == FUMEN_BALLOON || t == FUMEN_KUSUDAMA; }
 static bool has_renda_padding(uint32_t t) { return t == FUMEN_RENDA || t == FUMEN_BIG_RENDA; }
 
+// The PS3 games write the same structures big-endian. Nothing in the file
+// names its endianness, but the measure count can only be sane one way round.
+static uint32_t bswap32(uint32_t v) {
+    return (v >> 24) | ((v >> 8) & 0xFF00u) | ((v << 8) & 0xFF0000u) | (v << 24);
+}
+static void swap32(void* p, size_t words) {
+    uint32_t* w = static_cast<uint32_t*>(p);
+    for (size_t i = 0; i < words; i++) w[i] = bswap32(w[i]);
+}
+static void swap16(void* p) {
+    uint16_t* h = static_cast<uint16_t*>(p);
+    *h = (uint16_t)((*h >> 8) | (*h << 8));
+}
+
+static bool chart_is_big_endian(const std::vector<uint8_t>& data) {
+    if (data.size() < 520) return false;
+    uint32_t le;
+    memcpy(&le, data.data() + offsetof(FumenHeader, number_of_measures), 4);
+    uint32_t be = bswap32(le);
+    bool le_ok = le > 0 && le <= 100000;
+    bool be_ok = be > 0 && be <= 100000;
+    if (le_ok != be_ok) return be_ok;
+    // Both readable as a count: let the first judge window decide, since
+    // 25.025 ms read the wrong way round is nothing like a millisecond value.
+    float f;
+    memcpy(&f, data.data(), 4);
+    return !(f > 0.1f && f < 10000.0f);
+}
+
+static void swap_header(FumenHeader& h) {
+    swap32(&h, sizeof(FumenHeader) / 4);   // floats and u32/s32 all round-trip
+}
+static void swap_measure(FumenMeasureData& m) {
+    swap32(&m.bpm, 2);
+    swap16(&m.padding1);
+    swap32(&m.in_normal_to_advanced, 7);
+}
+static void swap_note(FumenNoteBase& n) {
+    swap32(&n.type, 3);
+    swap16(&n.initial_score_value);
+    swap16(&n.score_diff_times4);
+    // unknown2 is two halves, and the balloon hit count is the first of them
+    // in file order on both endiannesses - swapping them as one word would
+    // put the count in the other half.
+    swap16(&n.unknown2);
+    swap16(reinterpret_cast<uint16_t*>(&n.unknown2) + 1);
+    swap32(&n.length, 1);
+}
+
 FumenParser::FumenParser(const fs::path& path, int start_delay)
     : file_path(path), start_delay(static_cast<double>(start_delay)) {
     metadata = TJAMetadata();
@@ -109,6 +158,26 @@ FumenParser::FumenParser(const fs::path& path, int start_delay)
     }
 
     const gen4::SongEntry* entry = library ? library->find(song_id) : nullptr;
+    if (!entry && !song_id.empty()) {
+        // Not a gen 4 song: it may belong to one of the PS3 games instead,
+        // whose library speaks for it the same way.
+        green_library = green::library_for(file_path);
+        const green::SongEntry* ge = green_library ? green_library->find(song_id) : nullptr;
+        if (ge) {
+            // The XML is Japanese-only, so the title is the title everywhere.
+            metadata.title["ja"] = ge->title;
+            metadata.title["en"] = ge->title;
+            for (int d = 0; d < 5; d++) {
+                if (!green_library->has_difficulty(song_id, d)) continue;
+                CourseData course;
+                course.level = ge->stars[d];
+                metadata.course_data[d] = course;
+            }
+            metadata.wave = green_library->sound_path(song_id);
+            return;
+        }
+        green_library = nullptr;
+    }
     if (!entry) {
         // A bare chart file, or a folder the datatable does not list: all that
         // can be said about it is its name, and that it has one chart.
@@ -141,6 +210,14 @@ FumenParser::FumenParser(const fs::path& path, int start_delay)
 std::vector<uint8_t> FumenParser::read_chart(int diff) {
     if (library) return library->load_chart(song_id, diff);
 
+    // A PS3 chart is a plain file, big-endian, which build_notes detects.
+    if (green_library) {
+        std::ifstream f(green_library->chart_path(song_id, diff), std::ios::binary);
+        if (!f) return {};
+        return std::vector<uint8_t>((std::istreambuf_iterator<char>(f)),
+                                    std::istreambuf_iterator<char>());
+    }
+
     // A chart taken straight from the game data is encrypted; one that has
     // already been unpacked is not. Trying the key tells the two apart: a
     // plain file fails its padding check and is then used as it is.
@@ -171,9 +248,18 @@ void FumenParser::build_notes(int diff) {
         return true;
     };
 
+    // The PS3 games write the same file big-endian and nothing else differs,
+    // so the swap is decided once here and applied to everything read below.
+    bool big_endian = chart_is_big_endian(data);
+
     FumenHeader hdr{};
-    if (!take(&hdr, sizeof(FumenHeader)) ||
-        hdr.number_of_measures == 0 || hdr.number_of_measures > 100000) {
+    if (!take(&hdr, sizeof(FumenHeader))) {
+        spdlog::warn("FumenParser: no readable chart in {} difficulty {}",
+                     file_path.string(), diff);
+        return;
+    }
+    if (big_endian) swap_header(hdr);
+    if (hdr.number_of_measures == 0 || hdr.number_of_measures > 100000) {
         spdlog::warn("FumenParser: no readable chart in {} difficulty {}",
                      file_path.string(), diff);
         return;
@@ -186,6 +272,7 @@ void FumenParser::build_notes(int diff) {
     for (uint32_t m = 0; m < hdr.number_of_measures; m++) {
         FumenMeasureData mdata{};
         if (!take(&mdata, sizeof(FumenMeasureData))) break;
+        if (big_endian) swap_measure(mdata);
 
         double bpm        = static_cast<double>(mdata.bpm);
 
@@ -227,12 +314,18 @@ void FumenParser::build_notes(int diff) {
             if (!take(&note_count, sizeof(note_count)) ||
                 !take(&branch_unk, sizeof(branch_unk)) ||
                 !take(&scroll,     sizeof(scroll))) break;
+            if (big_endian) {
+                swap16(&note_count);
+                swap16(&branch_unk);
+                swap32(&scroll, 1);
+            }
 
             if (b == 0) normal_scroll = scroll;
 
             for (uint16_t n = 0; n < note_count; n++) {
                 FumenNoteBase nb{};
                 if (!take(&nb, sizeof(FumenNoteBase))) break;
+                if (big_endian) swap_note(nb);
 
                 if (has_renda_padding(nb.type)) {
                     uint32_t extra[2]{};

--- a/src/libs/parsers/fumen.cpp
+++ b/src/libs/parsers/fumen.cpp
@@ -97,26 +97,83 @@ static bool is_balloon(uint32_t t) { return t == FUMEN_BALLOON || t == FUMEN_KUS
 static bool has_renda_padding(uint32_t t) { return t == FUMEN_RENDA || t == FUMEN_BIG_RENDA; }
 
 FumenParser::FumenParser(const fs::path& path) : file_path(path) {
-    metadata             = TJAMetadata();
-    ex_data              = TJAEXData();
-    metadata.title["en"] = path.stem().string();
-    metadata.course_data[0] = CourseData{};
+    metadata = TJAMetadata();
+    ex_data  = TJAEXData();
+
+    std::error_code ec;
+    if (fs::is_directory(path, ec)) {
+        song_id = path.filename().string();
+        library = gen4::library_for(path);
+    }
+
+    const gen4::SongEntry* entry = library ? library->find(song_id) : nullptr;
+    if (!entry) {
+        // A bare chart file, or a folder the datatable does not list: all that
+        // can be said about it is its name, and that it has one chart.
+        metadata.title["en"] = path.stem().string();
+        metadata.course_data[0] = CourseData{};
+        return;
+    }
+
+    for (const auto& [lang, text] : entry->title)
+        if (!text.empty()) metadata.title[lang] = text;
+    for (const auto& [lang, text] : entry->subtitle)
+        if (!text.empty()) metadata.subtitle[lang] = text;
+    if (metadata.title.find("en") == metadata.title.end())
+        metadata.title["en"] = song_id;
+
+    // Only the difficulties that actually ship a chart, so the wheel does not
+    // offer one that cannot be played.
+    for (int d = 0; d < 5; d++) {
+        if (!library->has_difficulty(song_id, d)) continue;
+        CourseData course;
+        course.level        = entry->stars[d];
+        course.is_branching = entry->branch[d];
+        metadata.course_data[d] = course;
+    }
+
+    if (!entry->sound_file.empty())
+        metadata.wave = library->root() / (entry->sound_file + ".nus3bank");
 }
 
-void FumenParser::build_notes() {
-    if (parsed) return;
-    parsed = true;
+std::vector<uint8_t> FumenParser::read_chart(int diff) {
+    if (library) return library->load_chart(song_id, diff);
+
+    // A chart taken straight from the game data is encrypted; one that has
+    // already been unpacked is not. Trying the key tells the two apart: a
+    // plain file fails its padding check and is then used as it is.
+    static const std::vector<uint8_t> key = gen4::derive_key(gen4::FUMEN_SEED);
+    std::vector<uint8_t> plain = gen4::load_encrypted(file_path, key);
+    if (!plain.empty()) return plain;
 
     std::ifstream f(file_path, std::ios::binary);
     if (!f) {
         spdlog::warn("FumenParser: cannot open {}", file_path.string());
-        return;
+        return {};
     }
+    return std::vector<uint8_t>((std::istreambuf_iterator<char>(f)),
+                                std::istreambuf_iterator<char>());
+}
+
+void FumenParser::build_notes(int diff) {
+    if (cached_diff == diff) return;
+    cached_diff  = diff;
+    cached_notes = NoteList();
+
+    std::vector<uint8_t> data = read_chart(diff);
+    size_t pos = 0;
+    auto take = [&](void* dst, size_t n) {
+        if (pos + n > data.size()) return false;
+        memcpy(dst, data.data() + pos, n);
+        pos += n;
+        return true;
+    };
 
     FumenHeader hdr{};
-    f.read(reinterpret_cast<char*>(&hdr), sizeof(FumenHeader));
-    if (!f || hdr.number_of_measures == 0 || hdr.number_of_measures > 100000) {
-        spdlog::warn("FumenParser: invalid header in {}", file_path.string());
+    if (!take(&hdr, sizeof(FumenHeader)) ||
+        hdr.number_of_measures == 0 || hdr.number_of_measures > 100000) {
+        spdlog::warn("FumenParser: no readable chart in {} difficulty {}",
+                     file_path.string(), diff);
         return;
     }
 
@@ -126,8 +183,7 @@ void FumenParser::build_notes() {
 
     for (uint32_t m = 0; m < hdr.number_of_measures; m++) {
         FumenMeasureData mdata{};
-        f.read(reinterpret_cast<char*>(&mdata), sizeof(FumenMeasureData));
-        if (!f) break;
+        if (!take(&mdata, sizeof(FumenMeasureData))) break;
 
         double measure_ms = static_cast<double>(mdata.measure_offset);
         double bpm        = static_cast<double>(mdata.bpm);
@@ -160,21 +216,19 @@ void FumenParser::build_notes() {
             uint16_t branch_unk  = 0;
             float    scroll      = 1.0f;
 
-            f.read(reinterpret_cast<char*>(&note_count), sizeof(note_count));
-            f.read(reinterpret_cast<char*>(&branch_unk), sizeof(branch_unk));
-            f.read(reinterpret_cast<char*>(&scroll),     sizeof(scroll));
-            if (!f) break;
+            if (!take(&note_count, sizeof(note_count)) ||
+                !take(&branch_unk, sizeof(branch_unk)) ||
+                !take(&scroll,     sizeof(scroll))) break;
 
             if (b == 0) normal_scroll = scroll;
 
             for (uint16_t n = 0; n < note_count; n++) {
                 FumenNoteBase nb{};
-                f.read(reinterpret_cast<char*>(&nb), sizeof(FumenNoteBase));
-                if (!f) break;
+                if (!take(&nb, sizeof(FumenNoteBase))) break;
 
                 if (has_renda_padding(nb.type)) {
                     uint32_t extra[2]{};
-                    f.read(reinterpret_cast<char*>(extra), 8);
+                    take(extra, 8);
                 }
 
                 if (b != 0) continue;
@@ -251,13 +305,13 @@ void FumenParser::build_notes() {
 }
 
 std::tuple<NoteList, std::deque<NoteList>, std::deque<NoteList>, std::deque<NoteList>>
-FumenParser::notes_to_position(int /*diff*/) {
-    build_notes();
+FumenParser::notes_to_position(int diff) {
+    build_notes(diff);
     return {cached_notes, {}, {}, {}};
 }
 
-std::string FumenParser::get_diff_hash(int /*difficulty*/) {
-    build_notes();
+std::string FumenParser::get_diff_hash(int difficulty) {
+    build_notes(difficulty);
     if (cached_notes.notes.empty()) return "";
     std::vector<unsigned char> buffer;
     for (const Note& n : cached_notes.notes) {
@@ -269,5 +323,7 @@ std::string FumenParser::get_diff_hash(int /*difficulty*/) {
 }
 
 std::string FumenParser::get_song_hash() {
-    return get_diff_hash(0);
+    // The oni chart stands in for the song: every song has one, and it is the
+    // one difficulty that is never a cut-down arrangement of another.
+    return get_diff_hash(3);
 }

--- a/src/libs/parsers/fumen.cpp
+++ b/src/libs/parsers/fumen.cpp
@@ -1,4 +1,5 @@
 #include "fumen.h"
+#include <algorithm>
 #include <fstream>
 
 #pragma pack(push, 1)
@@ -96,7 +97,8 @@ static bool is_roll(uint32_t t)    { return t == FUMEN_RENDA || t == FUMEN_BIG_R
 static bool is_balloon(uint32_t t) { return t == FUMEN_BALLOON || t == FUMEN_KUSUDAMA; }
 static bool has_renda_padding(uint32_t t) { return t == FUMEN_RENDA || t == FUMEN_BIG_RENDA; }
 
-FumenParser::FumenParser(const fs::path& path) : file_path(path) {
+FumenParser::FumenParser(const fs::path& path, int start_delay)
+    : file_path(path), start_delay(static_cast<double>(start_delay)) {
     metadata = TJAMetadata();
     ex_data  = TJAEXData();
 
@@ -185,8 +187,14 @@ void FumenParser::build_notes(int diff) {
         FumenMeasureData mdata{};
         if (!take(&mdata, sizeof(FumenMeasureData))) break;
 
-        double measure_ms = static_cast<double>(mdata.measure_offset);
         double bpm        = static_cast<double>(mdata.bpm);
+
+        // The engine does not play a measure at the time the file gives it: it
+        // adds one whole 4/4 measure at that measure's own BPM. Chart-native
+        // times are that much too early, and since the term depends on the
+        // BPM of each measure it cannot be corrected with one fixed offset.
+        double lead_in    = bpm > 0.0 ? 60000.0 / bpm * 4.0 : 0.0;
+        double measure_ms = static_cast<double>(mdata.measure_offset) + lead_in + start_delay;
         bool   gogo       = mdata.is_gogo_time != 0;
         bool   show_bar   = mdata.is_bar_line_visible != 0;
 
@@ -233,8 +241,7 @@ void FumenParser::build_notes(int diff) {
 
                 if (b != 0) continue;
 
-                double hit_ms = static_cast<double>(mdata.measure_offset)
-                                + static_cast<double>(nb.note_offset);
+                double hit_ms = measure_ms + static_cast<double>(nb.note_offset);
                 NoteType nt = map_note_type(nb.type);
 
                 Note note;
@@ -265,7 +272,11 @@ void FumenParser::build_notes(int diff) {
                     cached_notes.notes.push_back(tail);
 
                 } else if (is_balloon(nb.type)) {
-                    note.count = 20;
+                    // The hit count is the first half of the word at offset 16,
+                    // which the simple note types use for their score value
+                    // instead. Twenty was a placeholder.
+                    int hits = (int)(uint16_t)(nb.unknown2 & 0xFFFF);
+                    note.count = hits > 0 ? hits : 20;
                     cached_notes.notes.push_back(note);
 
                     Note tail;
@@ -300,6 +311,13 @@ void FumenParser::build_notes(int diff) {
             }
         }
     }
+
+    // The added measure is worth less at a higher BPM, so a tempo change can
+    // put a later measure's note ahead of an earlier one in wall time.
+    std::stable_sort(cached_notes.notes.begin(), cached_notes.notes.end(),
+                     [](const Note& a, const Note& b) { return a.hit_ms < b.hit_ms; });
+    for (size_t i = 0; i < cached_notes.notes.size(); i++)
+        cached_notes.notes[i].index = (int)i;
 
     modifier_moji(cached_notes);
 }

--- a/src/libs/parsers/fumen.h
+++ b/src/libs/parsers/fumen.h
@@ -16,7 +16,7 @@ public:
     TJAEXData   ex_data;
 
     FumenParser() = default;
-    explicit FumenParser(const fs::path& path);
+    explicit FumenParser(const fs::path& path, int start_delay = 0);
     void get_metadata() {}
     std::string get_difficulty_name() { return ""; }
 
@@ -32,6 +32,10 @@ public:
 private:
     const gen4::Library* library = nullptr;
     std::string          song_id;
+    // The lead-in the game plays before the chart starts. TJA charts carry it
+    // in their note times, and the engine starts the music by it, so a chart
+    // without it runs a second ahead of its music.
+    double               start_delay = 0.0;
 
     int      cached_diff = -1;
     NoteList cached_notes;

--- a/src/libs/parsers/fumen.h
+++ b/src/libs/parsers/fumen.h
@@ -1,6 +1,14 @@
 #pragma once
 #include "tja.h"
+#include "../gen4.h"
 
+// The chart format of the gen 4 arcade games. A song is a folder of up to five
+// chart files, one per difficulty, and everything else about it -- title, star
+// ratings, which difficulties exist -- comes from the game's datatable rather
+// than from the charts themselves.
+//
+// A path to a single chart file also works, for looking at one chart on its
+// own; there is no metadata to be had that way.
 class FumenParser {
 public:
     fs::path   file_path;
@@ -18,9 +26,16 @@ public:
     std::string get_song_hash();
     std::string get_diff_hash(int difficulty);
 
+    // True when the path was a song folder that the datatable knows about.
+    bool is_library_song() const { return library != nullptr; }
+
 private:
-    bool     parsed = false;
+    const gen4::Library* library = nullptr;
+    std::string          song_id;
+
+    int      cached_diff = -1;
     NoteList cached_notes;
 
-    void build_notes();
+    void build_notes(int diff);
+    std::vector<uint8_t> read_chart(int diff);
 };

--- a/src/libs/parsers/fumen.h
+++ b/src/libs/parsers/fumen.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "tja.h"
 #include "../gen4.h"
+#include "../green.h"
 
 // The chart format of the gen 4 arcade games. A song is a folder of up to five
 // chart files, one per difficulty, and everything else about it -- title, star
@@ -26,11 +27,12 @@ public:
     std::string get_song_hash();
     std::string get_diff_hash(int difficulty);
 
-    // True when the path was a song folder that the datatable knows about.
-    bool is_library_song() const { return library != nullptr; }
+    // True when the path was a song folder that a game's tables know about.
+    bool is_library_song() const { return library != nullptr || green_library != nullptr; }
 
 private:
-    const gen4::Library* library = nullptr;
+    const gen4::Library*  library       = nullptr;
+    const green::Library* green_library = nullptr;
     std::string          song_id;
     // The lead-in the game plays before the chart starts. TJA charts carry it
     // in their note times, and the engine starts the music by it, so a chart

--- a/src/libs/scores.cpp
+++ b/src/libs/scores.cpp
@@ -123,6 +123,7 @@ ScoresManager::ScoresManager(const fs::path& db_path) {
 }
 
 void ScoresManager::load_score_cache() {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     score_cache.clear();
 
     sqlite3_stmt* stmt;
@@ -337,6 +338,7 @@ void ScoresManager::export_to_hiroba(const std::string& access_code, int player_
 }
 
 std::optional<Score> ScoresManager::get_score(std::string& hash, int difficulty, int player_id) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     auto it = score_cache.find(std::make_tuple(hash, difficulty, player_id));
     if (it != score_cache.end()) return it->second;
     return std::nullopt;
@@ -372,6 +374,7 @@ Score ScoresManager::save_score(std::string& hash, int difficulty, int player_id
     spdlog::info("Saved score for hash: {} score: {} crown: {}", hash, score.score, (int)score.crown);
 
     auto key = std::make_tuple(hash, difficulty, player_id);
+    std::lock_guard<std::mutex> lock(maps_mutex);
     auto it = score_cache.find(key);
     bool is_better = it == score_cache.end() ||
         score.crown > it->second.crown ||
@@ -382,6 +385,7 @@ Score ScoresManager::save_score(std::string& hash, int difficulty, int player_id
 }
 
 void ScoresManager::add_path_binding(const fs::path& path, const std::array<std::string, 5>& hashes) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     path_to_hashes[path] = hashes;
     std::string single = std::accumulate(hashes.begin(), hashes.end(), std::string{});
     single_hash_to_path[single] = path;
@@ -391,23 +395,30 @@ void ScoresManager::add_path_binding(const fs::path& path, const std::array<std:
 }
 
 std::optional<fs::path> ScoresManager::get_path_by_hash(const std::string& single_hash) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     auto it = single_hash_to_path.find(single_hash);
     if (it != single_hash_to_path.end()) return it->second;
     return std::nullopt;
 }
 
 std::optional<fs::path> ScoresManager::get_path_by_diff_hash(const std::string& diff_hash) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
     auto it = diff_hash_to_path.find(diff_hash);
     if (it != diff_hash_to_path.end()) return it->second;
     return std::nullopt;
 }
 
-std::array<std::string, 5>& ScoresManager::get_hashes(const fs::path& path) {
-    return path_to_hashes[path];
+std::array<std::string, 5> ScoresManager::get_hashes(const fs::path& path) {
+    std::lock_guard<std::mutex> lock(maps_mutex);
+    auto it = path_to_hashes.find(path);
+    return it != path_to_hashes.end() ? it->second : std::array<std::string, 5>{};
 }
 
 std::string ScoresManager::get_single_hash(const fs::path& path) {
-    return std::accumulate(path_to_hashes[path].begin(), path_to_hashes[path].end(), std::string{});
+    std::lock_guard<std::mutex> lock(maps_mutex);
+    auto it = path_to_hashes.find(path);
+    if (it == path_to_hashes.end()) return "";
+    return std::accumulate(it->second.begin(), it->second.end(), std::string{});
 }
 
 void ScoresManager::add_song(const std::array<std::string, 5>& hashes, const std::string& title, const std::string& subtitle) {

--- a/src/libs/scores.h
+++ b/src/libs/scores.h
@@ -2,6 +2,7 @@
 
 #include "global_data.h"
 #include <sqlite3.h>
+#include <mutex>
 
 struct PlayerData {
     int player_id;
@@ -43,6 +44,10 @@ struct Score {
 class ScoresManager {
 private:
     sqlite3* db_fsd;
+    // Guards the four lookup maps below: read by the loader thread for every
+    // box, written by the main thread when a hash is computed or a score
+    // saved.
+    mutable std::mutex maps_mutex;
     std::unordered_map<fs::path, std::array<std::string, 5>> path_to_hashes;
     std::unordered_map<std::string, fs::path> single_hash_to_path;
     std::unordered_map<std::string, fs::path> diff_hash_to_path;
@@ -59,7 +64,11 @@ public:
     std::optional<Score> get_score(std::string& hash, int difficulty, int player_id);
     Score save_score(std::string& hash, int difficulty, int player_id, Score score);
     void add_path_binding(const fs::path& path, const std::array<std::string, 5>& hashes);
-    std::array<std::string, 5>& get_hashes(const fs::path& path);
+    // By value on purpose: the maps below are written from the song select
+    // (recording a freshly computed hash) while the loader thread reads them
+    // for every box it builds, and a reference into an unordered_map does not
+    // survive the rehash an insert can cause.
+    std::array<std::string, 5> get_hashes(const fs::path& path);
     std::string get_single_hash(const fs::path& path);
     std::optional<fs::path> get_path_by_hash(const std::string& single_hash);
     std::optional<fs::path> get_path_by_diff_hash(const std::string& diff_hash);

--- a/src/libs/song_parser.cpp
+++ b/src/libs/song_parser.cpp
@@ -1,7 +1,12 @@
 #include "song_parser.h"
+#include <system_error>
 
 SongParser::SongParser(const fs::path& path, int start_delay, PlayerNum player_num) {
-    if (path.extension() == ".osu")
+    // A gen 4 song is a folder of chart files rather than a single file.
+    std::error_code dir_ec;
+    if (fs::is_directory(path, dir_ec))
+        impl = FumenParser(path);
+    else if (path.extension() == ".osu")
         impl = OsuParser(path);
     else if (path.extension() == ".bin")
         impl = FumenParser(path);

--- a/src/libs/song_parser.cpp
+++ b/src/libs/song_parser.cpp
@@ -5,11 +5,11 @@ SongParser::SongParser(const fs::path& path, int start_delay, PlayerNum player_n
     // A gen 4 song is a folder of chart files rather than a single file.
     std::error_code dir_ec;
     if (fs::is_directory(path, dir_ec))
-        impl = FumenParser(path);
+        impl = FumenParser(path, start_delay);
     else if (path.extension() == ".osu")
         impl = OsuParser(path);
     else if (path.extension() == ".bin")
-        impl = FumenParser(path);
+        impl = FumenParser(path, start_delay);
     else
         impl = TJAParser(path, start_delay, player_num);
     sync();

--- a/src/objects/song_select/file_navigator/box_folder.cpp
+++ b/src/objects/song_select/file_navigator/box_folder.cpp
@@ -1,5 +1,7 @@
 #include "box_folder.h"
 #include "../../../libs/gen4.h"
+#include "../../../libs/green.h"
+#include "../../../libs/green.h"
 #include "../../../libs/filesystem.h"
 #include "../../../libs/scores.h"
 #include "../../../libs/audio.h"
@@ -75,6 +77,22 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
         int genre_no = gen4::genre_of_path(path);
         for (const gen4::OrderEntry& listing : library->order())
             if (genre_no < 0 || listing.genre_no == genre_no) tja_count++;
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        scan_cache[path] = {crown, tja_count};
+        return;
+    }
+    if (const green::Library* library = green::library_for(path)) {
+        std::string genre = green::genre_of_path(path);
+        for (const green::SongEntry& e : library->songs())
+            if (genre.empty() || e.genre == genre) tja_count++;
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        scan_cache[path] = {crown, tja_count};
+        return;
+    }
+    if (const green::Library* library = green::library_for(path)) {
+        std::string genre = green::genre_of_path(path);
+        for (const green::SongEntry& e : library->songs())
+            if (genre.empty() || e.genre == genre) tja_count++;
         std::lock_guard<std::mutex> lock(scan_cache_mutex);
         scan_cache[path] = {crown, tja_count};
         return;

--- a/src/objects/song_select/file_navigator/box_folder.cpp
+++ b/src/objects/song_select/file_navigator/box_folder.cpp
@@ -1,4 +1,5 @@
 #include "box_folder.h"
+#include "../../../libs/gen4.h"
 #include "../../../libs/filesystem.h"
 #include "../../../libs/scores.h"
 #include "../../../libs/audio.h"
@@ -68,13 +69,32 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
         }
     };
 
-    for (const auto& entry : fs::recursive_directory_iterator(path)) {
+    // A game data root holds thousands of files that are not songs, and its
+    // song count is known without looking at the disk at all.
+    if (const gen4::Library* library = gen4::library_for(path)) {
+        int genre_no = gen4::genre_of_path(path);
+        for (const gen4::OrderEntry& listing : library->order())
+            if (genre_no < 0 || listing.genre_no == genre_no) tja_count++;
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        scan_cache[path] = {crown, tja_count};
+        return;
+    }
+
+    // Errors are stepped over rather than thrown: one unreadable entry deep in
+    // a tree should not take the folder box down with it.
+    std::error_code scan_ec;
+    auto scan = fs::recursive_directory_iterator(
+        path, fs::directory_options::skip_permission_denied, scan_ec);
+    while (scan != fs::end(scan)) {
+        const fs::directory_entry& entry = *scan;
         if (entry.path().filename() == "song_list.txt") {
             auto entries = read_song_list(entry.path());
             tja_count += (int)entries.size();
             for (const auto& e : entries)
                 if (auto found = scores_manager.get_path_by_hash(e.hash))
                     update_crown(*found);
+            scan.increment(scan_ec);
+            if (scan_ec) scan_ec.clear();
             continue;
         }
         auto ext = entry.path().extension();
@@ -82,6 +102,9 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
             tja_count++;
             update_crown(entry.path());
         }
+
+        scan.increment(scan_ec);
+        if (scan_ec) scan_ec.clear();
     }
 
     {

--- a/src/objects/song_select/file_navigator/box_folder.cpp
+++ b/src/objects/song_select/file_navigator/box_folder.cpp
@@ -1,10 +1,10 @@
 #include "box_folder.h"
 #include "../../../libs/gen4.h"
 #include "../../../libs/green.h"
-#include "../../../libs/green.h"
 #include "../../../libs/filesystem.h"
 #include "../../../libs/scores.h"
 #include "../../../libs/audio.h"
+#include <deque>
 #include <mutex>
 
 // The crown/count scan below walks the folder's whole subtree and runs a
@@ -20,34 +20,16 @@ struct FolderScan {
 };
 std::mutex scan_cache_mutex;
 std::map<fs::path, FolderScan> scan_cache;
-}
 
-void FolderBox::invalidate_scan_cache() {
-    std::lock_guard<std::mutex> lock(scan_cache_mutex);
-    scan_cache.clear();
-}
+// Folders whose scans were put off so the wheel could appear first.
+std::mutex deferred_mutex;
+std::deque<fs::path> deferred_scans;
 
-FolderBox::FolderBox(const fs::path& path, const BoxDef& box_def, std::map<std::pair<std::string, std::string>, fs::path>& song_files)
-    : BaseBox(path, box_def), tja_count(0)
-{
-    this->text_name = box_def.name;
-    enter_fade = std::make_unique<FadeAnimation>(166);
-    refresh_scores(song_files);
-}
-
-void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs::path>& song_files) {
-    {
-        std::lock_guard<std::mutex> lock(scan_cache_mutex);
-        auto it = scan_cache.find(path);
-        if (it != scan_cache.end()) {
-            crown = it->second.crown;
-            tja_count = it->second.tja_count;
-            return;
-        }
-    }
-
-    crown.clear();
-    tja_count = 0;
+// The subtree walk itself, self-contained: everything it touches - the score
+// maps, the cache - is behind its own lock, so it can run on any thread.
+void scan_folder_now(const fs::path& path) {
+    std::map<int, Crown> crown;
+    int tja_count = 0;
     std::set<int> disqualified;
 
     auto update_crown = [&](const fs::path& file_path) {
@@ -70,33 +52,6 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
                 crown[diff] = std::min(crown[diff], score->crown);
         }
     };
-
-    // A game data root holds thousands of files that are not songs, and its
-    // song count is known without looking at the disk at all.
-    if (const gen4::Library* library = gen4::library_for(path)) {
-        int genre_no = gen4::genre_of_path(path);
-        for (const gen4::OrderEntry& listing : library->order())
-            if (genre_no < 0 || listing.genre_no == genre_no) tja_count++;
-        std::lock_guard<std::mutex> lock(scan_cache_mutex);
-        scan_cache[path] = {crown, tja_count};
-        return;
-    }
-    if (const green::Library* library = green::library_for(path)) {
-        std::string genre = green::genre_of_path(path);
-        for (const green::SongEntry& e : library->songs())
-            if (genre.empty() || e.genre == genre) tja_count++;
-        std::lock_guard<std::mutex> lock(scan_cache_mutex);
-        scan_cache[path] = {crown, tja_count};
-        return;
-    }
-    if (const green::Library* library = green::library_for(path)) {
-        std::string genre = green::genre_of_path(path);
-        for (const green::SongEntry& e : library->songs())
-            if (genre.empty() || e.genre == genre) tja_count++;
-        std::lock_guard<std::mutex> lock(scan_cache_mutex);
-        scan_cache[path] = {crown, tja_count};
-        return;
-    }
 
     // Errors are stepped over rather than thrown: one unreadable entry deep in
     // a tree should not take the folder box down with it.
@@ -125,9 +80,81 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
         if (scan_ec) scan_ec.clear();
     }
 
+    std::lock_guard<std::mutex> lock(scan_cache_mutex);
+    scan_cache[path] = {crown, tja_count};
+}
+}
+
+void FolderBox::invalidate_scan_cache() {
+    std::lock_guard<std::mutex> lock(scan_cache_mutex);
+    scan_cache.clear();
+}
+
+FolderBox::FolderBox(const fs::path& path, const BoxDef& box_def, std::map<std::pair<std::string, std::string>, fs::path>& song_files)
+    : BaseBox(path, box_def), tja_count(0)
+{
+    this->text_name = box_def.name;
+    enter_fade = std::make_unique<FadeAnimation>(166);
+    refresh_scores(song_files);
+}
+
+void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs::path>& song_files) {
+    (void)song_files;
     {
         std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        auto it = scan_cache.find(path);
+        if (it != scan_cache.end()) {
+            crown = it->second.crown;
+            tja_count = it->second.tja_count;
+            return;
+        }
+    }
+
+    crown.clear();
+    tja_count = 0;
+
+    // A game data root holds thousands of files that are not songs, and its
+    // song count is known without looking at the disk at all.
+    if (const gen4::Library* library = gen4::library_for(path)) {
+        int genre_no = gen4::genre_of_path(path);
+        for (const gen4::OrderEntry& listing : library->order())
+            if (genre_no < 0 || listing.genre_no == genre_no) tja_count++;
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
         scan_cache[path] = {crown, tja_count};
+        return;
+    }
+    if (const green::Library* library = green::library_for(path)) {
+        std::string genre = green::genre_of_path(path);
+        for (const green::SongEntry& e : library->songs())
+            if (genre.empty() || e.genre == genre) tja_count++;
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        scan_cache[path] = {crown, tja_count};
+        return;
+    }
+
+    // Anything else means walking its whole subtree - seconds of disk for a
+    // big library - so the scan is put off until the wheel itself is up, and
+    // update() below picks the result up when it lands in the cache.
+    scan_pending = true;
+    std::lock_guard<std::mutex> lock(deferred_mutex);
+    deferred_scans.push_back(path);
+}
+
+void FolderBox::run_deferred_scans(std::atomic<bool>& abort_flag) {
+    for (;;) {
+        if (abort_flag) return;   // leave the rest queued for the next load
+        fs::path next;
+        {
+            std::lock_guard<std::mutex> lock(deferred_mutex);
+            if (deferred_scans.empty()) return;
+            next = std::move(deferred_scans.front());
+            deferred_scans.pop_front();
+        }
+        {
+            std::lock_guard<std::mutex> lock(scan_cache_mutex);
+            if (scan_cache.count(next)) continue;
+        }
+        scan_folder_now(next);
     }
 }
 
@@ -154,16 +181,36 @@ void FolderBox::load_text() {
 }
 
 void FolderBox::update(double current_time) {
+    if (scan_pending) {
+        std::lock_guard<std::mutex> lock(scan_cache_mutex);
+        auto it = scan_cache.find(path);
+        if (it != scan_cache.end()) {
+            crown = it->second.crown;
+            tja_count = it->second.tja_count;
+            scan_pending = false;
+            // The count text may already be baked with the placeholder.
+            if (text_loaded)
+                tja_count_text = std::make_unique<OutlinedText>(std::to_string(tja_count),
+                    tex.skin_config[SC::SONG_TJA_COUNT].font_size, ray::WHITE, ray::BLACK, false);
+        }
+    }
+
     bool is_open_prev = yellow_box_opened;
     enter_fade->update(current_time);
     BaseBox::update(current_time);
 
+    // Only the open/close transitions touch the audio engine. The old form
+    // asked it "is the voice playing" every frame for every closed box on the
+    // wheel - hundreds of lock acquisitions a second across the boxes, enough
+    // to starve the audio writers and wedge the whole engine.
     if (!is_open_prev && yellow_box_opened) {
         if (!audio.is_sound_playing("voice_enter")) {
             audio.play_sound("genre_voice_" + std::to_string((int)genre_index), VolumePreset::VOICE);
+            genre_voice_started = true;
         }
-    } else if (!yellow_box_opened && audio.is_sound_playing("genre_voice_" + std::to_string((int)genre_index))) {
+    } else if (!yellow_box_opened && genre_voice_started) {
         audio.stop_sound("genre_voice_" + std::to_string((int)genre_index));
+        genre_voice_started = false;
     }
 }
 

--- a/src/objects/song_select/file_navigator/box_folder.cpp
+++ b/src/objects/song_select/file_navigator/box_folder.cpp
@@ -49,7 +49,7 @@ void FolderBox::refresh_scores(std::map<std::pair<std::string, std::string>, fs:
     std::set<int> disqualified;
 
     auto update_crown = [&](const fs::path& file_path) {
-        auto& hashes = scores_manager.get_hashes(file_path);
+        auto hashes = scores_manager.get_hashes(file_path);
         for (int diff = 0; diff < 5; diff++) {
             if (hashes[diff].empty()) continue;
             auto score = scores_manager.get_score(hashes[diff], diff, global_data.config->general.player_1_id);

--- a/src/objects/song_select/file_navigator/box_folder.h
+++ b/src/objects/song_select/file_navigator/box_folder.h
@@ -9,6 +9,9 @@ public:
     bool is_osu_folder = false;
     std::map<int, Crown> crown;
     bool entered = false;
+    // The genre voice this box started, so closing only talks to the audio
+    // engine when there is actually something to stop.
+    bool genre_voice_started = false;
     std::unique_ptr<FadeAnimation> enter_fade;
     std::optional<ray::Texture> box_texture;
 
@@ -25,6 +28,12 @@ public:
     void exit_box() override;
 
     void refresh_scores(std::map<std::pair<std::string, std::string>, fs::path>& song_files);
+    // Runs every scan that refresh_scores put off. Called on the loader
+    // thread once the whole wheel is up, so the boxes appear immediately and
+    // their crowns and counts fill in behind them.
+    static void run_deferred_scans(std::atomic<bool>& abort_flag);
+    // True while this box's subtree scan is still queued or running.
+    bool scan_pending = false;
     // Drop the cached crown/tja_count folder scans. Call whenever scores or
     // song lists change (after a play, favorite toggle, recent update).
     static void invalidate_scan_cache();

--- a/src/objects/song_select/file_navigator/box_song.cpp
+++ b/src/objects/song_select/file_navigator/box_song.cpp
@@ -1,5 +1,6 @@
 #include "box_song.h"
 #include "../../../libs/audio.h"
+#include <thread>
 
 SongBox::SongBox(const fs::path& path, const BoxDef& box_def, SongParser parser)
     : BaseBox(path, box_def)
@@ -48,6 +49,8 @@ void SongBox::reset() {
         audio.unload_music_stream("preview");
     }
     music_playing = false;
+    preview_load.reset();
+    preview_attempted = false;
     score_history.reset();
     box_opened_at = 0.0;
 }
@@ -84,13 +87,53 @@ void SongBox::update(double current_time) {
     BaseBox::update(current_time);
     diff_fade_in->update(current_time);
 
-    if (yellow_box.has_value() && (yellow_box->left_out != nullptr) && yellow_box->left_out->is_finished && fs::exists(parser.metadata.wave) && !music_playing) {
+    bool is_bank = parser.metadata.wave.extension() == ".nus3bank";
+
+    // A bank has to be decoded whole, which takes over a second: done on this
+    // thread it is a frozen wheel, and started when the box has finished
+    // opening it is a second of silence on top of the opening. So the decode
+    // runs on its own thread, kicked off as soon as the cursor has rested
+    // here for a moment, overlapping the animation it used to wait behind.
+    if (is_bank && yellow_box.has_value() && !music_playing && !preview_load &&
+        !preview_attempted && get_current_ms() - bar_open_started_at > 250 &&
+        fs::exists(parser.metadata.wave)) {
+        preview_attempted = true;
+        preview_load = std::make_shared<PreviewLoad>();
+        std::thread([state = preview_load, wave = parser.metadata.wave] {
+            state->ok = audio.prepare_nus3bank_pcm(wave, state->pcm, true);
+            state->done.store(true, std::memory_order_release);
+        }).detach();
+    }
+
+    if (!is_bank && yellow_box.has_value() && (yellow_box->left_out != nullptr) && yellow_box->left_out->is_finished && fs::exists(parser.metadata.wave) && !music_playing) {
         music_playing = true;
         audio.stop_sound("bgm");
         audio.load_music_stream(parser.metadata.wave, "preview");
         if (audio.is_music_stream_valid("preview")) {
             audio.play_music_stream("preview", VolumePreset::MUSIC);
             audio.seek_music_stream("preview", parser.metadata.demostart);
+        }
+    }
+
+    // The decoded preview starts once the box has also finished opening, the
+    // same moment the synchronous path above starts its music.
+    if (preview_load && preview_load->done.load(std::memory_order_acquire) &&
+        yellow_box.has_value() && (yellow_box->left_out != nullptr) &&
+        yellow_box->left_out->is_finished && !music_playing) {
+        auto state = std::move(preview_load);
+        if (state->ok) {
+            music_playing = true;
+            audio.stop_sound("bgm");
+            // The bank names its own preview point; the chart has no
+            // DEMOSTART to fall back on beyond zero.
+            float demo_start = state->pcm.preview_ms > 0
+                             ? state->pcm.preview_ms / 1000.0f
+                             : parser.metadata.demostart;
+            audio.load_music_stream_prepared(std::move(state->pcm), "preview");
+            if (audio.is_music_stream_valid("preview")) {
+                audio.play_music_stream("preview", VolumePreset::MUSIC);
+                audio.seek_music_stream("preview", demo_start);
+            }
         }
     }
 
@@ -115,6 +158,8 @@ void SongBox::expand_box() {
 void SongBox::close_box() {
     BaseBox::close_box();
     box_opened_at = 0.0;
+    preview_load.reset();
+    preview_attempted = false;
     if (music_playing) {
         if (audio.is_music_stream_valid("preview")) {
             audio.stop_music_stream("preview");

--- a/src/objects/song_select/file_navigator/box_song.cpp
+++ b/src/objects/song_select/file_navigator/box_song.cpp
@@ -103,7 +103,8 @@ void SongBox::update(double current_time) {
     BaseBox::update(current_time);
     diff_fade_in->update(current_time);
 
-    bool is_bank = parser.metadata.wave.extension() == ".nus3bank";
+    auto wave_ext = parser.metadata.wave.extension();
+    bool is_bank = wave_ext == ".nus3bank" || wave_ext == ".nub";
 
     // A bank has to be decoded whole, which takes over a second: done on this
     // thread it is a frozen wheel, and started when the box has finished

--- a/src/objects/song_select/file_navigator/box_song.cpp
+++ b/src/objects/song_select/file_navigator/box_song.cpp
@@ -30,16 +30,32 @@ SongBox::SongBox(const fs::path& path, const BoxDef& box_def, SongParser parser)
 
 void SongBox::refresh_scores() {
     hashes = scores_manager.get_hashes(path);
+    // An arcade chart's hash means parsing and digesting the whole chart, and
+    // this runs for every difficulty of every box a genre opens - hundreds of
+    // file reads for a wheel that is just being looked at. No stored hash
+    // means the song was never played, so there is no score to find anyway;
+    // playing it once computes and records the real hash.
+    bool cheap_hash = !std::holds_alternative<FumenParser>(parser.impl);
     for (const auto& [course, course_data] : parser.metadata.course_data) {
         if (course < 0 || course >= static_cast<int>(hashes.size()))
             continue;
-        if (hashes[course].empty())
+        if (hashes[course].empty() && cheap_hash)
             hashes[course] = parser.get_diff_hash(course);
     }
     for (int i = 0; i < 5; i++) {
         scores[i] = scores_manager.get_score(hashes[i], i, global_data.config->general.player_1_id);
     }
     score_history.reset();
+}
+
+std::string SongBox::hash_for(int difficulty) {
+    if (difficulty < 0 || difficulty >= (int)hashes.size()) return "";
+    if (hashes[difficulty].empty()) {
+        hashes[difficulty] = parser.get_diff_hash(difficulty);
+        if (!hashes[difficulty].empty())
+            scores_manager.add_path_binding(path, hashes);
+    }
+    return hashes[difficulty];
 }
 
 void SongBox::reset() {

--- a/src/objects/song_select/file_navigator/box_song.h
+++ b/src/objects/song_select/file_navigator/box_song.h
@@ -55,6 +55,11 @@ public:
     std::vector<Difficulty> get_diffs();
 
     void refresh_scores();
+    // The chart hash for one difficulty, computed on first use. Arcade charts
+    // skip hashing when the box is built (it means parsing the whole chart),
+    // so the moment a song is actually picked the hash is filled in here and
+    // recorded, and every later lookup finds it stored.
+    std::string hash_for(int difficulty);
 
     const char* lua_kind() const override { return "song"; }
     OutlinedText* horizontal_subtitle() {

--- a/src/objects/song_select/file_navigator/box_song.h
+++ b/src/objects/song_select/file_navigator/box_song.h
@@ -3,6 +3,8 @@
 #include "box_base.h"
 #include "score_history.h"
 #include "../../../libs/song_parser.h"
+#include "../../../libs/audio.h"
+#include <atomic>
 #include <cmath>
 
 class SongBox : public BaseBox {
@@ -17,6 +19,19 @@ public:
     std::unique_ptr<OutlinedText> bpm_text;
     std::optional<ray::Texture2D> preimage;
     bool music_playing = false;
+    // Decoding a .nus3bank preview takes over a second, so it runs on its own
+    // thread; the box polls this in update and starts the stream when it is
+    // ready. Dropping the pointer abandons a load whose result is not wanted
+    // any more - the worker holds its own reference and finishes harmlessly.
+    struct PreviewLoad {
+        std::atomic<bool>       done{false};
+        bool                    ok = false;
+        AudioEngine::PreparedPCM pcm;
+    };
+    std::shared_ptr<PreviewLoad> preview_load;
+    // One decode per opening: a failed bank would otherwise be retried every
+    // frame for as long as the cursor sits on it.
+    bool preview_attempted = false;
     std::unique_ptr<ScoreHistory> score_history;
     double box_opened_at = 0.0;
     FadeAnimation* diff_fade_in;

--- a/src/objects/song_select/file_navigator/color_utils.cpp
+++ b/src/objects/song_select/file_navigator/color_utils.cpp
@@ -48,19 +48,22 @@ ray::Color darken_color(const ray::Color& rgb) {
 }
 
 
+// Alpha is spelled out on every colour: ray::Color is a plain aggregate, so a
+// three-value initialisation quietly leaves alpha at 0 and anything drawn with
+// it - a text outline, say - is painted fully transparent.
 const std::map<GenreIndex, std::array<std::optional<ray::Color>, 2>> DEFAULT_COLORS = {
-    { GenreIndex::JPOP,        { ray::Color(32,  160, 186), ray::Color(0,   77,  104) } },
-    { GenreIndex::ANIME,       { ray::Color(255, 152, 0),   ray::Color(156, 64,  2)   } },
-    { GenreIndex::VOCALOID,    { std::nullopt,        ray::Color(84,  101, 126) } },
-    { GenreIndex::CHILDREN,    { ray::Color(255, 82,  134), ray::Color(153, 4,   46)  } },
-    { GenreIndex::VARIETY,     { ray::Color(142, 212, 30),  ray::Color(60,  104, 0)   } },
-    { GenreIndex::CLASSICAL,   { ray::Color(209, 162, 19),  ray::Color(134, 88,  0)   } },
-    { GenreIndex::GAME,        { ray::Color(156, 117, 189), ray::Color(79,  40,  134) } },
-    { GenreIndex::NAMCO,       { ray::Color(255, 90,  19),  ray::Color(148, 24,  0)   } },
-    { GenreIndex::DEFAULT,     { std::nullopt,        ray::Color(101, 0,   82)  } },
-    { GenreIndex::RECOMMENDED, { std::nullopt,        ray::Color(140, 39,  92)  } },
-    { GenreIndex::FAVORITE,    { std::nullopt,        ray::Color(151, 57,  30)  } },
-    { GenreIndex::RECENT,      { std::nullopt,        ray::Color(35,  123, 103) } },
-    { GenreIndex::DAN,         { ray::Color(35,  102, 170), ray::Color(25,  68,  137) } },
-    { GenreIndex::DIFFICULTY,  { ray::Color(255, 85,  95),  ray::Color(157, 13,  31)  } },
+    { GenreIndex::JPOP,        { ray::Color(32,  160, 186, 255), ray::Color(0,   77,  104, 255) } },
+    { GenreIndex::ANIME,       { ray::Color(255, 152, 0,   255), ray::Color(156, 64,  2,   255) } },
+    { GenreIndex::VOCALOID,    { std::nullopt,             ray::Color(84,  101, 126, 255) } },
+    { GenreIndex::CHILDREN,    { ray::Color(255, 82,  134, 255), ray::Color(153, 4,   46,  255) } },
+    { GenreIndex::VARIETY,     { ray::Color(142, 212, 30,  255), ray::Color(60,  104, 0,   255) } },
+    { GenreIndex::CLASSICAL,   { ray::Color(209, 162, 19,  255), ray::Color(134, 88,  0,   255) } },
+    { GenreIndex::GAME,        { ray::Color(156, 117, 189, 255), ray::Color(79,  40,  134, 255) } },
+    { GenreIndex::NAMCO,       { ray::Color(255, 90,  19,  255), ray::Color(148, 24,  0,   255) } },
+    { GenreIndex::DEFAULT,     { std::nullopt,             ray::Color(101, 0,   82,  255) } },
+    { GenreIndex::RECOMMENDED, { std::nullopt,             ray::Color(140, 39,  92,  255) } },
+    { GenreIndex::FAVORITE,    { std::nullopt,             ray::Color(151, 57,  30,  255) } },
+    { GenreIndex::RECENT,      { std::nullopt,             ray::Color(35,  123, 103, 255) } },
+    { GenreIndex::DAN,         { ray::Color(35,  102, 170, 255), ray::Color(25,  68,  137, 255) } },
+    { GenreIndex::DIFFICULTY,  { ray::Color(255, 85,  95,  255), ray::Color(157, 13,  31,  255) } },
 };

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -101,6 +101,17 @@ void Navigator::wait_for_song_files() {
 
 void Navigator::load_all_roots() {
     join_loader();
+    // Everything on the wheel is going away, so the genre band and inline
+    // listing that pointed into it go too - draw would otherwise index boxes
+    // that no longer exist. Coming back out of a game's genre is exactly
+    // this: the band is still up when the rebuild starts.
+    is_inline = false;
+    inline_state.reset();
+    pending_inline_path.reset();
+    pending_inline_folder = nullptr;
+    genre_bg.reset();
+    genre_bg_end_pos.reset();
+    inline_streaming = false;
     items.clear();
     open_index = 0;
     def_file_cache.clear();
@@ -117,6 +128,9 @@ void Navigator::load_all_roots() {
         }
         reloading_roots  = false;
         loading_complete = true;
+        // With every level of the wheel up, catch up on the folder scans the
+        // boxes put off - crowns and counts fill in as each one finishes.
+        FolderBox::run_deferred_scans(abort_loading);
     };
 
 #ifndef __EMSCRIPTEN__
@@ -133,31 +147,43 @@ void Navigator::preload(std::vector<fs::path> songs_paths) {
 
 #ifndef __EMSCRIPTEN__
     song_files_thread = std::thread([this, songs_paths]() {
-        for (const fs::path& root_path : songs_paths) {
-            try {
-                std::error_code ec;
-                auto it = fs::recursive_directory_iterator(root_path, fs::directory_options::skip_permission_denied, ec);
-                while (it != fs::end(it)) {
+        // The walk itself is quick now that game data roots are stepped over;
+        // the cost is opening and parsing every chart for its title. That is
+        // embarrassingly parallel, so a small pool splits the library.
+        std::vector<fs::path> files = get_song_files(songs_paths);
+        std::mutex map_mutex;
+        std::atomic<size_t> cursor{0};
+        unsigned pool_size = std::max(2u, std::thread::hardware_concurrency() / 2);
+        std::vector<std::thread> pool;
+        for (unsigned t = 0; t < pool_size; t++) {
+            pool.emplace_back([&]() {
+                for (;;) {
+                    size_t i = cursor.fetch_add(1);
+                    if (i >= files.size() || abort_loading) break;
+                    const fs::path& file = files[i];
+                    if (!is_song_file(file)) continue;
                     try {
-                        if (is_song_file(it->path())) {
-                            SongParser parsed_entry = SongParser(it->path());
-                            parsed_entry.get_metadata();
-                            bool playable = false;
-                            for (const auto& [course, data] : parsed_entry.metadata.course_data)
-                                if (course >= 0 && course <= 4) { playable = true; break; }
-                            if (playable)
-                                song_files[{parsed_entry.metadata.title["en"], parsed_entry.metadata.subtitle["en"]}] = it->path();
+                        SongParser parsed_entry = SongParser(file);
+                        parsed_entry.get_metadata();
+                        // Dan (course 6) and Tower (course 5) charts are played
+                        // from their own screens, never from a song box: they
+                        // have no normal difficulty to select and picking one
+                        // out of a collection breaks. Keep them out of the
+                        // index the collections draw from.
+                        bool playable = false;
+                        for (const auto& [course, data] : parsed_entry.metadata.course_data)
+                            if (course >= 0 && course <= 4) { playable = true; break; }
+                        if (playable) {
+                            std::lock_guard<std::mutex> lock(map_mutex);
+                            song_files[{parsed_entry.metadata.title["en"], parsed_entry.metadata.subtitle["en"]}] = file;
                         }
                     } catch (const std::exception& inner) {
                         spdlog::warn("Skipping song during scan: {}", inner.what());
                     }
-                    it.increment(ec);
-                    if (ec) { spdlog::warn("Skipping entry: {}", ec.message()); ec.clear(); }
                 }
-            } catch (const fs::filesystem_error& e) {
-                spdlog::error("Error scanning song directory: {}", e.what());
-            }
+            });
         }
+        for (std::thread& worker : pool) worker.join();
     });
 #endif // !__EMSCRIPTEN__
 
@@ -188,6 +214,8 @@ void Navigator::init(std::vector<fs::path> songs_paths) {
         genre_bg_end_pos.reset();
         awaiting_diff_sort = false;
         diff_sort_filter.reset();
+        reopen_folder_path.reset();
+        reopen_song_path.reset();
         items.clear();
         open_index = 0;
         is_init = false;
@@ -211,9 +239,7 @@ void Navigator::init(std::vector<fs::path> songs_paths) {
             genre_bg.reset();
             awaiting_diff_sort = false;
             diff_sort_filter.reset();
-            for (const fs::path& root_path : root_paths) {
-                load_current_directory(root_path);
-            }
+            load_all_roots();
         } else {
             // A song was played (or the screen was left) with a folder open:
             // come back to closed folders, cursor on the folder that was
@@ -422,6 +448,14 @@ void Navigator::flush_pending_boxes() {
             for (int j = 0; j < (int)sortable_indices.size(); j++)
                 items[sortable_indices[j]] = std::move(sortable[j]);
         }
+        // A rebuilt wheel starts the cursor at zero; put it back on the box
+        // it was on when the rebuild began.
+        if (restore_cursor_path && !inline_state.has_value()) {
+            for (int i = 0; i < (int)items.size(); i++)
+                if (items[i]->path == *restore_cursor_path) { open_index = i; break; }
+            restore_cursor_path.reset();
+        }
+
         if (inline_state.has_value() && reopen_song_path && reopen_folder_path) {
             const auto& folder = inline_state->saved_folder_box;
             if (folder && folder->path == *reopen_folder_path) {
@@ -485,7 +519,10 @@ void Navigator::parse_song_list(const fs::path& path, BoxDef box_def, bool inlin
 }
 
 void Navigator::load_current_directory_async(const fs::path path) {
-    wait_for_song_files();
+    // Not waiting for the song index here: the wheel's boxes need nothing
+    // from it, and waiting meant the whole wheel sat empty behind the
+    // library-wide metadata scan. The one thing below that does need it -
+    // a song_list.txt collection - waits for itself.
     BoxDef box_def = parse_box_def(path);
 
     setup_back_box(path, true);
@@ -535,6 +572,15 @@ void Navigator::load_current_directory_async(const fs::path path) {
         return;
     }
 
+    // A PS3 game nests its data as <game>/USRDIR/data; the back box the
+    // generic setup pointed at USRDIR would just show this same game again,
+    // so it leads out beside the game's folder instead.
+    if (is_green_root(path) && path.filename() == "data" &&
+        path.parent_path().filename() == "USRDIR" && !items.empty()) {
+        if (auto* back = dynamic_cast<BackBox*>(items.front().get()))
+            back->path = path.parent_path().parent_path().parent_path();
+    }
+
     // A data root lists its own genres and nothing else, so the songs of this
     // game replace the ones that were on the wheel until the back box is used.
     if (is_gen4_root(path) || is_green_root(path)) {
@@ -570,6 +616,7 @@ void Navigator::load_current_directory_async(const fs::path path) {
             try {
                 if (!fs::is_directory(curr_path)) {
                     if (curr_path.filename() == "song_list.txt") {
+                        wait_for_song_files();
                         BoxDef entry_box_def = parse_box_def(curr_path);
                         parse_song_list(curr_path, entry_box_def, false);
                         continue;
@@ -578,16 +625,23 @@ void Navigator::load_current_directory_async(const fs::path path) {
                         enqueue_box(make_song_box(curr_path, box_def, take_parser(preparsed, curr_path)));
                     continue;
                 }
-                if (is_gen4_root(curr_path) || is_green_root(curr_path)) {
+                fs::path groot = green_root_at(curr_path);
+                if (is_gen4_root(curr_path) || !groot.empty()) {
                     if (only_gen4_songs()) {
-                        if (is_green_root(curr_path)) load_green_genres(curr_path);
-                        else                          load_gen4_genres(curr_path);
+                        if (!groot.empty()) load_green_genres(groot);
+                        else                load_gen4_genres(curr_path);
                         continue;
                     }
                     BoxDef gen4_def = box_def;
-                    gen4_def.name        = curr_path.filename().string();
+                    gen4_def.name = curr_path.filename().string();
+                    // The game says what it is called; the folder is often
+                    // just a serial like SCEEXE009.
+                    if (!groot.empty())
+                        if (const green::Library* lib = green::library_for(groot))
+                            gen4_def.name = lib->game_name();
                     gen4_def.genre_index = GenreIndex::DEFAULT;
-                    enqueue_box(std::make_unique<FolderBox>(curr_path, gen4_def, song_files));
+                    enqueue_box(std::make_unique<FolderBox>(groot.empty() ? curr_path : groot,
+                                                            gen4_def, song_files));
                     continue;
                 }
                 if (is_green_song_folder(curr_path)) {
@@ -658,6 +712,7 @@ void Navigator::load_current_directory_async(const fs::path path) {
     }
     loading_complete = true;
     current_path = path;
+    if (!reloading_roots) FolderBox::run_deferred_scans(abort_loading);
 }
 
 void Navigator::load_collection_new(const fs::path& path, const BoxDef& box_def) {
@@ -1089,7 +1144,11 @@ bool Navigator::has_def_file(const std::filesystem::path& path) {
     }
 
     for (const auto& entry : fs::directory_iterator(path, fs::directory_options::skip_permission_denied, ec)) {
-        if (entry.is_directory(ec) && has_def_file(entry.path())) {
+        if (!entry.is_directory(ec)) continue;
+        // Never descend into a game's data: there is no box.def inside, just
+        // an enormous tree of charts and tables.
+        if (is_gen4_root(entry.path()) || !green_root_at(entry.path()).empty()) continue;
+        if (has_def_file(entry.path())) {
             def_file_cache[key] = true;
             return true;
         }
@@ -1159,6 +1218,19 @@ void Navigator::load_current_directory(const fs::path path) {
         // that same path. Opening it is going in, not coming back out, so it
         // must not be read as a return to the top of the wheel.
         gen4::find_data_root(path).empty() && green::find_data_root(path).empty()) {
+        // The rebuild empties the wheel, so remember which box the cursor
+        // was on: the folder that was just closed, the game that was just
+        // left, or wherever it stood.
+        if (inline_state.has_value() && inline_state->saved_folder_box) {
+            restore_cursor_path = inline_state->saved_folder_box->path;
+        } else {
+            fs::path game = gen4::find_data_root(current_path);
+            if (game.empty()) game = green::find_data_root(current_path);
+            if (!game.empty())
+                restore_cursor_path = game;
+            else if (open_index >= 0 && open_index < (int)items.size())
+                restore_cursor_path = items[open_index]->path;
+        }
         load_all_roots();
         return;
     }
@@ -1371,7 +1443,7 @@ bool Navigator::has_child_folders(const fs::path& path) {
             return true;
         // A folder holding a game data root is a level of its own too, or
         // coming back out of that game tries to expand this folder as a song.
-        if (is_gen4_root(entry.path()) || is_green_root(entry.path()))
+        if (is_gen4_root(entry.path()) || !green_root_at(entry.path()).empty())
             return true;
     }
     return false;
@@ -1399,10 +1471,15 @@ const BoxDef* Navigator::box_def_for_genre(GenreIndex genre) {
         genre_box_defs_built = true;
         for (const fs::path& root : root_paths) {
             std::error_code ec;
+            // A game data root holds no box.def, only tens of thousands of
+            // chart files the recursive search below would crawl through.
+            if (!gen4::find_data_root(root).empty() ||
+                !green::find_data_root(root).empty()) continue;
             if (!fs::is_directory(root, ec)) continue;
             for (const auto& entry : fs::directory_iterator(root, ec)) {
                 if (abort_loading) return nullptr;
                 if (!fs::is_directory(entry.path(), ec)) continue;
+                if (is_gen4_root(entry.path()) || !green_root_at(entry.path()).empty()) continue;
                 if (!has_def_file(entry.path())) continue;
                 BoxDef def = parse_box_def(entry.path());
                 genre_box_defs.emplace(def.genre_index, def);
@@ -1426,20 +1503,24 @@ bool Navigator::is_gen4_root(const fs::path& path) {
 // to switch back to, so the genres of that game are the top of the wheel
 // rather than sitting inside a folder of their own.
 bool Navigator::only_gen4_songs() {
-    bool found_gen4 = false;
+    int games = 0;
     std::error_code ec;
     for (const fs::path& root : root_paths) {
         if (!gen4::find_data_root(root).empty() ||
-            !green::find_data_root(root).empty()) { found_gen4 = true; continue; }
+            !green::find_data_root(root).empty()) { games++; continue; }
         if (!fs::is_directory(root, ec)) continue;
         for (const auto& entry : fs::directory_iterator(root, ec)) {
-            if (is_gen4_root(entry.path()) || is_green_root(entry.path())) { found_gen4 = true; continue; }
+            if (is_gen4_root(entry.path()) || !green_root_at(entry.path()).empty()) {
+                games++;
+                continue;
+            }
             // Anything else at all - a genre folder, an osu folder, a loose
             // chart - means the wheel has somewhere else to go.
             return false;
         }
     }
-    return found_gen4;
+    // Several games have to stand as boxes; one on its own is the wheel.
+    return games == 1;
 }
 
 void Navigator::load_gen4_genres(const fs::path& data_root) {
@@ -1533,6 +1614,16 @@ bool Navigator::is_green_root(const fs::path& path) {
     std::error_code ec;
     if (!fs::is_directory(path, ec)) return false;
     return green::find_data_root(path) == path && green::library_for(path) != nullptr;
+}
+
+// The green data root standing at - or nested just under - a folder: the
+// PS3 dumps keep it as <game>/USRDIR/data, and a folder of dumps should show
+// one box per game without the user having to point at each data folder.
+fs::path Navigator::green_root_at(const fs::path& path) {
+    if (is_green_root(path)) return path;
+    fs::path nested = path / "USRDIR" / "data";
+    if (is_green_root(nested)) return nested;
+    return {};
 }
 
 // A green song folder is fumen/<id>, holding solo/ and duet/ chart folders.
@@ -1861,13 +1952,18 @@ void Navigator::draw() {
             pending_inline_folder != nullptr && genre_bg_end_pos.has_value()) {
             start_pos = pending_inline_folder->left_bound;
             end_pos = genre_bg_end_pos.value();  // approximation while loading
-        } else {
+        } else if (genre_bg_start < (int)items.size() && genre_bg_end < (int)items.size()) {
             start_pos = items[genre_bg_start]->left_bound;
-            end_pos = items[genre_bg_end]->right_bound;  // safe, loading done
+            end_pos = items[genre_bg_end]->right_bound;
+        } else {
+            // The wheel was rebuilt under the band; nothing to anchor it to.
+            genre_bg.reset();
         }
 
-        FolderBox* folder = pending_inline_folder;
-        genre_bg->draw(start_pos, end_pos, folder);
+        if (genre_bg.has_value()) {
+            FolderBox* folder = pending_inline_folder;
+            genre_bg->draw(start_pos, end_pos, folder);
+        }
     }
     for (auto& box : items) {
         bool on_screen = vertical_gallery

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -1355,12 +1355,21 @@ void Navigator::load_gen4_genres(const fs::path& data_root) {
         BoxDef def;
         if (const BoxDef* like = box_def_for_genre(genre)) {
             def = *like;
-        } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
-            // Nothing in the library uses this genre, so fall back to the
-            // built-in colours.
-            def.texture_index = TextureIndex::NONE;
-            def.back_color    = colors->second[0];
-            def.fore_color    = colors->second[1];
+        } else {
+            // Nothing in the library defines this genre - a game on its own,
+            // with no TJA songs beside it - so the look a box.def would give
+            // it is spelled out here instead: the same colours, and the same
+            // texture, which is the plain genre art for everything except
+            // vocaloid, which has art of its own.
+            // NONE means "tint the plain box with these colours", which is
+            // what gives each genre its own look; vocaloid is the one genre
+            // the skin has art for, and its box.def uses that instead.
+            def.texture_index = (genre == GenreIndex::VOCALOID)
+                              ? TextureIndex::VOCALOID : TextureIndex::NONE;
+            if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
+                def.back_color = colors->second[0];
+                def.fore_color = colors->second[1];
+            }
         }
         def.name        = gen4::genre_name(genre_no, lang);
         def.genre_index = genre;
@@ -1387,10 +1396,13 @@ bool Navigator::load_gen4_genre_songs(const fs::path& path, const BoxDef& box_de
     if (const BoxDef* like = box_def_for_genre(genre)) {
         def = *like;
     } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
-        // NONE means "tint the plain box art with these colours", which is what
-        // a box.def genre does to its songs; any other value draws fixed art
-        // and ignores the colours.
-        def.texture_index = TextureIndex::NONE;
+        // NONE means "tint the plain box art with these colours", which is
+        // what a box.def genre does to its songs. Vocaloid is the exception:
+        // it has no colour to tint to, only art of its own, and asking for a
+        // tint that cannot happen leaves the untinted art showing through -
+        // which is a green box under a genre that is not green.
+        def.texture_index = (genre == GenreIndex::VOCALOID)
+                          ? TextureIndex::VOCALOID : TextureIndex::NONE;
         def.back_color    = colors->second[0];
         def.fore_color    = colors->second[1];
     }

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -107,6 +107,33 @@ void Navigator::wait_for_song_files() {
         song_files_thread.join();
 }
 
+void Navigator::load_all_roots() {
+    join_loader();
+    items.clear();
+    open_index = 0;
+    def_file_cache.clear();
+    box_def_cache.clear();
+    is_processing    = true;
+    loading_complete = false;
+    reloading_roots  = true;
+
+    auto walk_roots = [this] {
+        for (const fs::path& root : root_paths) {
+            if (abort_loading) break;
+            loading_complete = false;
+            load_current_directory_async(root);
+        }
+        reloading_roots  = false;
+        loading_complete = true;
+    };
+
+#ifndef __EMSCRIPTEN__
+    loader_thread = std::thread(walk_roots);
+#else
+    walk_roots();
+#endif
+}
+
 void Navigator::preload(std::vector<fs::path> songs_paths) {
     if (is_preloaded) return;
     root_paths = songs_paths;
@@ -160,9 +187,7 @@ void Navigator::init(std::vector<fs::path> songs_paths) {
             preload(songs_paths);
         }
 
-        for (const fs::path& root_path : root_paths) {
-            load_current_directory(root_path);
-        }
+        load_all_roots();
         is_init = true;
     } else {
         if (global_data.config->general.song_limit > 0) {
@@ -206,13 +231,18 @@ void Navigator::join_loader() {
 }
 
 void Navigator::enqueue_box(std::unique_ptr<BaseBox> box) {
-    auto last_write = fs::last_write_time(box->path);
-    auto last_write_sys = ch::system_clock::now() +
-        std::chrono::duration_cast<ch::system_clock::duration>(
-            last_write - std::filesystem::file_time_type::clock::now());
-    auto two_weeks_ago = ch::system_clock::now() - ch::weeks(2);
-    if (last_write_sys < two_weeks_ago)
-        box->is_new = true;
+    // Not every box stands for something on disk: a gen 4 genre is a property
+    // of a song, not a folder, so it has no file time and simply is not new.
+    std::error_code ec;
+    auto last_write = fs::last_write_time(box->path, ec);
+    if (!ec) {
+        auto last_write_sys = ch::system_clock::now() +
+            std::chrono::duration_cast<ch::system_clock::duration>(
+                last_write - std::filesystem::file_time_type::clock::now());
+        auto two_weeks_ago = ch::system_clock::now() - ch::weeks(2);
+        if (last_write_sys < two_weeks_ago)
+            box->is_new = true;
+    }
 
     std::lock_guard<std::mutex> lock(pending_mutex);
     if (auto* song = dynamic_cast<SongBox*>(box.get())) {
@@ -389,6 +419,21 @@ void Navigator::load_current_directory_async(const fs::path path) {
 
     setup_back_box(path, true);
 
+    // A data root lists its own genres and nothing else, so the songs of this
+    // game replace the ones that were on the wheel until the back box is used.
+    if (is_gen4_root(path)) {
+        try {
+            load_gen4_genres(path);
+        } catch (const std::exception& e) {
+            spdlog::error("Error listing gen4 genres of {}: {}", path.string(), e.what());
+        } catch (...) {
+            spdlog::error("Unknown error listing gen4 genres of {}", path.string());
+        }
+        loading_complete = true;
+        current_path = path;
+        return;
+    }
+
     // Pre-parse the level's song files on a worker pool (see
     // parse_songs_parallel) so the streaming loop below only assembles boxes.
     std::vector<fs::path> song_paths;
@@ -414,6 +459,13 @@ void Navigator::load_current_directory_async(const fs::path path) {
                     }
                     if (is_song_file(curr_path))
                         enqueue_box(make_song_box(curr_path, box_def, take_parser(preparsed, curr_path)));
+                    continue;
+                }
+                if (is_gen4_root(curr_path)) {
+                    BoxDef gen4_def = box_def;
+                    gen4_def.name        = curr_path.filename().string();
+                    gen4_def.genre_index = GenreIndex::DEFAULT;
+                    enqueue_box(std::make_unique<FolderBox>(curr_path, gen4_def, song_files));
                     continue;
                 }
                 if (is_gen4_song_folder(curr_path)) {
@@ -466,6 +518,12 @@ void Navigator::load_current_directory_async(const fs::path path) {
         }
     } catch (const fs::filesystem_error& e) {
         spdlog::error("Error loading directory: {}", e.what());
+    } catch (const std::exception& e) {
+        // This runs on the loader thread, where an escaping exception takes
+        // the process down instead of failing one directory.
+        spdlog::error("Error loading directory {}: {}", path.string(), e.what());
+    } catch (...) {
+        spdlog::error("Unknown error loading directory {}", path.string());
     }
     loading_complete = true;
     current_path = path;
@@ -708,6 +766,11 @@ void Navigator::load_collection_search(const fs::path& path, const BoxDef& box_d
 }
 
 void Navigator::load_songs_inline_async(const fs::path path, BoxDef box_def) {
+    if (load_gen4_genre_songs(path, box_def)) {
+        loading_complete = true;
+        return;
+    }
+
     wait_for_song_files();
     int songs_added = 0;
     std::unordered_map<std::string, std::unique_ptr<SongParser>> preparsed;
@@ -960,6 +1023,15 @@ void Navigator::load_current_directory(const fs::path path) {
     BoxDef box_def = parse_box_def(path);
     bool has_children = has_child_folders(path);
 
+    // Coming back out to a root rebuilds every root together: the top of the
+    // wheel is all of them, and each load cancels the one before it, so
+    // reloading just this one would leave only its own songs on the wheel.
+    if (has_children && root_paths.size() > 1 && !reloading_roots &&
+        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end()) {
+        load_all_roots();
+        return;
+    }
+
     if (!has_children && !items.empty()) {
         InlineState state;
         state.folder_index     = open_index;
@@ -1131,7 +1203,9 @@ bool Navigator::jump_to_song(const std::string& hash) {
 
 void Navigator::setup_back_box(const fs::path& path, bool has_children) {
     if (has_children) {
-        items.clear();
+        // While every root is being walked in turn, the wheel was already
+        // emptied once and each root adds to it.
+        if (!reloading_roots) items.clear();
         // A root level has no folder to close: the box would point at the
         // songs dir's parent and selecting it does nothing sensible.
         if (std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end())
@@ -1146,15 +1220,27 @@ void Navigator::setup_back_box(const fs::path& path, bool has_children) {
 }
 
 bool Navigator::has_child_folders(const fs::path& path) {
-    for (const auto& entry : fs::directory_iterator(path))
+    // A data root opens into its genres, which replaces the wheel; a genre
+    // opens into songs, which expands in place like any other genre folder.
+    if (gen4::genre_of_path(path) >= 0) return false;
+    if (is_gen4_root(path)) return true;
+
+    for (const auto& entry : fs::directory_iterator(path)) {
         if (fs::is_directory(entry.path()) && has_def_file(entry.path()) || is_osu_song_folder(entry.path()))
             return true;
+        // A folder holding a game data root is a level of its own too, or
+        // coming back out of that game tries to expand this folder as a song.
+        if (is_gen4_root(entry.path()))
+            return true;
+    }
     return false;
 }
 
 bool Navigator::is_directory(BaseBox* item) {
     // Not simply "the path is a folder": a gen 4 song is a folder of chart
-    // files, and treating one as a directory opens it instead of playing it.
+    // files, and treating one as a directory opens it instead of playing it,
+    // while a gen 4 genre is a folder whose path is not on disk at all.
+    if (dynamic_cast<FolderBox*>(item) != nullptr) return true;
     return !is_song(item) && fs::is_directory(item->path);
 }
 
@@ -1162,6 +1248,111 @@ bool Navigator::is_song_file(const fs::path& path) {
     if (!fs::is_regular_file(path)) return false;
     auto ext = path.extension();
     return ext == ".tja" || ext == ".osu";
+}
+
+// A gen 4 genre has no box.def of its own, so it borrows the one the library
+// already has for that genre: same colours, same folder art, same text
+// outline, rather than a second set that only nearly matches.
+const BoxDef* Navigator::box_def_for_genre(GenreIndex genre) {
+    if (!genre_box_defs_built) {
+        genre_box_defs_built = true;
+        for (const fs::path& root : root_paths) {
+            std::error_code ec;
+            if (!fs::is_directory(root, ec)) continue;
+            for (const auto& entry : fs::directory_iterator(root, ec)) {
+                if (abort_loading) return nullptr;
+                if (!fs::is_directory(entry.path(), ec)) continue;
+                if (!has_def_file(entry.path())) continue;
+                BoxDef def = parse_box_def(entry.path());
+                genre_box_defs.emplace(def.genre_index, def);
+            }
+        }
+    }
+    auto it = genre_box_defs.find(genre);
+    return it != genre_box_defs.end() ? &it->second : nullptr;
+}
+
+// The folder holding a game's datatable, fumen and sound. It stands in the
+// wheel as one box: opening it puts the wheel into that game's own genres, and
+// the back box leads out again.
+bool Navigator::is_gen4_root(const fs::path& path) {
+    std::error_code ec;
+    if (!fs::is_directory(path, ec)) return false;
+    return gen4::find_data_root(path) == path && gen4::library_for(path) != nullptr;
+}
+
+void Navigator::load_gen4_genres(const fs::path& data_root) {
+    const gen4::Library* library = gen4::library_for(data_root);
+    if (!library) return;
+
+    const std::string& lang = global_data.config->general.language;
+    for (int genre_no : gen4::genres_present(*library)) {
+        if (abort_loading) break;
+        GenreIndex genre = (GenreIndex)gen4::genre_index_for(genre_no);
+
+        BoxDef def;
+        if (const BoxDef* like = box_def_for_genre(genre)) {
+            def = *like;
+        } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
+            // Nothing in the library uses this genre, so fall back to the
+            // built-in colours.
+            def.texture_index = TextureIndex::NONE;
+            def.back_color    = colors->second[0];
+            def.fore_color    = colors->second[1];
+        }
+        def.name        = gen4::genre_name(genre_no, lang);
+        def.genre_index = genre;
+        auto folder = std::make_unique<FolderBox>(gen4::genre_path(data_root, genre_no),
+                                                  def, song_files);
+        folder->tja_count = 0;
+        for (const gen4::OrderEntry& listing : library->order())
+            if (listing.genre_no == genre_no) folder->tja_count++;
+        enqueue_box(std::move(folder));
+    }
+}
+
+bool Navigator::load_gen4_genre_songs(const fs::path& path, const BoxDef& box_def) {
+    int genre_no = gen4::genre_of_path(path);
+    if (genre_no < 0) return false;
+
+    fs::path data_root = gen4::find_data_root(path);
+    const gen4::Library* library = gen4::library_for(data_root);
+    if (!library) return false;
+
+    GenreIndex genre = (GenreIndex)gen4::genre_index_for(genre_no);
+
+    BoxDef def = box_def;
+    if (const BoxDef* like = box_def_for_genre(genre)) {
+        def = *like;
+    } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
+        // NONE means "tint the plain box art with these colours", which is what
+        // a box.def genre does to its songs; any other value draws fixed art
+        // and ignores the colours.
+        def.texture_index = TextureIndex::NONE;
+        def.back_color    = colors->second[0];
+        def.fore_color    = colors->second[1];
+    }
+    def.name        = box_def.name;
+    def.genre_index = genre;
+
+    int songs_added = 0;
+    for (const gen4::OrderEntry& listing : library->order()) {
+        if (abort_loading) break;
+        if (listing.genre_no != genre_no) continue;
+        fs::path song_folder = data_root / "fumen" / listing.id;
+        std::error_code ec;
+        if (!fs::is_directory(song_folder, ec)) continue;
+        if (songs_added > 0 && songs_added % 10 == 0)
+            enqueue_inline_box(make_back_box(data_root));
+        auto box = make_song_box(song_folder, def, SongParser(song_folder));
+        // The running order is the order: leave it alone rather than sorting
+        // these by title the way a folder of files is sorted.
+        box->preserve_order = true;
+        box->fade_in(266);
+        enqueue_inline_box(std::move(box));
+        songs_added++;
+    }
+    return true;
 }
 
 // A gen 4 song folder is named after the song id and holds that id's chart

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -419,6 +419,21 @@ void Navigator::load_current_directory_async(const fs::path path) {
 
     setup_back_box(path, true);
 
+    // A song path pointing into a game - at its data root, or at the fumen
+    // folder inside it - lists that game's genres straight away.
+    fs::path own_root = gen4::find_data_root(path);
+    if (!own_root.empty() && own_root != path && gen4::library_for(own_root) &&
+        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end()) {
+        try {
+            load_gen4_genres(own_root);
+        } catch (const std::exception& e) {
+            spdlog::error("Error listing gen4 genres of {}: {}", own_root.string(), e.what());
+        }
+        loading_complete = true;
+        current_path = path;
+        return;
+    }
+
     // A data root lists its own genres and nothing else, so the songs of this
     // game replace the ones that were on the wheel until the back box is used.
     if (is_gen4_root(path)) {
@@ -462,6 +477,10 @@ void Navigator::load_current_directory_async(const fs::path path) {
                     continue;
                 }
                 if (is_gen4_root(curr_path)) {
+                    if (only_gen4_songs()) {
+                        load_gen4_genres(curr_path);
+                        continue;
+                    }
                     BoxDef gen4_def = box_def;
                     gen4_def.name        = curr_path.filename().string();
                     gen4_def.genre_index = GenreIndex::DEFAULT;
@@ -1279,6 +1298,25 @@ bool Navigator::is_gen4_root(const fs::path& path) {
     std::error_code ec;
     if (!fs::is_directory(path, ec)) return false;
     return gen4::find_data_root(path) == path && gen4::library_for(path) != nullptr;
+}
+
+// True when the song paths hold nothing but game data. There is then nothing
+// to switch back to, so the genres of that game are the top of the wheel
+// rather than sitting inside a folder of their own.
+bool Navigator::only_gen4_songs() {
+    bool found_gen4 = false;
+    std::error_code ec;
+    for (const fs::path& root : root_paths) {
+        if (!gen4::find_data_root(root).empty()) { found_gen4 = true; continue; }
+        if (!fs::is_directory(root, ec)) continue;
+        for (const auto& entry : fs::directory_iterator(root, ec)) {
+            if (is_gen4_root(entry.path())) { found_gen4 = true; continue; }
+            // Anything else at all - a genre folder, an osu folder, a loose
+            // chart - means the wheel has somewhere else to go.
+            return false;
+        }
+    }
+    return found_gen4;
 }
 
 void Navigator::load_gen4_genres(const fs::path& data_root) {

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -1218,12 +1218,18 @@ void Navigator::load_current_directory(const fs::path path) {
         // that same path. Opening it is going in, not coming back out, so it
         // must not be read as a return to the top of the wheel.
         gen4::find_data_root(path).empty() && green::find_data_root(path).empty()) {
-        // The rebuild empties the wheel, so remember which box the cursor
-        // was on: the folder that was just closed, the game that was just
-        // left, or wherever it stood.
-        if (inline_state.has_value() && inline_state->saved_folder_box) {
-            restore_cursor_path = inline_state->saved_folder_box->path;
-        } else {
+        // A folder was open on a wheel that is otherwise already showing the
+        // top level: fold the listing shut and leave every box standing,
+        // rather than rebuilding the whole wheel just to show what is
+        // already there.
+        if (inline_state.has_value()) {
+            collapse_inline_now();
+            return;
+        }
+
+        // The wheel really was replaced (a game's genres were up), so it has
+        // to be rebuilt; remember which box the cursor should come back to.
+        {
             fs::path game = gen4::find_data_root(current_path);
             if (game.empty()) game = green::find_data_root(current_path);
             if (!game.empty())

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -5,6 +5,7 @@
 #include "../song_select_script.h"
 #include "../../../libs/filesystem.h"
 #include "../../../libs/gen4.h"
+#include "../../../libs/green.h"
 #include <random>
 #include <cmath>
 
@@ -425,8 +426,17 @@ void Navigator::load_current_directory_async(const fs::path path) {
     // all there is, when its genres are the wheel itself. Opening that box
     // comes back here with reloading_roots clear and lists the genres.
     fs::path own_root = gen4::find_data_root(path);
+    bool own_root_is_green = false;
+    if (own_root.empty() || !gen4::library_for(own_root)) {
+        fs::path green_root = green::find_data_root(path);
+        if (!green_root.empty() && green::library_for(green_root)) {
+            own_root = green_root;
+            own_root_is_green = true;
+        }
+    }
     bool is_a_root = std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end();
-    if (!own_root.empty() && is_a_root && gen4::library_for(own_root)) {
+    if (!own_root.empty() && is_a_root &&
+        (own_root_is_green || gen4::library_for(own_root))) {
         if (reloading_roots && !only_gen4_songs()) {
             BoxDef gen4_def = box_def;
             gen4_def.name        = own_root.filename().string();
@@ -445,9 +455,10 @@ void Navigator::load_current_directory_async(const fs::path path) {
             break;
         }
         try {
-            load_gen4_genres(own_root);
+            if (own_root_is_green) load_green_genres(own_root);
+            else                   load_gen4_genres(own_root);
         } catch (const std::exception& e) {
-            spdlog::error("Error listing gen4 genres of {}: {}", own_root.string(), e.what());
+            spdlog::error("Error listing arcade genres of {}: {}", own_root.string(), e.what());
         }
         loading_complete = true;
         current_path = path;
@@ -456,9 +467,10 @@ void Navigator::load_current_directory_async(const fs::path path) {
 
     // A data root lists its own genres and nothing else, so the songs of this
     // game replace the ones that were on the wheel until the back box is used.
-    if (is_gen4_root(path)) {
+    if (is_gen4_root(path) || is_green_root(path)) {
         try {
-            load_gen4_genres(path);
+            if (is_green_root(path)) load_green_genres(path);
+            else                     load_gen4_genres(path);
         } catch (const std::exception& e) {
             spdlog::error("Error listing gen4 genres of {}: {}", path.string(), e.what());
         } catch (...) {
@@ -496,15 +508,20 @@ void Navigator::load_current_directory_async(const fs::path path) {
                         enqueue_box(make_song_box(curr_path, box_def, take_parser(preparsed, curr_path)));
                     continue;
                 }
-                if (is_gen4_root(curr_path)) {
+                if (is_gen4_root(curr_path) || is_green_root(curr_path)) {
                     if (only_gen4_songs()) {
-                        load_gen4_genres(curr_path);
+                        if (is_green_root(curr_path)) load_green_genres(curr_path);
+                        else                          load_gen4_genres(curr_path);
                         continue;
                     }
                     BoxDef gen4_def = box_def;
                     gen4_def.name        = curr_path.filename().string();
                     gen4_def.genre_index = GenreIndex::DEFAULT;
                     enqueue_box(std::make_unique<FolderBox>(curr_path, gen4_def, song_files));
+                    continue;
+                }
+                if (is_green_song_folder(curr_path)) {
+                    enqueue_box(make_song_box(curr_path, box_def, SongParser(curr_path)));
                     continue;
                 }
                 if (is_gen4_song_folder(curr_path)) {
@@ -809,6 +826,10 @@ void Navigator::load_songs_inline_async(const fs::path path, BoxDef box_def) {
         loading_complete = true;
         return;
     }
+    if (load_green_genre_songs(path, box_def)) {
+        loading_complete = true;
+        return;
+    }
 
     wait_for_song_files();
     int songs_added = 0;
@@ -1070,7 +1091,7 @@ void Navigator::load_current_directory(const fs::path path) {
         // A song path can point straight at a game, and then its box carries
         // that same path. Opening it is going in, not coming back out, so it
         // must not be read as a return to the top of the wheel.
-        gen4::find_data_root(path).empty()) {
+        gen4::find_data_root(path).empty() && green::find_data_root(path).empty()) {
         load_all_roots();
         return;
     }
@@ -1266,14 +1287,15 @@ bool Navigator::has_child_folders(const fs::path& path) {
     // A data root opens into its genres, which replaces the wheel; a genre
     // opens into songs, which expands in place like any other genre folder.
     if (gen4::genre_of_path(path) >= 0) return false;
-    if (is_gen4_root(path)) return true;
+    if (!green::genre_of_path(path).empty()) return false;
+    if (is_gen4_root(path) || is_green_root(path)) return true;
 
     for (const auto& entry : fs::directory_iterator(path)) {
         if (fs::is_directory(entry.path()) && has_def_file(entry.path()) || is_osu_song_folder(entry.path()))
             return true;
         // A folder holding a game data root is a level of its own too, or
         // coming back out of that game tries to expand this folder as a song.
-        if (is_gen4_root(entry.path()))
+        if (is_gen4_root(entry.path()) || is_green_root(entry.path()))
             return true;
     }
     return false;
@@ -1331,10 +1353,11 @@ bool Navigator::only_gen4_songs() {
     bool found_gen4 = false;
     std::error_code ec;
     for (const fs::path& root : root_paths) {
-        if (!gen4::find_data_root(root).empty()) { found_gen4 = true; continue; }
+        if (!gen4::find_data_root(root).empty() ||
+            !green::find_data_root(root).empty()) { found_gen4 = true; continue; }
         if (!fs::is_directory(root, ec)) continue;
         for (const auto& entry : fs::directory_iterator(root, ec)) {
-            if (is_gen4_root(entry.path())) { found_gen4 = true; continue; }
+            if (is_gen4_root(entry.path()) || is_green_root(entry.path())) { found_gen4 = true; continue; }
             // Anything else at all - a genre folder, an osu folder, a loose
             // chart - means the wheel has somewhere else to go.
             return false;
@@ -1421,6 +1444,91 @@ bool Navigator::load_gen4_genre_songs(const fs::path& path, const BoxDef& box_de
         auto box = make_song_box(song_folder, def, SongParser(song_folder));
         // The running order is the order: leave it alone rather than sorting
         // these by title the way a folder of files is sorted.
+        box->preserve_order = true;
+        box->fade_in(266);
+        enqueue_inline_box(std::move(box));
+        songs_added++;
+    }
+    return true;
+}
+
+// The folder holding a PS3 game's data: fumen/, sound/ and config/ together.
+bool Navigator::is_green_root(const fs::path& path) {
+    std::error_code ec;
+    if (!fs::is_directory(path, ec)) return false;
+    return green::find_data_root(path) == path && green::library_for(path) != nullptr;
+}
+
+// A green song folder is fumen/<id>, holding solo/ and duet/ chart folders.
+bool Navigator::is_green_song_folder(const fs::path& path) {
+    if (path.parent_path().filename() != "fumen") return false;
+    const green::Library* library = green::library_for(path);
+    return library && library->find(path.filename().string()) != nullptr;
+}
+
+void Navigator::load_green_genres(const fs::path& data_root) {
+    const green::Library* library = green::library_for(data_root);
+    if (!library) return;
+
+    for (const std::string& genre_name : green::genres_present(*library)) {
+        if (abort_loading) break;
+        GenreIndex genre = (GenreIndex)green::genre_index_for(genre_name);
+
+        BoxDef def;
+        if (const BoxDef* like = box_def_for_genre(genre)) {
+            def = *like;
+        } else {
+            def.texture_index = (genre == GenreIndex::VOCALOID)
+                              ? TextureIndex::VOCALOID : TextureIndex::NONE;
+            if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
+                def.back_color = colors->second[0];
+                def.fore_color = colors->second[1];
+            }
+        }
+        def.name        = genre_name;
+        def.genre_index = genre;
+        auto folder = std::make_unique<FolderBox>(green::genre_path(data_root, genre_name),
+                                                  def, song_files);
+        folder->tja_count = 0;
+        for (const green::SongEntry& e : library->songs())
+            if (e.genre == genre_name) folder->tja_count++;
+        enqueue_box(std::move(folder));
+    }
+}
+
+bool Navigator::load_green_genre_songs(const fs::path& path, const BoxDef& box_def) {
+    std::string genre_name = green::genre_of_path(path);
+    if (genre_name.empty()) return false;
+
+    fs::path data_root = green::find_data_root(path);
+    const green::Library* library = green::library_for(data_root);
+    if (!library) return false;
+
+    GenreIndex genre = (GenreIndex)green::genre_index_for(genre_name);
+
+    BoxDef def = box_def;
+    if (const BoxDef* like = box_def_for_genre(genre)) {
+        def = *like;
+    } else if (auto colors = DEFAULT_COLORS.find(genre); colors != DEFAULT_COLORS.end()) {
+        def.texture_index = (genre == GenreIndex::VOCALOID)
+                          ? TextureIndex::VOCALOID : TextureIndex::NONE;
+        def.back_color    = colors->second[0];
+        def.fore_color    = colors->second[1];
+    }
+    def.name        = box_def.name;
+    def.genre_index = genre;
+
+    int songs_added = 0;
+    for (const green::SongEntry& listing : library->songs()) {
+        if (abort_loading) break;
+        if (listing.genre != genre_name) continue;
+        fs::path song_folder = data_root / "fumen" / listing.id;
+        std::error_code ec;
+        if (!fs::is_directory(song_folder, ec)) continue;
+        if (songs_added > 0 && songs_added % 10 == 0)
+            enqueue_inline_box(make_back_box(data_root));
+        auto box = make_song_box(song_folder, def, SongParser(song_folder));
+        // The file's own order is the game's order.
         box->preserve_order = true;
         box->fade_in(266);
         enqueue_inline_box(std::move(box));

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -419,11 +419,31 @@ void Navigator::load_current_directory_async(const fs::path path) {
 
     setup_back_box(path, true);
 
-    // A song path pointing into a game - at its data root, or at the fumen
-    // folder inside it - lists that game's genres straight away.
+    // A song path pointing at a game, either at its data root or at the fumen
+    // folder inside it. While the roots are being walked this is a level of
+    // the wheel like any other, so it gets a box to open - unless the game is
+    // all there is, when its genres are the wheel itself. Opening that box
+    // comes back here with reloading_roots clear and lists the genres.
     fs::path own_root = gen4::find_data_root(path);
-    if (!own_root.empty() && own_root != path && gen4::library_for(own_root) &&
-        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end()) {
+    bool is_a_root = std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end();
+    if (!own_root.empty() && is_a_root && gen4::library_for(own_root)) {
+        if (reloading_roots && !only_gen4_songs()) {
+            BoxDef gen4_def = box_def;
+            gen4_def.name        = own_root.filename().string();
+            gen4_def.genre_index = GenreIndex::DEFAULT;
+            enqueue_box(std::make_unique<FolderBox>(own_root, gen4_def, song_files));
+            loading_complete = true;
+            current_path = path;
+            return;
+        }
+        // setup_back_box gives a root level no way out, since a root has no
+        // folder above it. This one does: the rest of the library. The box
+        // points at another root, and opening a root rebuilds them all.
+        for (const fs::path& root : root_paths) {
+            if (!gen4::find_data_root(root).empty()) continue;
+            items.push_back(make_back_box(root));
+            break;
+        }
         try {
             load_gen4_genres(own_root);
         } catch (const std::exception& e) {
@@ -1046,7 +1066,11 @@ void Navigator::load_current_directory(const fs::path path) {
     // wheel is all of them, and each load cancels the one before it, so
     // reloading just this one would leave only its own songs on the wheel.
     if (has_children && root_paths.size() > 1 && !reloading_roots &&
-        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end()) {
+        std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end() &&
+        // A song path can point straight at a game, and then its box carries
+        // that same path. Opening it is going in, not coming back out, so it
+        // must not be read as a return to the top of the wheel.
+        gen4::find_data_root(path).empty()) {
         load_all_roots();
         return;
     }

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -4,6 +4,7 @@
 #include "color_utils.h"
 #include "../song_select_script.h"
 #include "../../../libs/filesystem.h"
+#include "../../../libs/gen4.h"
 #include <random>
 #include <cmath>
 
@@ -413,6 +414,10 @@ void Navigator::load_current_directory_async(const fs::path path) {
                     }
                     if (is_song_file(curr_path))
                         enqueue_box(make_song_box(curr_path, box_def, take_parser(preparsed, curr_path)));
+                    continue;
+                }
+                if (is_gen4_song_folder(curr_path)) {
+                    enqueue_box(make_song_box(curr_path, box_def, SongParser(curr_path)));
                     continue;
                 }
                 if (has_def_file(curr_path)) {
@@ -1148,13 +1153,33 @@ bool Navigator::has_child_folders(const fs::path& path) {
 }
 
 bool Navigator::is_directory(BaseBox* item) {
-    return fs::is_directory(item->path);
+    // Not simply "the path is a folder": a gen 4 song is a folder of chart
+    // files, and treating one as a directory opens it instead of playing it.
+    return !is_song(item) && fs::is_directory(item->path);
 }
 
 bool Navigator::is_song_file(const fs::path& path) {
     if (!fs::is_regular_file(path)) return false;
     auto ext = path.extension();
     return ext == ".tja" || ext == ".osu";
+}
+
+// A gen 4 song folder is named after the song id and holds that id's chart
+// files, one per difficulty. It only counts as a song when the game data it
+// belongs to can be read, since the folder alone carries no title or ratings.
+bool Navigator::is_gen4_song_folder(const fs::path& path) {
+    std::error_code ec;
+    if (!fs::is_directory(path, ec)) return false;
+
+    std::string id = path.filename().string();
+    static const char* suffixes[] = { "_e", "_n", "_h", "_m", "_x" };
+    bool has_chart = false;
+    for (const char* suffix : suffixes) {
+        if (fs::exists(path / (id + suffix + ".bin"), ec)) { has_chart = true; break; }
+    }
+    if (!has_chart) return false;
+
+    return gen4::library_for(path) != nullptr;
 }
 
 bool Navigator::is_osu_song_folder(const fs::path& path) {
@@ -1170,7 +1195,8 @@ bool Navigator::is_osu_song_folder(const fs::path& path) {
 
 
 bool Navigator::is_song(BaseBox* item) {
-    return is_song_file(item->path);
+    // What the box is, not what its path looks like.
+    return dynamic_cast<SongBox*>(item) != nullptr;
 }
 
 BaseBox* Navigator::get_current_item() {

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -64,6 +64,9 @@ private:
     // that same folder puts the cursor back on the song that was played.
     std::optional<fs::path>  reopen_folder_path;
     std::optional<fs::path>  reopen_song_path;
+    // Where the cursor was when the whole wheel had to be rebuilt, so coming
+    // back out of a folder or a game does not dump it on the first box.
+    std::optional<fs::path>  restore_cursor_path;
 
     std::optional<fs::path>  recent_folder_path;
     std::optional<fs::path>  favorite_folder_path;
@@ -84,10 +87,7 @@ private:
     bool is_gen4_song_folder(const fs::path& path);
     bool is_gen4_root(const fs::path& path);
     bool is_green_root(const fs::path& path);
-    bool is_green_song_folder(const fs::path& path);
-    void load_green_genres(const fs::path& data_root);
-    bool load_green_genre_songs(const fs::path& genre_path, const BoxDef& box_def);
-    bool is_green_root(const fs::path& path);
+    fs::path green_root_at(const fs::path& path);
     bool is_green_song_folder(const fs::path& path);
     void load_green_genres(const fs::path& data_root);
     bool load_green_genre_songs(const fs::path& genre_path, const BoxDef& box_def);

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -77,6 +77,7 @@ private:
     bool is_osu_song_folder(const fs::path& path);
     bool is_gen4_song_folder(const fs::path& path);
     bool is_gen4_root(const fs::path& path);
+    bool only_gen4_songs();
     const BoxDef* box_def_for_genre(GenreIndex genre);
     void load_gen4_genres(const fs::path& data_root);
     bool load_gen4_genre_songs(const fs::path& genre_path, const BoxDef& box_def);

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -72,6 +72,7 @@ private:
     void set_positions(bool init, float duration);
     bool is_song_file(const fs::path& path);
     bool is_osu_song_folder(const fs::path& path);
+    bool is_gen4_song_folder(const fs::path& path);
     bool has_def_file(const std::filesystem::path& path);
     fs::path find_box_def_folder(const fs::path& song_path);
     void setup_back_box(const fs::path& path, bool has_children);

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -77,6 +77,14 @@ private:
     bool is_osu_song_folder(const fs::path& path);
     bool is_gen4_song_folder(const fs::path& path);
     bool is_gen4_root(const fs::path& path);
+    bool is_green_root(const fs::path& path);
+    bool is_green_song_folder(const fs::path& path);
+    void load_green_genres(const fs::path& data_root);
+    bool load_green_genre_songs(const fs::path& genre_path, const BoxDef& box_def);
+    bool is_green_root(const fs::path& path);
+    bool is_green_song_folder(const fs::path& path);
+    void load_green_genres(const fs::path& data_root);
+    bool load_green_genre_songs(const fs::path& genre_path, const BoxDef& box_def);
     bool only_gen4_songs();
     const BoxDef* box_def_for_genre(GenreIndex genre);
     void load_gen4_genres(const fs::path& data_root);

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -31,6 +31,9 @@ private:
     int open_index;
     bool is_init      = false;
     bool is_preloaded = false;
+    bool reloading_roots = false;
+    bool genre_box_defs_built = false;
+    std::map<GenreIndex, BoxDef> genre_box_defs;
 
     std::optional<InlineState>  inline_state;
     std::optional<fs::path>     pending_inline_path;
@@ -73,6 +76,10 @@ private:
     bool is_song_file(const fs::path& path);
     bool is_osu_song_folder(const fs::path& path);
     bool is_gen4_song_folder(const fs::path& path);
+    bool is_gen4_root(const fs::path& path);
+    const BoxDef* box_def_for_genre(GenreIndex genre);
+    void load_gen4_genres(const fs::path& data_root);
+    bool load_gen4_genre_songs(const fs::path& genre_path, const BoxDef& box_def);
     bool has_def_file(const std::filesystem::path& path);
     fs::path find_box_def_folder(const fs::path& song_path);
     void setup_back_box(const fs::path& path, bool has_children);
@@ -83,6 +90,7 @@ private:
     void enqueue_inline_box(std::unique_ptr<BaseBox> box);
     void parse_song_list(const fs::path& path, BoxDef box_def, bool inline_mode);
     void load_current_directory_async(const fs::path path);
+    void load_all_roots();
     void load_collection_difficulty(const fs::path& path, const BoxDef& box_def, int course, int level);
     void load_from_song_list(const fs::path& path, const BoxDef& box_def, bool mark_favorite);
     void load_collection_new(const fs::path& path, const BoxDef& box_def);

--- a/src/scenes/dan_select.cpp
+++ b/src/scenes/dan_select.cpp
@@ -1,4 +1,6 @@
 #include "dan_select.h"
+#include "../libs/gen4.h"
+#include "../libs/green.h"
 #include "../libs/song_parser.h"
 #include "../libs/input.h"
 #include "../objects/song_select/file_navigator/navigator.h"
@@ -89,8 +91,21 @@ void DanNavigator::init(const std::vector<fs::path>& song_paths) {
     selected_index = 0;
 
     for (const fs::path& root_path : song_paths) {
+        // A path at or inside a game's data holds no dan.json, only tens of
+        // thousands of chart files this walk would crawl through.
+        if (!gen4::find_data_root(root_path).empty() ||
+            !green::find_data_root(root_path).empty()) continue;
         try {
-            for (const auto& entry : fs::recursive_directory_iterator(root_path)) {
+            auto it = fs::recursive_directory_iterator(
+                root_path, fs::directory_options::skip_permission_denied);
+            for (; it != fs::end(it); ++it) {
+                const auto& entry = *it;
+                if (entry.is_directory() &&
+                    (gen4::find_data_root(entry.path()) == entry.path() ||
+                     green::find_data_root(entry.path()) == entry.path())) {
+                    it.disable_recursion_pending();
+                    continue;
+                }
                 if (entry.path().filename() == "dan.json") {
                     if (auto box = load_dan_box(entry.path())) {
                         boxes.push_back(std::move(box));

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -333,6 +333,10 @@ std::optional<Screens> DanGameScreen::update() {
         song_index = 0;
         prev_good = prev_ok = prev_bad = prev_drumroll = 0;
         sd.dan_result_data = DanResultData();
+        // The flag still says the music is on from before the restart, and
+        // with it set the first song never gets its playback started.
+        song_started = false;
+        score_saved  = false;
         init_dan();
         audio.play_sound("restart", VolumePreset::SOUND);
     }

--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -45,7 +45,11 @@ void PracticeGameScreen::init_tja_practice(const fs::path& song) {
     // Extract bars and note list for scrobbling from the already-parsed TJA
     int difficulty = global_data.session_data[(int)global_data.player_num].selected_difficulty;
     auto [notes, bm, be, bn] = parser->notes_to_position(difficulty);
-    std::get<TJAParser>(parser->impl).scroll_disabled = true;
+    // Only a TJA has scroll commands to disable; asking the variant for one
+    // when an arcade chart is loaded threw and kept practice mode out of
+    // those songs entirely.
+    if (auto* tja = std::get_if<TJAParser>(&parser->impl))
+        tja->scroll_disabled = true;
     apply_modifiers(notes, get_player_modifiers(global_data.player_num));
 
     bars.clear();

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -42,7 +42,7 @@ void SongSelectScreen::select_song(SongBox* song) {
     SessionData& session_data = global_data.session_data[(int)global_data.player_num];
     session_data.selected_song = song->path;
     session_data.selected_difficulty = (int)player->selected_difficulty;
-    session_data.song_hash = song->hashes[session_data.selected_difficulty];
+    session_data.song_hash = song->hash_for(session_data.selected_difficulty);
     session_data.genre_index = (int)song->song_genre_index - 1;
     global_data.last_difficulty[(int)global_data.player_num] = session_data.selected_difficulty;
     game_transition.emplace(song->text_name, song->text_subtitle, false);

--- a/src/scenes/song_select_2p.cpp
+++ b/src/scenes/song_select_2p.cpp
@@ -57,13 +57,13 @@ void SongSelect2PScreen::select_song(SongBox* song) {
     auto& sd1 = global_data.session_data[(int)PlayerNum::P1];
     sd1.selected_song = song->path;
     sd1.selected_difficulty = (int)player->selected_difficulty;
-    sd1.song_hash = song->hashes[sd1.selected_difficulty];
+    sd1.song_hash = song->hash_for(sd1.selected_difficulty);
     sd1.genre_index = (int)song->song_genre_index - 1;
 
     auto& sd2 = global_data.session_data[(int)PlayerNum::P2];
     sd2.selected_song = song->path;
     sd2.selected_difficulty = (int)player_2->selected_difficulty;
-    sd2.song_hash = song->hashes[sd2.selected_difficulty];
+    sd2.song_hash = song->hash_for(sd2.selected_difficulty);
     sd2.genre_index = (int)song->song_genre_index - 1;
 
     global_data.last_difficulty[(int)PlayerNum::P1] = sd1.selected_difficulty;


### PR DESCRIPTION
Adds the System 357 ("Green" era) games to the song wheel, alongside #130's gen 4 support - point a song path at (or into) the game's `USRDIR/data` folder and its genres appear with the game's own titles, ordering, star ratings, previews and charts.

**Stacked on #130** - the first commits here are that PR; review from "Read the PS3 arcade song data".

What the era looks like on disk, all established against a real dump:

- **Song list**: plain boost-XML `musicinfo.xml` under `config/<version>/`; versions run ST5…S11 and only the newest folder present is read (each lists the full library up to itself).
- **Charts**: the same fumen structures as gen 4, unencrypted and big-endian. The parser detects the endianness (the measure count is only sane one way round) and byte-swaps; the layout was validated by walking all 4,252 solo charts of a Green dump to exact end-of-file.
- **Stars**: `fumen/tuning.bin` (big-endian records; chart int 1 is the star rating). An ura chart is its own record named `ex_<id>` with its stars in the oni slot.
- **Audio**: each `.nub` holds a complete RIFF ATRAC3+ file, decoded with the FFmpeg the project already bundles for video. The RIFF `fact` chunk's priming delay is cut off the front so the song lines up with the chart, and the preview point sits at container offset 0xE0 - the same millisecond values these songs carry in their gen 4 banks' TONE chunks, which is how the field was confirmed.
- The medley-mode assemblies (`メドレー`) are left off the wheel; they are mode data, not songs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)