### PR TITLE
Draw the practice menu art at its skin size, not scaled twice

### DIFF
--- a/src/objects/game/practice_menu.cpp
+++ b/src/objects/game/practice_menu.cpp
@@ -140,7 +140,6 @@ void PracticeMenu::draw() const {
     int n = (int)menu_text.size();
     if (n == 0) return;
 
-    float scale   = tex.screen_scale;
     float bar_w   = tex.skin_config[SC::PRACTICE_MENU_BAR].width;
     float bar_h   = tex.skin_config[SC::PRACTICE_MENU_BAR].height;
     float gap     = tex.skin_config[SC::PRACTICE_MENU_BAR].x;
@@ -150,7 +149,7 @@ void PracticeMenu::draw() const {
     float panel_y = tex.skin_config[SC::PRACTICE_MENU_PANEL].y;
     float pad     = (panel_w - n * bar_w - (n - 1) * gap) / 2.0f;
 
-    tex.draw_texture(PRACTICE::MENU_PANEL, {.scale = scale, .x = panel_x, .y = panel_y});
+    tex.draw_texture(PRACTICE::MENU_PANEL, {.x = panel_x, .y = panel_y});
 
     for (int i = 0; i < n; i++) {
         float x = panel_x + pad + i * (bar_w + gap);
@@ -158,7 +157,7 @@ void PracticeMenu::draw() const {
         bool selected = (i == index);
 
         tex.draw_texture(selected ? PRACTICE::MENU_BAR_SELECTED : PRACTICE::MENU_BAR,
-                         {.scale = scale, .x = x, .y = y});
+                         {.x = x, .y = y});
 
         OutlinedText* text = menu_text[i].get();
         float tx = x + (bar_w - text->width) / 2.0f;
@@ -168,13 +167,12 @@ void PracticeMenu::draw() const {
 }
 
 void PracticeMenu::draw_dialog() const {
-    float scale   = tex.screen_scale;
     float panel_w = tex.skin_config[SC::PRACTICE_MENU_PANEL].width;
     float panel_h = tex.skin_config[SC::PRACTICE_MENU_PANEL].height;
     float panel_x = (tex.screen_width - panel_w) / 2.0f;
     float panel_y = tex.skin_config[SC::PRACTICE_MENU_PANEL].y;
 
-    tex.draw_texture(PRACTICE::MENU_PANEL, {.scale = scale, .x = panel_x, .y = panel_y});
+    tex.draw_texture(PRACTICE::MENU_PANEL, {.x = panel_x, .y = panel_y});
 
     // The auto dialog stacks a label chip and the toggle row below its
     // title, so the title sits high; the yes/no confirms sit lower.
@@ -192,8 +190,7 @@ void PracticeMenu::draw_dialog() const {
         // Don chip above an ON | slider | OFF row, like the arcade's.
         float label_w = tex.skin_config[SC::PRACTICE_MENU_AUTO_LABEL].width;
         tex.draw_texture(PRACTICE::MENU_AUTO_LABEL,
-                         {.scale = scale,
-                          .x = panel_x + (panel_w - label_w) / 2.0f,
+                         {.x = panel_x + (panel_w - label_w) / 2.0f,
                           .y = panel_y + tex.skin_config[SC::PRACTICE_MENU_AUTO_LABEL].y});
         float tog_w = tex.skin_config[SC::PRACTICE_MENU_AUTO_TOGGLE].width;
         float gap   = tex.skin_config[SC::PRACTICE_MENU_AUTO_TOGGLE].x;
@@ -203,9 +200,8 @@ void PracticeMenu::draw_dialog() const {
         row_y   = panel_y + tex.skin_config[SC::PRACTICE_MENU_AUTO_TOGGLE].y;
         // The red knob slides toward whichever side is picked.
         tex.draw_texture(PRACTICE::MENU_TOGGLE,
-                         {.scale  = scale,
-                          .mirror = dialog_sel == 1 ? Mirror::HORIZONTAL : Mirror::NONE,
-                          .x = left_x + btn_w + gap, .y = row_y + 6 * scale});
+                         {.mirror = dialog_sel == 1 ? Mirror::HORIZONTAL : Mirror::NONE,
+                          .x = left_x + btn_w + gap, .y = row_y + 6 * tex.screen_scale});
     } else {
         left_x  = panel_x + tex.skin_config[SC::PRACTICE_MENU_DIALOG_BUTTON].x;
         right_x = panel_x + panel_w - tex.skin_config[SC::PRACTICE_MENU_DIALOG_BUTTON].x - btn_w;
@@ -213,9 +209,9 @@ void PracticeMenu::draw_dialog() const {
     }
 
     tex.draw_texture(dialog_sel == 0 ? PRACTICE::MENU_BUTTON_SELECTED : PRACTICE::MENU_BUTTON,
-                     {.scale = scale, .x = left_x, .y = row_y});
+                     {.x = left_x, .y = row_y});
     tex.draw_texture(dialog_sel == 1 ? PRACTICE::MENU_BUTTON_SELECTED : PRACTICE::MENU_BUTTON,
-                     {.scale = scale, .x = right_x, .y = row_y});
+                     {.x = right_x, .y = row_y});
 
     if (dlg_left)
         dlg_left->draw({.x = left_x + (btn_w - dlg_left->width) / 2.0f,


### PR DESCRIPTION
`PracticeMenu::draw` / `draw_dialog` pass `tex.screen_scale` as `draw_texture`'s `.scale`. But a texture's drawn size (`x2`/`y2`) is already multiplied by the skin scale at load, and `draw_texture` multiplies by `params.scale` on top — so this is a double scale. Invisible at 720p (scale = 1), but with a 1920x1080 skin the panel/bars/buttons/toggle render 2.25x too large (1.5x for a child skin's native-1080p art). All positions here come from `skin_config`, which is already in screen pixels, so simply dropping the extra factor puts the art back on its layout at every resolution.

Found while building a 1080p child skin; no behaviour change at the 720p base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)