### PR TITLE
gauge: clear threshold is per-difficulty (6000/7000/8000), not a constant 8000

### DIFF
--- a/src/objects/game/gauge.cpp
+++ b/src/objects/game/gauge.cpp
@@ -4,6 +4,13 @@
 Gauge::Gauge(int total_notes, int difficulty, int level, PlayerNum player_num)
     : player_num(player_num) {
     this->difficulty = std::min((int)Difficulty::ONI, difficulty);
+    // The arcade's clear threshold depends on the difficulty: the clear zone
+    // begins at cell 30/35/40 of the 50-cell gauge (Easy/Normal/Hard+), i.e.
+    // 6000/7000/8000 of 10000. The rewrite drew it at 8000 for every course,
+    // which shifts the clear divider visibly on Easy and Normal.
+    clear_points = this->difficulty <= (int)Difficulty::EASY   ? 6000
+                 : this->difficulty == (int)Difficulty::NORMAL ? 7000
+                                                              : 8000;
     GaugeTable table_row = table[this->difficulty][std::min(9, level - 1)];
     good_points = (int)std::ceil(1000000 / (total_notes * table_row.soul_percent));
     ok_points   = (int)std::round(good_points * table_row.ok_multiplier);

--- a/src/objects/game/gauge.cpp
+++ b/src/objects/game/gauge.cpp
@@ -4,10 +4,6 @@
 Gauge::Gauge(int total_notes, int difficulty, int level, PlayerNum player_num)
     : player_num(player_num) {
     this->difficulty = std::min((int)Difficulty::ONI, difficulty);
-    // The arcade's clear threshold depends on the difficulty: the clear zone
-    // begins at cell 30/35/40 of the 50-cell gauge (Easy/Normal/Hard+), i.e.
-    // 6000/7000/8000 of 10000. The rewrite drew it at 8000 for every course,
-    // which shifts the clear divider visibly on Easy and Normal.
     clear_points = this->difficulty <= (int)Difficulty::EASY   ? 6000
                  : this->difficulty == (int)Difficulty::NORMAL ? 7000
                                                               : 8000;


### PR DESCRIPTION
The gauge rewrite (19e5536) hardcodes `clear_points = 8000`. On the cabinet the clear zone starts at cell 30/35/40 of 50 depending on difficulty - 6000/7000/8000 of 10000 - so on Easy and Normal courses the clear divider (and `get_is_clear()`) sits at the wrong place; visually the zone boundary is offset from where the skin art expects it. One-line-ish fix in the constructor, which already receives the difficulty. Matches our independent measurement of the reference cabinet's clear cells (30/35/40) made while porting the gauge art, and verified live at all three thresholds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)