### PR TITLE
gauge: fix soul gauge frozen on star-1 charts (and Dan Dojo), off-by-one table index

### DIFF
--- a/src/objects/game/gauge.cpp
+++ b/src/objects/game/gauge.cpp
@@ -4,7 +4,11 @@
 Gauge::Gauge(int total_notes, int difficulty, int level, PlayerNum player_num)
     : player_num(player_num) {
     this->difficulty = std::min((int)Difficulty::ONI, difficulty);
-    GaugeTable table_row = table[this->difficulty][std::min(9, level - 1)];
+    // `level` is the 1-based star rating; clamp the row index into [0, 9].
+    // Guards against the out-of-bounds table[diff][-1] read a ★1 chart used to
+    // trigger (garbage soul_percent -> div-by-zero -> INT_MIN good_points ->
+    // the gauge could never fill).
+    GaugeTable table_row = table[this->difficulty][std::clamp(level - 1, 0, 9)];
     good_points = (int)std::ceil(1000000 / (total_notes * table_row.soul_percent));
     ok_points   = (int)std::round(good_points * table_row.ok_multiplier);
     bad_points  = (int)std::round(good_points * table_row.bad_multiplier);

--- a/src/objects/game/gauge.cpp
+++ b/src/objects/game/gauge.cpp
@@ -4,10 +4,6 @@
 Gauge::Gauge(int total_notes, int difficulty, int level, PlayerNum player_num)
     : player_num(player_num) {
     this->difficulty = std::min((int)Difficulty::ONI, difficulty);
-    // `level` is the 1-based star rating; clamp the row index into [0, 9].
-    // Guards against the out-of-bounds table[diff][-1] read a ★1 chart used to
-    // trigger (garbage soul_percent -> div-by-zero -> INT_MIN good_points ->
-    // the gauge could never fill).
     GaugeTable table_row = table[this->difficulty][std::clamp(level - 1, 0, 9)];
     good_points = (int)std::ceil(1000000 / (total_notes * table_row.soul_percent));
     ok_points   = (int)std::round(good_points * table_row.ok_multiplier);

--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -666,7 +666,7 @@ void Player::reset_chart() {
         }
     }
     judgeable_note_count = gauge_total_notes;
-    gauge = Gauge(gauge_total_notes, difficulty, stars - 1, player_num);
+    gauge = Gauge(gauge_total_notes, difficulty, stars, player_num);
 
     //setup score
     base_score = 0;


### PR DESCRIPTION
`Player::reset_chart` passes `stars - 1` to the Gauge constructor, but the constructor treats `level` as 1-based and looks up `table[difficulty][min(9, level - 1)]`. So the effective index is `stars - 2`:

- **star-1 chart -> index -1**, an out-of-bounds `std::vector` read. The garbage `soul_percent` (0.0 in practice) makes `good_points = ceil(1000000 / (notes * 0.0))` overflow to INT_MIN, and `add_good()` clamps to 0 -- the gauge can never fill. Easy charts are commonly star-1, so that difficulty looks completely broken.
- **star-2..N -> off by one** (reads the row for one star lower, i.e. a slightly easier soul requirement than intended -- this also skews the clear check).
- **Dan Dojo** constructs `Gauge(..., 0, 0, ...)` and hits the same index -1.

Fix: pass the real 1-based `stars`, and defensively `std::clamp(level - 1, 0, 9)` in the constructor so a stray 0/negative can never index out of bounds again.

Reproduced with `--auto` on an Easy star-1 chart: before `idx=-1 soul=0.0 good=-2147483648` (stuck at 0); after `idx=0 soul=60.0 good=298` (fills normally).

Independent of #148 but also touches gauge.cpp -- they should merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)