### PR TITLE
Let a partial skin lean on its parent's scripts

### DIFF
--- a/src/libs/script.cpp
+++ b/src/libs/script.cpp
@@ -51,33 +51,54 @@ static DrawTextureParams parse_draw_params(sol::optional<sol::table> params_tabl
     return params;
 }
 
+// Index every script under one Scripts folder. Names already present are
+// kept: the skin's own scripts are indexed first, and a parent skin only
+// fills the gaps, the same way its graphics do.
+void ScriptManager::index_scripts(const fs::path& script_path) {
+    std::error_code ec;
+    for (const auto& script : fs::directory_iterator(script_path, ec)) {
+        fs::path p = script.path();
+        if (fs::is_directory(p)) {
+            fs::path lua_file = p / (p.stem().string() + ".lua");
+            if (fs::exists(lua_file) && !scripts.count(p.stem().string())) {
+                scripts[p.stem().string()] = lua_file.string();
+            }
+            for (const auto& sub : fs::directory_iterator(p)) {
+                fs::path sub_p = sub.path();
+                if (!fs::is_directory(sub_p) && sub_p.extension() == ".lua" && sub_p.stem() != p.stem() &&
+                    !scripts.count(sub_p.stem().string())) {
+                    scripts[sub_p.stem().string()] = sub_p.string();
+                }
+            }
+        } else if (p.extension() == ".lua" && !scripts.count(p.stem().string())) {
+            scripts[p.stem().string()] = p.string();
+        }
+    }
+}
+
 void ScriptManager::init(fs::path script_path) {
     lua = std::make_unique<sol::state>();
     lua->open_libraries(sol::lib::base, sol::lib::package, sol::lib::string,
                         sol::lib::math, sol::lib::table);
 
-    std::string skin_scripts_dir = script_path.string();
-        std::string package_path = skin_scripts_dir + "/?.lua;" +
-                                   skin_scripts_dir + "/?/init.lua";
-        (*lua)["package"]["path"] = package_path;
+    // A partial skin scripts only some screens and leans on its parent for
+    // the rest, exactly like its graphics.
+    fs::path parent_scripts;
+    if (global_tex.has_parent_skin())
+        parent_scripts = global_tex.parent_root() / "Scripts";
 
-    for (const auto& script : fs::directory_iterator(script_path)) {
-        fs::path p = script.path();
-        if (fs::is_directory(p)) {
-            fs::path lua_file = p / (p.stem().string() + ".lua");
-            if (fs::exists(lua_file)) {
-                scripts[p.stem().string()] = lua_file.string();
-            }
-            for (const auto& sub : fs::directory_iterator(p)) {
-                fs::path sub_p = sub.path();
-                if (!fs::is_directory(sub_p) && sub_p.extension() == ".lua" && sub_p.stem() != p.stem()) {
-                    scripts[sub_p.stem().string()] = sub_p.string();
-                }
-            }
-        } else if (p.extension() == ".lua") {
-            scripts[p.stem().string()] = p.string();
-        }
+    std::string skin_scripts_dir = script_path.string();
+    std::string package_path = skin_scripts_dir + "/?.lua;" +
+                               skin_scripts_dir + "/?/init.lua";
+    if (!parent_scripts.empty()) {
+        package_path += ";" + parent_scripts.string() + "/?.lua;" +
+                        parent_scripts.string() + "/?/init.lua";
     }
+    (*lua)["package"]["path"] = package_path;
+
+    index_scripts(script_path);
+    if (!parent_scripts.empty()) index_scripts(parent_scripts);
+
     spdlog::debug("Loaded scripts:");
     for (const auto& [name, path] : scripts) {
         spdlog::debug("  {} -> {}", name, path);
@@ -87,6 +108,10 @@ void ScriptManager::init(fs::path script_path) {
     tex.init(script_path.parent_path() / "Graphics");
 
     register_lua_bindings();
+}
+
+bool ScriptManager::has_lua_script(const std::string& script_name) const {
+    return scripts.count(script_name) != 0;
 }
 
 std::string ScriptManager::get_lua_script_path(const std::string& script_name) {

--- a/src/libs/script.h
+++ b/src/libs/script.h
@@ -42,8 +42,10 @@ public:
     std::unique_ptr<sol::state> lua;
 
     void init(fs::path script_path);
+    bool has_lua_script(const std::string& script_name) const;
     void shutdown();
     std::string get_lua_script_path(const std::string& script_name);
+    void index_scripts(const fs::path& script_path);
     void register_lua_bindings();
 };
 
@@ -55,6 +57,9 @@ bool LuaScript::load(const std::string& class_name, const std::string& script_na
     sol::state& lua = *script_manager.lua;
 
     if (!lua[class_name].valid()) {
+        // A skin that scripts some screens but not this one simply has no
+        // script here; that is a plain "not scripted", not an error.
+        if (!script_manager.has_lua_script(script_name)) return false;
         auto result = lua.script_file(script_manager.get_lua_script_path(script_name));
         if (!result.valid()) {
             sol::error err = result;

--- a/src/objects/game/background.cpp
+++ b/src/objects/game/background.cpp
@@ -5,6 +5,10 @@ Background::Background(PlayerNum player_num, float bpm, const std::string& scene
     sol::state& lua = *script_manager.lua;
 
     if (!lua["Background"].valid()) {
+        if (!script_manager.has_lua_script("background")) {
+            spdlog::error("No background script in this skin or its parent");
+            return;
+        }
         std::string script_path = script_manager.get_lua_script_path("background");
         auto result = lua.script_file(script_path);
         if (!result.valid()) {

--- a/src/objects/result/player.cpp
+++ b/src/objects/result/player.cpp
@@ -50,6 +50,7 @@ ResultPlayer::ResultPlayer(PlayerNum player_num, bool has_2p, bool is_2p)
         sol::state& lua = *script_manager.lua;
         auto preload = [&](const char* cls, const char* script) {
             if (lua[cls].valid()) return;
+            if (!script_manager.has_lua_script(script)) return;
             auto result = lua.script_file(script_manager.get_lua_script_path(script));
             if (!result.valid()) {
                 sol::error err = result;


### PR DESCRIPTION
Booting with **YataiDON-HSS** selected crashed before the title screen with an uncaught C++ exception. The trace led to `CoinOverlay`'s constructor → `ScriptManager::get_lua_script_path`, which throws for any script the skin does not carry - and HSS only ships `song_select/song_select.lua`, leaning on `parent: PyTaikoGreen` for everything else, which Graphics and Sounds honour but Scripts never did.

Scripts now inherit like the rest of the skin:

- `ScriptManager::init` indexes the skin's own scripts first, then the parent's for whatever names are still missing, and `package.path` covers both directories (child first) so `require` resolves the same way.
- A script absent from both skins is a plain "this part is not scripted": `LuaScript::load` returns false, the background constructor logs and bails, and the result screen's preload skips it - no more exceptions escaping to the crash handler.

Verified by booting with HSS: it now reaches the title screen with its own song select script active and everything else running on the parent's. (Its missing sound files were already handled by the existing parent-fill in `load_screen_sounds` - those errors in the log are just the child-override attempt.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)