### PR TITLE
result: play the best-score voice when the total score lands

### DIFF
--- a/src/objects/result/player.cpp
+++ b/src/objects/result/player.cpp
@@ -145,7 +145,10 @@ void ResultPlayer::update_score_animation(double current_ms, bool is_skipped) {
         }
     }
     if (rows_done_ms == 0 && update_index >= (int)update_list.size()) rows_done_ms = current_ms;
-    if (update_index > 0 && !high_score_sound_played) {
+    // The best-score voice belongs to the "ベストスコア更新" banner, which the result
+    // scripts raise when the total-score row lands -- not when the first row (good) does.
+    // `score` is set the moment that row is assigned (count-up, instant, or skipped).
+    if (!score.empty() && !high_score_sound_played) {
         SessionData& sd = global_data.session_data[(int)player_num];
         if (sd.result_data.score > sd.result_data.prev_score) {
             audio.play_sound("high_score_voice_" + std::to_string((int)player_num) + "p", VolumePreset::VOICE);

--- a/src/objects/result/player.cpp
+++ b/src/objects/result/player.cpp
@@ -145,9 +145,6 @@ void ResultPlayer::update_score_animation(double current_ms, bool is_skipped) {
         }
     }
     if (rows_done_ms == 0 && update_index >= (int)update_list.size()) rows_done_ms = current_ms;
-    // The best-score voice belongs to the "ベストスコア更新" banner, which the result
-    // scripts raise when the total-score row lands -- not when the first row (good) does.
-    // `score` is set the moment that row is assigned (count-up, instant, or skipped).
     if (!score.empty() && !high_score_sound_played) {
         SessionData& sd = global_data.session_data[(int)player_num];
         if (sd.result_data.score > sd.result_data.prev_score) {


### PR DESCRIPTION
The best-score voice fired as soon as the first result row (good) finished counting (`update_index > 0`). The skins raise the ベストスコア更新 banner when the total-score row is assigned, so the voice now keys on `score` being set instead — count-up, instant and skipped paths all assign it at that point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)