### PR TITLE
cmake: make FetchContent patch commands portable to plain Windows

### DIFF
--- a/cmake/apply_git_patch.cmake
+++ b/cmake/apply_git_patch.cmake
@@ -1,0 +1,22 @@
+# Portable replacement for `git apply <patch> || true`: the `|| true` is a shell
+# idiom, and on Windows FetchContent runs PATCH_COMMAND through cmd.exe, where
+# `true` is not a command -- so the second populate (patch already applied,
+# git apply exits non-zero) failed the whole configure.
+#
+# Usage: ${CMAKE_COMMAND} -DPATCH_FILE=<abs path to .patch> -P apply_git_patch.cmake
+#
+# If the patch reverse-applies cleanly it is already in the tree: skip. A real
+# apply failure is reported as a warning, never a fatal error (matching the old
+# `|| true` behaviour -- the sol2 android patch is irrelevant on other targets).
+if(NOT DEFINED PATCH_FILE)
+    message(FATAL_ERROR "apply_git_patch.cmake needs -DPATCH_FILE=")
+endif()
+execute_process(COMMAND git apply --reverse --check "${PATCH_FILE}"
+                RESULT_VARIABLE _reversed OUTPUT_QUIET ERROR_QUIET)
+if(_reversed EQUAL 0)
+    return()   # already applied
+endif()
+execute_process(COMMAND git apply "${PATCH_FILE}" RESULT_VARIABLE _res ERROR_VARIABLE _err)
+if(NOT _res EQUAL 0)
+    message(WARNING "git apply ${PATCH_FILE} failed (ignored): ${_err}")
+endif()

--- a/cmake/deps.cmake
+++ b/cmake/deps.cmake
@@ -74,7 +74,7 @@ FetchContent_Declare(
   GIT_TAG        master
   GIT_SHALLOW    TRUE
   UPDATE_DISCONNECTED TRUE
-  PATCH_COMMAND sed -i "112a #include <ctype.h>                 // Required for: isalpha() [Used in IsPathFile()]" src/rcore.c || true
+  PATCH_COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_LIST_DIR}/patch_raylib_ctype.cmake
 )
 FetchContent_GetProperties(raylib)
 FetchContent_MakeAvailable(raylib)
@@ -119,7 +119,7 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/marovira/lua.git
     GIT_TAG 5.4.8
     GIT_SHALLOW TRUE
-    PATCH_COMMAND sed -i "s/cmake_minimum_required(VERSION 3\\.30)/cmake_minimum_required(VERSION 3.5)/" CMakeLists.txt || true
+    PATCH_COMMAND ${CMAKE_COMMAND} -DPATCH_FILE=CMakeLists.txt -DOLD_VERSION=3.30 -P ${CMAKE_CURRENT_LIST_DIR}/patch_min_cmake_version.cmake
 )
 FetchContent_MakeAvailable(lua)
 
@@ -130,8 +130,8 @@ FetchContent_Declare(
     GIT_REPOSITORY https://github.com/ThePhD/sol2.git
     GIT_TAG v3.5.0
     GIT_SHALLOW TRUE
-    PATCH_COMMAND git apply ${CMAKE_SOURCE_DIR}/cmake/patches/sol2-android-noexcept.patch || true
-        COMMAND sed -i "s/cmake_minimum_required(VERSION 3\\.26\\.0)/cmake_minimum_required(VERSION 3.5)/" CMakeLists.txt || true
+    PATCH_COMMAND ${CMAKE_COMMAND} -DPATCH_FILE=${CMAKE_SOURCE_DIR}/cmake/patches/sol2-android-noexcept.patch -P ${CMAKE_CURRENT_LIST_DIR}/apply_git_patch.cmake
+        COMMAND ${CMAKE_COMMAND} -DPATCH_FILE=CMakeLists.txt -DOLD_VERSION=3.26.0 -P ${CMAKE_CURRENT_LIST_DIR}/patch_min_cmake_version.cmake
 )
 FetchContent_MakeAvailable(sol2)
 
@@ -160,7 +160,7 @@ if(ANDROID OR EMSCRIPTEN OR WIN32)
       GIT_REPOSITORY https://github.com/xiph/ogg.git
       GIT_TAG v1.3.5
       GIT_SHALLOW TRUE
-      PATCH_COMMAND sed -i "s/cmake_minimum_required(VERSION 2\\.8\\.12)/cmake_minimum_required(VERSION 3.5)/" CMakeLists.txt || true
+      PATCH_COMMAND ${CMAKE_COMMAND} -DPATCH_FILE=CMakeLists.txt -DOLD_VERSION=2.8.12 -P ${CMAKE_CURRENT_LIST_DIR}/patch_min_cmake_version.cmake
   )
   FetchContent_MakeAvailable(ogg)
   set(OGG_INCLUDE_DIR "${ogg_SOURCE_DIR}/include" CACHE PATH "" FORCE)
@@ -171,7 +171,7 @@ if(ANDROID OR EMSCRIPTEN OR WIN32)
       GIT_REPOSITORY https://github.com/xiph/vorbis.git
       GIT_TAG v1.3.7
       GIT_SHALLOW TRUE
-      PATCH_COMMAND sed -i "s/cmake_minimum_required(VERSION 2\\.8\\.12)/cmake_minimum_required(VERSION 3.5)/" CMakeLists.txt || true
+      PATCH_COMMAND ${CMAKE_COMMAND} -DPATCH_FILE=CMakeLists.txt -DOLD_VERSION=2.8.12 -P ${CMAKE_CURRENT_LIST_DIR}/patch_min_cmake_version.cmake
   )
   FetchContent_MakeAvailable(vorbis)
   set(Vorbis_Vorbis_INCLUDE_DIR "${vorbis_SOURCE_DIR}/include" CACHE PATH "" FORCE)

--- a/cmake/patch_min_cmake_version.cmake
+++ b/cmake/patch_min_cmake_version.cmake
@@ -1,0 +1,18 @@
+# Portable replacement for the `sed -i "s/cmake_minimum_required(VERSION X)/...3.5)/" || true`
+# PATCH_COMMANDs. Those only work when a Unix toolchain is on PATH: FetchContent
+# runs PATCH_COMMAND through cmd.exe on Windows, where `sed` and `true` do not
+# exist, so the populate step fails the whole configure on a plain Windows host.
+#
+# Usage (working directory is the fetched source tree):
+#   ${CMAKE_COMMAND} -DPATCH_FILE=CMakeLists.txt -DOLD_VERSION=3.30 -P patch_min_cmake_version.cmake
+#
+# string(REPLACE) is a no-op when the pattern is absent, so re-running on an
+# already-patched tree is harmless -- same intent as the old `|| true`.
+if(NOT DEFINED PATCH_FILE OR NOT DEFINED OLD_VERSION)
+    message(FATAL_ERROR "patch_min_cmake_version.cmake needs -DPATCH_FILE= and -DOLD_VERSION=")
+endif()
+file(READ "${PATCH_FILE}" _content)
+string(REPLACE "cmake_minimum_required(VERSION ${OLD_VERSION})"
+               "cmake_minimum_required(VERSION 3.5)"
+               _content "${_content}")
+file(WRITE "${PATCH_FILE}" "${_content}")

--- a/cmake/patch_raylib_ctype.cmake
+++ b/cmake/patch_raylib_ctype.cmake
@@ -1,0 +1,28 @@
+# Portable replacement for `sed -i "112a #include <ctype.h> ..." src/rcore.c || true`.
+# Inserts the include after line 112 of src/rcore.c, exactly as the sed `112a`
+# command did, but with plain CMake so it works where PATCH_COMMAND runs under
+# cmd.exe (no sed, no `true`).
+#
+# Guarded on the include already being present, so re-running is a no-op --
+# and if a future raylib master already includes <ctype.h> itself, this
+# correctly does nothing at all.
+set(_line "#include <ctype.h>                 // Required for: isalpha() [Used in IsPathFile()]")
+file(READ src/rcore.c _content)
+string(FIND "${_content}" "#include <ctype.h>" _already)
+if(NOT _already EQUAL -1)
+    return()
+endif()
+# Find the offset just past the 112th newline.
+set(_offset 0)
+foreach(_i RANGE 1 112)
+    string(SUBSTRING "${_content}" ${_offset} -1 _rest)
+    string(FIND "${_rest}" "\n" _nl)
+    if(_nl EQUAL -1)
+        message(WARNING "src/rcore.c has fewer than 112 lines; ctype.h patch skipped")
+        return()
+    endif()
+    math(EXPR _offset "${_offset} + ${_nl} + 1")
+endforeach()
+string(SUBSTRING "${_content}" 0 ${_offset} _head)
+string(SUBSTRING "${_content}" ${_offset} -1 _tail)
+file(WRITE src/rcore.c "${_head}${_line}\n${_tail}")


### PR DESCRIPTION
`PATCH_COMMAND` runs through `cmd.exe` on Windows, where `sed` and `true` are not commands. All five patch steps (the raylib `ctype.h` insert, the lua/sol2/ogg/vorbis `cmake_minimum_required` bumps, and the sol2 android `git apply || true`) fail the whole configure on any host without MSYS/Git-Bash utilities on PATH:

```
'true' is not recognized as an internal or external command
CMake Error: Build step for lua failed: 1
```

CI never sees it because it builds on Linux.

Replaced with three `cmake -P` scripts (no shell involved, same semantics, idempotent like the old `|| true`):

- `cmake/patch_min_cmake_version.cmake` — literal `string(REPLACE)`, parameterised by `-DOLD_VERSION=`; used for lua (3.30), sol2 (3.26.0), ogg and vorbis (2.8.12)
- `cmake/patch_raylib_ctype.cmake` — the `sed 112a` insert, guarded on the include already being present (so it also does nothing if a future raylib master gains the include itself)
- `cmake/apply_git_patch.cmake` — `git apply` with a `--reverse --check` idempotence test first, and a warning instead of a failure on a real mismatch

Verified by a full fresh configure (every dependency fetched and patched from scratch) with only `mingw64\bin`, `system32` and Git on PATH — exit 0. The same tree fails at the first patch step without this change.

(The earlier second commit — a texture-name manifest for checkouts with missing skin submodules — has been dropped from this PR as agreed; a fully-initialised checkout does not need it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)