### PR TITLE
gauge: 2P border frame, gauge-up sprite on the right cell, skin-driven cell count / fade-in

### DIFF
--- a/src/objects/game/gauge.cpp
+++ b/src/objects/game/gauge.cpp
@@ -64,7 +64,7 @@ void Gauge::draw(float y) {
     bool mirrored = y > tex.screen_height / 2.0f;
     Mirror mirror = mirrored ? Mirror::VERTICAL : Mirror::NONE;
 
-    tex.draw_texture(tex.get_enum("gauge/border" + string_diff), {.mirror = mirror, .y = y});
+    tex.draw_texture(tex.get_enum("gauge/border" + string_diff), {.mirror = mirror, .y = y, .index = mirrored});
 
     tex.draw_texture(tex.get_enum("gauge/" + (std::to_string((int)player_num) + "p_unfilled" + string_diff)),
                       {.mirror = mirror, .y = y, .index = mirrored});
@@ -75,20 +75,32 @@ void Gauge::draw(float y) {
     int clear_point = clear_points * bar_units / max_points;
     float bar_width  = tex.textures[tex.get_enum("gauge/" + std::to_string((int)player_num) + "p_bar")]->width;
 
-    tex.draw_texture(tex.get_enum("gauge/" + (std::to_string((int)player_num) + "p_bar")),
-                      {.y = y, .x2 = std::min(gauge_length_int * bar_width, (clear_point - 1) * bar_width) - bar_width, .index = mirrored});
+    // Skin option "gauge_cell_fade_in": the newest cell is not part of the solid
+    // bar while the gauge-up animation runs; it is shown by the fade sprite
+    // instead, whose alpha is inverted so the stock 1->0 flash becomes a 0->1
+    // fade-in of that cell. Off (default) keeps the flash overlay on a solid bar.
+    const bool cell_fade_in = tex.options[SCO::GAUGE_CELL_FADE_IN];
+    const bool cell_pending = gauge_length_int <= bar_units && gauge_length_int > previous_length_int
+                              && gauge_update_anim && gauge_update_anim->is_started && !gauge_update_anim->is_finished;
+    const int  solid_length = (cell_fade_in && cell_pending) ? gauge_length_int - 1 : gauge_length_int;
+    const float anim_alpha  = gauge_update_anim ? (float)gauge_update_anim->attribute : 0.0f;
+    const float cell_alpha  = cell_fade_in ? 1.0f - anim_alpha : anim_alpha;
 
-    if (gauge_length_int >= clear_point - 1)
+    if (solid_length > 0)
+        tex.draw_texture(tex.get_enum("gauge/" + (std::to_string((int)player_num) + "p_bar")),
+                          {.y = y, .x2 = std::min(solid_length * bar_width, (clear_point - 1) * bar_width) - bar_width, .index = mirrored});
+
+    if (solid_length >= clear_point - 1)
         tex.draw_texture(GAUGE::BAR_CLEAR_TRANSITION,
                           {.mirror = mirror, .x = (clear_point - 1) * bar_width, .y = y, .index = mirrored});
 
-    if (gauge_length_int > clear_point) {
+    if (solid_length > clear_point) {
         tex.draw_texture(GAUGE::BAR_CLEAR_TOP,
                           {.mirror = mirror, .x = clear_point * bar_width, .y = y,
-                           .x2 = (gauge_length_int - clear_point) * bar_width, .index = mirrored});
+                           .x2 = (solid_length - clear_point) * bar_width, .index = mirrored});
         tex.draw_texture(GAUGE::BAR_CLEAR_BOTTOM,
                           {.x = clear_point * bar_width, .y = y,
-                           .x2 = (gauge_length_int - clear_point) * bar_width, .index = mirrored});
+                           .x2 = (solid_length - clear_point) * bar_width, .index = mirrored});
     }
 
     if (get_is_rainbow() && rainbow_fade_in.has_value()) {
@@ -103,18 +115,21 @@ void Gauge::draw(float y) {
     }
 
     if (gauge_length_int <= bar_units && gauge_length_int > previous_length_int) {
+        // The gauge-up sprite belongs on the cell that was just filled (index
+        // gauge_length_int - 1), not on the empty cell after it.
+        const float fade_x = (gauge_length_int - 1) * bar_width;
         if (gauge_length_int == clear_point) {
             tex.draw_texture(GAUGE::BAR_CLEAR_TRANSITION_FADE,
-                              {.mirror = mirror, .x = gauge_length_int * bar_width, .y = y,
-                               .fade = gauge_update_anim->attribute, .index = mirrored});
+                              {.mirror = mirror, .x = fade_x, .y = y,
+                               .fade = cell_alpha, .index = mirrored});
         } else if (gauge_length_int > clear_point) {
             tex.draw_texture(GAUGE::BAR_CLEAR_FADE,
-                              {.x = gauge_length_int * bar_width, .y = y,
-                               .fade = gauge_update_anim->attribute, .index = mirrored});
+                              {.x = fade_x, .y = y,
+                               .fade = cell_alpha, .index = mirrored});
         } else {
             tex.draw_texture(tex.get_enum("gauge/" + (std::to_string((int)player_num) + "p_bar_fade")),
-                              {.x = gauge_length_int * bar_width, .y = y,
-                               .fade = gauge_update_anim->attribute, .index = mirrored});
+                              {.x = fade_x, .y = y,
+                               .fade = cell_alpha, .index = mirrored});
         }
     }
 

--- a/src/objects/game/gauge.cpp
+++ b/src/objects/game/gauge.cpp
@@ -1,4 +1,5 @@
 #include "gauge.h"
+#include <cmath>
 #include "../../libs/texture.h"
 
 Gauge::Gauge(int total_notes, int difficulty, int level, PlayerNum player_num)
@@ -69,7 +70,11 @@ void Gauge::draw(float y) {
     tex.draw_texture(tex.get_enum("gauge/" + (std::to_string((int)player_num) + "p_unfilled" + string_diff)),
                       {.mirror = mirror, .y = y, .index = mirrored});
 
-    constexpr int bar_units = 87;
+    // Cell count of the gauge art. Skins that ship a different grid (e.g. the
+    // cabinet's 50 x 21 px) declare it as skin_config "gauge_cells": {"x": N};
+    // the cell width always comes from the <n>p_bar texture.
+    const SkinInfo* cells_cfg = tex.skin_entry("gauge_cells");
+    const int bar_units = (cells_cfg && cells_cfg->x > 0) ? (int)std::lround(cells_cfg->x) : 87;
     int gauge_length_int = points * bar_units / max_points;
     int previous_length_int = previous_points * bar_units / max_points;
     int clear_point = clear_points * bar_units / max_points;

--- a/src/objects/game/gauge.cpp
+++ b/src/objects/game/gauge.cpp
@@ -70,9 +70,6 @@ void Gauge::draw(float y) {
     tex.draw_texture(tex.get_enum("gauge/" + (std::to_string((int)player_num) + "p_unfilled" + string_diff)),
                       {.mirror = mirror, .y = y, .index = mirrored});
 
-    // Cell count of the gauge art. Skins that ship a different grid (e.g. the
-    // cabinet's 50 x 21 px) declare it as skin_config "gauge_cells": {"x": N};
-    // the cell width always comes from the <n>p_bar texture.
     const SkinInfo* cells_cfg = tex.skin_entry("gauge_cells");
     const int bar_units = (cells_cfg && cells_cfg->x > 0) ? (int)std::lround(cells_cfg->x) : 87;
     int gauge_length_int = points * bar_units / max_points;
@@ -80,10 +77,6 @@ void Gauge::draw(float y) {
     int clear_point = clear_points * bar_units / max_points;
     float bar_width  = tex.textures[tex.get_enum("gauge/" + std::to_string((int)player_num) + "p_bar")]->width;
 
-    // Skin option "gauge_cell_fade_in": the newest cell is not part of the solid
-    // bar while the gauge-up animation runs; it is shown by the fade sprite
-    // instead, whose alpha is inverted so the stock 1->0 flash becomes a 0->1
-    // fade-in of that cell. Off (default) keeps the flash overlay on a solid bar.
     const bool cell_fade_in = tex.options[SCO::GAUGE_CELL_FADE_IN];
     const bool cell_pending = gauge_length_int <= bar_units && gauge_length_int > previous_length_int
                               && gauge_update_anim && gauge_update_anim->is_started && !gauge_update_anim->is_finished;
@@ -120,8 +113,6 @@ void Gauge::draw(float y) {
     }
 
     if (gauge_length_int <= bar_units && gauge_length_int > previous_length_int) {
-        // The gauge-up sprite belongs on the cell that was just filled (index
-        // gauge_length_int - 1), not on the empty cell after it.
         const float fade_x = (gauge_length_int - 1) * bar_width;
         if (gauge_length_int == clear_point) {
             tex.draw_texture(GAUGE::BAR_CLEAR_TRANSITION_FADE,


### PR DESCRIPTION
Three follow-ups to the gauge rewrite, found while porting the Nijiiro skin:

1. **2P border used the 1P frame.** `Gauge::draw` drew `border` with `.mirror` but without `.index = mirrored`, so on 2P the border sat at the 1P frame's y and its groove peeked out as a thin dark strip under the 2P gauge.
2. **Gauge-up sprite was one cell too far right.** `*_bar_fade` / `bar_clear_fade` / `bar_clear_transition_fade` were drawn at cell `len`, the empty cell after the fill, instead of the cell that was just filled (`len - 1`). It read as a half/extra cell.
3. **Skin-driven cell count.** `bar_units` was a constant 87; the cell count now comes from skin_config `"gauge_cells": {"x": N}` via `tex.skin_entry` (default 87, so PyTaikoGreen is unchanged). The Nijiiro art is a 50-cell / 21 px grid.
4. **SCO `gauge_cell_fade_in`** (default off = current flash on a solid bar). When on, the newest cell is left out of the solid bar while the gauge-up animation runs and the sprite's alpha is inverted, so the cell fades in. Option key: https://ese.tjadataba.se/Yonokid/PyTaikoGreen/pulls/4 — needs to land first, same as #150.

Verified on YataiDONNijiiro (fill edge on the 21 px grid, cell fading in, no stray strip under the 2P gauge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)