### PR TITLE
Draw the practice menu the way the arcade does

### DIFF
--- a/src/objects/game/player.h
+++ b/src/objects/game/player.h
@@ -63,6 +63,8 @@ public:
     int get_ok()   const { return ok_count; }
     int get_bad()  const { return bad_count; }
     bool is_auto_play() const { return modifiers.auto_play; }
+    // Practice mode toggles auto from its pause menu mid-song.
+    void set_auto_play(bool value) { modifiers.auto_play = value; }
     int get_score() const { return score; }
     int get_max_combo() const { return max_combo; }
     int get_total_drumroll() const { return total_drumroll; }

--- a/src/objects/game/player.h
+++ b/src/objects/game/player.h
@@ -65,6 +65,16 @@ public:
     bool is_auto_play() const { return modifiers.auto_play; }
     // Practice mode toggles auto from its pause menu mid-song.
     void set_auto_play(bool value) { modifiers.auto_play = value; }
+    // Practice replays sections over and over; each resume starts the score,
+    // combo and judgement tallies fresh so the numbers describe the current
+    // attempt only.
+    void reset_performance() {
+        good_count = ok_count = bad_count = 0;
+        combo = max_combo = 0;
+        score = 0;
+        total_drumroll = 0;
+        if (judge_counter) judge_counter = JudgeCounter();
+    }
     int get_score() const { return score; }
     int get_max_combo() const { return max_combo; }
     int get_total_drumroll() const { return total_drumroll; }

--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -115,6 +115,9 @@ void PracticeGameScreen::pause_song_practice() {
             // runway: seeking to the scrobbled bar drops their notes from
             // both the hit queues and the draw path.
             practice_player->seek_to(resume_time);
+            // A fresh attempt: score, combo and the judgement tallies all
+            // start over rather than keeping the last run's numbers.
+            practice_player->reset_performance();
         }
 
         pause_time = (int)start_time;

--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -49,7 +49,11 @@ void PracticeGameScreen::init_tja_practice(const fs::path& song) {
     // Extract bars and note list for scrobbling from the already-parsed TJA
     int difficulty = global_data.session_data[(int)global_data.player_num].selected_difficulty;
     auto [notes, bm, be, bn] = parser->notes_to_position(difficulty);
-    std::get<TJAParser>(parser->impl).scroll_disabled = true;
+    // Only a TJA has scroll commands to disable; asking the variant for one
+    // when an arcade chart is loaded threw and kept practice mode out of
+    // those songs entirely.
+    if (auto* tja = std::get_if<TJAParser>(&parser->impl))
+        tja->scroll_disabled = true;
     apply_modifiers(notes, get_player_modifiers(global_data.player_num));
 
     bars.clear();
@@ -169,74 +173,58 @@ void PracticeGameScreen::build_menu_text() {
     const std::string& lang = global_data.config->general.language;
     int col = lang == "ja" ? 0 : (lang.rfind("zh", 0) == 0 ? 1 : 2);
 
+    // Visual order left to right, as the arcade lays its bars out; the
+    // rightmost one, closing the menu, is where the cursor starts.
     struct Row { const char* ja; const char* zh; const char* en; };
     static const Row ROWS[] = {
-        { "つづきから",
-          "繼續",
-          "Resume" },
-        { "オート：",
-          "自動演奏：",
-          "Auto: " },
-        { "この小節を登録",
-          "登錄此小節",
+        { "\u30b2\u30fc\u30e0\u7d42\u4e86",
+          "\u7d50\u675f\u904a\u6232",
+          "End Game" },
+        { "\u307b\u304b\u306e\u66f2\u3092\u6f14\u594f",
+          "\u9078\u5176\u4ed6\u6b4c\u66f2",
+          "Another Song" },
+        { "\u6700\u521d\u304b\u3089\u6f14\u594f",
+          "\u5f9e\u982d\u6f14\u594f",
+          "From the Top" },
+        { "\u30aa\u30fc\u30c8\u6f14\u594f\u8a2d\u5b9a",
+          "\u81ea\u52d5\u6f14\u594f\u8a2d\u5b9a",
+          "Auto Play" },
+        { "\u30b8\u30e3\u30f3\u30d7\u30dd\u30a4\u30f3\u30c8\u3078",
+          "\u8df3\u81f3\u8df3\u8f49\u9ede",
+          "To Jump Point" },
+        { "\u30b8\u30e3\u30f3\u30d7\u30dd\u30a4\u30f3\u30c8\u8a2d\u5b9a",
+          "\u8a2d\u5b9a\u8df3\u8f49\u9ede",
           "Set Jump Point" },
-        { nullptr, nullptr, nullptr },   // the jump row is built below
-        { "さいしょから",
-          "重新開始",
-          "Restart" },
-        { "選曲にもどる",
-          "返回選曲",
-          "Back to Song Select" },
-        { "れんしゅうをやめる",
-          "結束練習",
-          "Quit Practice" },
-    };
-    auto pick = [&](const Row& r) -> std::string {
-        return col == 0 ? r.ja : col == 1 ? r.zh : r.en;
+        { "\u30e1\u30cb\u30e5\u30fc\u3092\u3068\u3058\u308b",
+          "\u95dc\u9589\u9078\u55ae",
+          "Close Menu" },
     };
 
-    std::vector<std::string> labels;
-    for (int i = 0; i < (int)(sizeof(ROWS) / sizeof(ROWS[0])); i++) {
-        if (i == 1) { labels.push_back(pick(ROWS[i]) + (auto_on ? "ON" : "OFF")); continue; }
-        if (i == 3) {
-            std::string n = std::to_string(jump_bar + 1);
-            if (col == 0)
-                labels.push_back(jump_bar >= 0
-                    ? "登録小節へ（" + n + "）"
-                    : "登録小節へ（なし）");
-            else if (col == 1)
-                labels.push_back(jump_bar >= 0
-                    ? "跳至第 " + n + " 小節"
-                    : "跳至登錄點（無）");
-            else
-                labels.push_back(jump_bar >= 0 ? "Jump to Bar " + n : "Jump (not set)");
-            continue;
-        }
-        labels.push_back(pick(ROWS[i]));
+    for (const Row& r : ROWS) {
+        std::string label = col == 0 ? r.ja : col == 1 ? r.zh : r.en;
+        menu_text.push_back(std::make_unique<OutlinedText>(label,
+            (int)(tex.skin_config[SC::SONG_BOX_NAME].font_size),
+            ray::WHITE, ray::BLACK, true));
     }
-
-    float font_size = tex.skin_config[SC::YB_SUBTITLE].font_size * 1.1f;
-    for (const std::string& label : labels)
-        menu_text.push_back(std::make_unique<OutlinedText>(label, (int)font_size,
-                                                           ray::WHITE, ray::BLACK, false));
+    (void)auto_on;
 }
 
 std::optional<Screens> PracticeGameScreen::menu_action(int index) {
     switch (index) {
-        case 0:   // resume
-            menu_open = false;
-            pause_song_practice();
+        case 0:   // leave practice altogether
+            if (song_music.has_value()) audio.stop_sound(song_music.value());
+            return on_screen_end(Screens::ENTRY);
+        case 1:   // pick another song
+            if (song_music.has_value()) audio.stop_sound(song_music.value());
+            return on_screen_end(Screens::PRACTICE_SELECT);
+        case 2:   // restart from the top
+            restart_practice();
             return std::nullopt;
-        case 1:   // toggle auto
+        case 3:   // toggle auto
             if (practice_player)
                 practice_player->set_auto_play(!practice_player->is_auto_play());
-            build_menu_text();
             return std::nullopt;
-        case 2:   // register the current bar as the jump point
-            jump_bar = scrobble_index;
-            build_menu_text();
-            return std::nullopt;
-        case 3:   // move the scrobble cursor to the jump point
+        case 4:   // move the scrobble cursor to the jump point
             if (jump_bar >= 0 && jump_bar < (int)bars.size()) {
                 scrobble_index = jump_bar;
                 scrobble_time  = bars[scrobble_index].hit_ms;
@@ -244,37 +232,57 @@ std::optional<Screens> PracticeGameScreen::menu_action(int index) {
                 menu_open = false;
             }
             return std::nullopt;
-        case 4:   // restart from the top
-            restart_practice();
+        case 5:   // register the current bar as the jump point
+            jump_bar = scrobble_index;
             return std::nullopt;
-        case 5:   // back to song select
-            if (song_music.has_value()) audio.stop_sound(song_music.value());
-            return on_screen_end(Screens::PRACTICE_SELECT);
-        case 6:   // leave practice altogether
-            if (song_music.has_value()) audio.stop_sound(song_music.value());
-            return on_screen_end(Screens::ENTRY);
+        case 6:   // close the menu, stay paused
+            menu_open = false;
+            return std::nullopt;
     }
     return std::nullopt;
 }
 
 void PracticeGameScreen::draw_practice_menu() const {
-    float w = 420 * tex.screen_scale;
-    float row = 46 * tex.screen_scale;
-    float h = row * (float)menu_text.size() + 40 * tex.screen_scale;
-    float x = (tex.screen_width - w) / 2.0f;
-    float y = (720 * tex.screen_scale - h) / 2.0f;
-    ray::DrawRectangle((int)x, (int)y, (int)w, (int)h, ray::Color(0, 0, 0, 200));
-    ray::DrawRectangleLines((int)x, (int)y, (int)w, (int)h, ray::WHITE);
+    int n = (int)menu_text.size();
+    if (n == 0) return;
 
-    for (int i = 0; i < (int)menu_text.size(); i++) {
-        float ty = y + 20 * tex.screen_scale + i * row;
-        float tx = x + 50 * tex.screen_scale;
-        if (i == menu_index) {
-            ray::DrawRectangle((int)(x + 8 * tex.screen_scale), (int)ty,
-                               (int)(w - 16 * tex.screen_scale), (int)row,
-                               ray::Color(255, 64, 64, 160));
-        }
-        menu_text[i]->draw({.x = tx, .y = ty});
+    float scale   = tex.screen_scale;
+    float bar_w   = 86 * scale;
+    float bar_h   = 380 * scale;
+    float gap     = 42 * scale;
+    float pad     = 48 * scale;
+    float panel_w = n * bar_w + (n - 1) * gap + pad * 2;
+    float panel_h = bar_h + pad * 2;
+    float panel_x = (tex.screen_width - panel_w) / 2.0f;
+    float panel_y = 48 * scale;
+
+    // The arcade's pale blue panel with its white frame.
+    ray::Rectangle panel = { panel_x, panel_y, panel_w, panel_h };
+    ray::DrawRectangleRounded(panel, 0.06f, 8, ray::Color(186, 192, 232, 245));
+    ray::DrawRectangleRoundedLinesEx(panel, 0.06f, 8, 4 * scale, ray::WHITE);
+
+    for (int i = 0; i < n; i++) {
+        float x = panel_x + pad + i * (bar_w + gap);
+        float y = panel_y + pad;
+        bool selected = (i == menu_index);
+
+        // Wooden bars, the chosen one gold - the same language as the wheel.
+        ray::Color face   = selected ? ray::Color(255, 214,  74, 255)
+                                     : ray::Color(166, 106,  44, 255);
+        ray::Color border = selected ? ray::WHITE
+                                     : ray::Color( 74,  46,  16, 255);
+        ray::DrawRectangle((int)x, (int)y, (int)bar_w, (int)bar_h, face);
+        ray::DrawRectangleLinesEx({x, y, bar_w, bar_h}, 4 * scale, border);
+
+        // A darker inner edge gives the bar its bevel.
+        ray::DrawRectangleLinesEx({x + 4 * scale, y + 4 * scale,
+                                   bar_w - 8 * scale, bar_h - 8 * scale},
+                                  2 * scale, ray::Color(0, 0, 0, 40));
+
+        OutlinedText* text = menu_text[i].get();
+        float tx = x + (bar_w - text->width) / 2.0f;
+        float ty = y + std::max(10.0f * scale, (bar_h - text->height) / 2.0f);
+        text->draw({.x = tx, .y = ty});
     }
 }
 
@@ -329,8 +337,8 @@ std::optional<Screens> PracticeGameScreen::global_keys_practice() {
             audio.play_sound("don", VolumePreset::SOUND);
             menu_don_anim->start();
             menu_open  = true;
-            menu_index = 0;
             build_menu_text();
+            menu_index = (int)menu_text.size() - 1;
             return std::nullopt;
         }
 

--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -21,6 +21,10 @@ void PracticeGameScreen::on_screen_start() {
 Screens PracticeGameScreen::on_screen_end(Screens next_screen) {
     scrobble_index = 0;
     scrobble_time = 0;
+    menu_open  = false;
+    menu_index = 0;
+    jump_bar   = -1;
+    menu_text.clear();
     scrobble_move = std::make_unique<MoveAnimation>(200.0, 0);
     bars.clear();
     scrobble_note_list.clear();
@@ -107,6 +111,9 @@ void PracticeGameScreen::pause_song_practice() {
         double start_time  = bars[previous_bar_index].hit_ms - first_bar_time + start_delay;
 
         if (practice_player) {
+            // The lead-in bars before the scrobbled bar stay an empty
+            // runway: seeking to the scrobbled bar drops their notes from
+            // both the hit queues and the draw path.
             practice_player->seek_to(resume_time);
         }
 
@@ -130,17 +137,147 @@ void PracticeGameScreen::pause_song_practice() {
     }
 }
 
+void PracticeGameScreen::restart_practice() {
+    if (song_music.has_value()) {
+        audio.stop_sound(song_music.value());
+    }
+    players.clear();
+    init_tja(global_data.session_data[(int)global_data.player_num].selected_song);
+    init_tja_practice(global_data.session_data[(int)global_data.player_num].selected_song);
+    audio.play_sound("restart", VolumePreset::SOUND);
+    song_started = false;
+    paused       = false;
+    menu_open    = false;
+    // Reset the chart clock the same way on_screen_start does; with the
+    // stale start_ms the opening notes were already past the sweep and
+    // could never be hit (same clock as the base game's restart, #83).
+    last_resync_ms = 0;
+    start_ms = get_current_ms() - parser->metadata.offset * 1000
+             - (double)global_data.config->general.audio_offset;
+    ms_from_start = get_current_ms() - start_ms;
+}
+
+void PracticeGameScreen::build_menu_text() {
+    menu_text.clear();
+    bool auto_on = practice_player && practice_player->is_auto_play();
+
+    // Follows the language the config picked, the same way the rest of the
+    // interface does: Japanese, Chinese (either script setting) or English.
+    const std::string& lang = global_data.config->general.language;
+    int col = lang == "ja" ? 0 : (lang.rfind("zh", 0) == 0 ? 1 : 2);
+
+    struct Row { const char* ja; const char* zh; const char* en; };
+    static const Row ROWS[] = {
+        { "つづきから",
+          "繼續",
+          "Resume" },
+        { "オート：",
+          "自動演奏：",
+          "Auto: " },
+        { "この小節を登録",
+          "登錄此小節",
+          "Set Jump Point" },
+        { nullptr, nullptr, nullptr },   // the jump row is built below
+        { "さいしょから",
+          "重新開始",
+          "Restart" },
+        { "選曲にもどる",
+          "返回選曲",
+          "Back to Song Select" },
+        { "れんしゅうをやめる",
+          "結束練習",
+          "Quit Practice" },
+    };
+    auto pick = [&](const Row& r) -> std::string {
+        return col == 0 ? r.ja : col == 1 ? r.zh : r.en;
+    };
+
+    std::vector<std::string> labels;
+    for (int i = 0; i < (int)(sizeof(ROWS) / sizeof(ROWS[0])); i++) {
+        if (i == 1) { labels.push_back(pick(ROWS[i]) + (auto_on ? "ON" : "OFF")); continue; }
+        if (i == 3) {
+            std::string n = std::to_string(jump_bar + 1);
+            if (col == 0)
+                labels.push_back(jump_bar >= 0
+                    ? "登録小節へ（" + n + "）"
+                    : "登録小節へ（なし）");
+            else if (col == 1)
+                labels.push_back(jump_bar >= 0
+                    ? "跳至第 " + n + " 小節"
+                    : "跳至登錄點（無）");
+            else
+                labels.push_back(jump_bar >= 0 ? "Jump to Bar " + n : "Jump (not set)");
+            continue;
+        }
+        labels.push_back(pick(ROWS[i]));
+    }
+
+    float font_size = tex.skin_config[SC::YB_SUBTITLE].font_size * 1.1f;
+    for (const std::string& label : labels)
+        menu_text.push_back(std::make_unique<OutlinedText>(label, (int)font_size,
+                                                           ray::WHITE, ray::BLACK, false));
+}
+
+std::optional<Screens> PracticeGameScreen::menu_action(int index) {
+    switch (index) {
+        case 0:   // resume
+            menu_open = false;
+            pause_song_practice();
+            return std::nullopt;
+        case 1:   // toggle auto
+            if (practice_player)
+                practice_player->set_auto_play(!practice_player->is_auto_play());
+            build_menu_text();
+            return std::nullopt;
+        case 2:   // register the current bar as the jump point
+            jump_bar = scrobble_index;
+            build_menu_text();
+            return std::nullopt;
+        case 3:   // move the scrobble cursor to the jump point
+            if (jump_bar >= 0 && jump_bar < (int)bars.size()) {
+                scrobble_index = jump_bar;
+                scrobble_time  = bars[scrobble_index].hit_ms;
+                scrobble_move  = std::make_unique<MoveAnimation>(200.0, 0);
+                menu_open = false;
+            }
+            return std::nullopt;
+        case 4:   // restart from the top
+            restart_practice();
+            return std::nullopt;
+        case 5:   // back to song select
+            if (song_music.has_value()) audio.stop_sound(song_music.value());
+            return on_screen_end(Screens::PRACTICE_SELECT);
+        case 6:   // leave practice altogether
+            if (song_music.has_value()) audio.stop_sound(song_music.value());
+            return on_screen_end(Screens::ENTRY);
+    }
+    return std::nullopt;
+}
+
+void PracticeGameScreen::draw_practice_menu() const {
+    float w = 420 * tex.screen_scale;
+    float row = 46 * tex.screen_scale;
+    float h = row * (float)menu_text.size() + 40 * tex.screen_scale;
+    float x = (tex.screen_width - w) / 2.0f;
+    float y = (720 * tex.screen_scale - h) / 2.0f;
+    ray::DrawRectangle((int)x, (int)y, (int)w, (int)h, ray::Color(0, 0, 0, 200));
+    ray::DrawRectangleLines((int)x, (int)y, (int)w, (int)h, ray::WHITE);
+
+    for (int i = 0; i < (int)menu_text.size(); i++) {
+        float ty = y + 20 * tex.screen_scale + i * row;
+        float tx = x + 50 * tex.screen_scale;
+        if (i == menu_index) {
+            ray::DrawRectangle((int)(x + 8 * tex.screen_scale), (int)ty,
+                               (int)(w - 16 * tex.screen_scale), (int)row,
+                               ray::Color(255, 64, 64, 160));
+        }
+        menu_text[i]->draw({.x = tx, .y = ty});
+    }
+}
+
 std::optional<Screens> PracticeGameScreen::global_keys_practice() {
     if (ray::IsKeyPressed(global_data.config->keys.restart_key)) {
-        if (song_music.has_value()) {
-            audio.stop_sound(song_music.value());
-        }
-        players.clear();
-        init_tja(global_data.session_data[(int)global_data.player_num].selected_song);
-        init_tja_practice(global_data.session_data[(int)global_data.player_num].selected_song);
-        audio.play_sound("restart", VolumePreset::SOUND);
-        song_started = false;
-        paused = false;
+        restart_practice();
         return std::nullopt;
     }
 
@@ -167,6 +304,33 @@ std::optional<Screens> PracticeGameScreen::global_keys_practice() {
             practice_player->spawn_scrobble_effect(DrumType::DON, Side::LEFT, other_idx);
         }
     } else {
+        if (menu_open) {
+            // The menu swallows the drums: kat steps, don confirms.
+            bool step_l = is_l_kat_pressed(global_data.player_num) || is_l_kat_pressed(other_player);
+            bool step_r = is_r_kat_pressed(global_data.player_num) || is_r_kat_pressed(other_player);
+            if (step_l || step_r) {
+                audio.play_sound("kat", VolumePreset::SOUND);
+                int n = (int)menu_text.size();
+                menu_index = ((menu_index + (step_r ? 1 : -1)) % n + n) % n;
+            }
+            if (is_l_don_pressed(global_data.player_num) || is_r_don_pressed(global_data.player_num) ||
+                is_l_don_pressed(other_player) || is_r_don_pressed(other_player)) {
+                audio.play_sound("don", VolumePreset::SOUND);
+                auto next = menu_action(menu_index);
+                if (next.has_value()) return next;
+            }
+            return std::nullopt;
+        }
+
+        if (is_l_don_pressed(other_player) || is_r_don_pressed(other_player)) {
+            audio.play_sound("don", VolumePreset::SOUND);
+            menu_don_anim->start();
+            menu_open  = true;
+            menu_index = 0;
+            build_menu_text();
+            return std::nullopt;
+        }
+
         if (is_l_don_pressed(global_data.player_num) || is_r_don_pressed(global_data.player_num)) {
             pause_song_practice();
             resume_don_anim->start();
@@ -506,6 +670,7 @@ void PracticeGameScreen::draw() {
 
     if (paused) {
         tex.draw_texture(PRACTICE::PAUSED, {.fade = 0.5});
+        if (menu_open) draw_practice_menu();
     }
 
     draw_overlay();

--- a/src/scenes/game_practice.h
+++ b/src/scenes/game_practice.h
@@ -82,8 +82,19 @@ private:
     TextureResizeAnimation* speed_l_kat_anim;
     TextureResizeAnimation* speed_r_kat_anim;
 
+    // The pause menu (issue #41): opened with the second drum's don while
+    // paused, stepped through with kat, confirmed with don.
+    bool menu_open  = false;
+    int  menu_index = 0;
+    int  jump_bar   = -1;   // the bar registered as the jump point, -1 = none
+    std::vector<std::unique_ptr<OutlinedText>> menu_text;
+
     void init_tja_practice(const fs::path& song);
     void pause_song_practice();
+    void restart_practice();
+    void build_menu_text();
+    std::optional<Screens> menu_action(int index);
+    void draw_practice_menu() const;
     std::optional<Screens> global_keys_practice();
 
     float get_scrobble_position_x(const Note& note, double current_ms) const;


### PR DESCRIPTION
Restyles #136's pause menu to the arcade's look (screenshot reference from the 特訓モード videos in #41): vertical wooden bars on the pale blue rounded panel, the selected bar gold, labels drawn top-to-bottom with the wheel's vertical text. Drawn with primitives for now, so it needs no new skin assets and can be swapped for the tutorial_training graphics when those land.

The line-up and order now match the arcade too - ゲーム終了・ほかの曲を演奏・最初から演奏・オート演奏設定・ジャンプポイントへ・ジャンプポイント設定・メニューをとじる - with the cursor starting on メニューをとじる. Closing the menu keeps the song paused (resume stays on the player's own don), and labels still follow the configured language.

**Stacked on #136** - review from "Draw the practice menu the way the arcade does".

🤖 Generated with [Claude Code](https://claude.com/claude-code)