### PR TITLE
network: probe the server once at boot and submit scores off the main thread

### DIFF
--- a/src/YataiDON.cpp
+++ b/src/YataiDON.cpp
@@ -410,7 +410,8 @@ int main(int argc, char* argv[]) {
     if (auto pd = scores_manager.get_player_data(scores_manager.player_2))
         scores_manager.player_2_data = *pd;
 
-    if (global_data.config->network.access_code.empty()) {
+    const bool net_ok = network.probe_online();
+    if (net_ok && global_data.config->network.access_code.empty()) {
         std::string access_code = network.register_user(scores_manager.player_1_data.username);
         if (!access_code.empty()) {
             global_data.config->network.access_code = access_code;
@@ -418,14 +419,14 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (!global_data.config->network.access_code.empty() &&
+    if (net_ok && !global_data.config->network.access_code.empty() &&
         network.check_import_requested(global_data.config->network.access_code)) {
         spdlog::info("hiroba requested a score import, exporting scores.db");
         scores_manager.export_to_hiroba(global_data.config->network.access_code, scores_manager.player_1);
         network.clear_import_flag(global_data.config->network.access_code);
     }
 
-    if (!global_data.config->network.access_code.empty()) {
+    if (net_ok && !global_data.config->network.access_code.empty()) {
         ray::Color chara_color_1, chara_color_2, chara_color_3;
         if (network.fetch_chara_colors(global_data.config->network.access_code, chara_color_1, chara_color_2, chara_color_3)) {
             scores_manager.player_1_data.chara_color_1 = chara_color_1;

--- a/src/libs/network.cpp
+++ b/src/libs/network.cpp
@@ -1,4 +1,5 @@
 #include "network.h"
+#include <thread>
 #include "scores.h"
 #include "color_utils.h"
 #include "global_data.h"
@@ -172,6 +173,19 @@ static std::string network_url(const std::string& endpoint) {
     std::string base = NETWORK_URL;
     while (!base.empty() && base.back() == '/') base.pop_back();
     return base + endpoint;
+}
+
+bool NetworkClient::probe_online() {
+    if (!network_enabled()) { online = false; return false; }
+    cpr::Response r = cpr::Get(
+        cpr::Url{network_url("/health")},
+        signed_headers("GET", "/health", {}),
+        cpr::Timeout{1500}
+        NETWORK_CA_OPT
+    );
+    online = (r.status_code == 200);
+    if (!online) spdlog::warn("Network: server unreachable at startup (HTTP {}), skipping profile sync", r.status_code);
+    return online;
 }
 
 void NetworkClient::check_heartbeat() {
@@ -435,35 +449,40 @@ void NetworkClient::submit_score(std::string& hash, int difficulty, const std::s
         {"drumroll", std::to_string(score.drumroll)},
         {"max_combo", std::to_string(score.max_combo)},
     };
-    cpr::Response response = cpr::Post(
-        cpr::Url{network_url("/submit_score")},
-        signed_headers("POST", "/submit_score", params),
-        cpr::Parameters{
-            {"access_code", params["access_code"]},
-            {"hash", params["hash"]},
-            {"difficulty", params["difficulty"]},
-            {"crown", params["crown"]},
-            {"rank", params["rank"]},
-            {"score", params["score"]},
-            {"good", params["good"]},
-            {"ok", params["ok"]},
-            {"bad", params["bad"]},
-            {"drumroll", params["drumroll"]},
-            {"max_combo", params["max_combo"]},
-        },
-        cpr::Payload{
-            {"input_log", map_to_json(input_log)},
-            {"played_at", played_at > 0 ? std::to_string(played_at) : ""},
-            {"modifiers", modifiers_json},
-            {"chara_is_costume", chara_is_costume ? "true" : "false"},
-            {"chara_cos_index", std::to_string(chara_cos_index)},
-        },
-        cpr::Timeout{5000}
-        NETWORK_CA_OPT
-    );
-    if (response.status_code != 200) {
-        spdlog::error("Failed to submit score: HTTP {} - {}", response.status_code, response.text);
-    }
+    // The upload runs off the render thread: a synchronous POST stalled the end of
+    // the song for up to the 5 s timeout whenever the server was unreachable.
+    std::thread([this, params = std::move(params), input_log = std::move(input_log), played_at,
+                 modifiers_json, chara_is_costume, chara_cos_index]() mutable {
+        cpr::Response response = cpr::Post(
+            cpr::Url{network_url("/submit_score")},
+            signed_headers("POST", "/submit_score", params),
+            cpr::Parameters{
+                {"access_code", params["access_code"]},
+                {"hash", params["hash"]},
+                {"difficulty", params["difficulty"]},
+                {"crown", params["crown"]},
+                {"rank", params["rank"]},
+                {"score", params["score"]},
+                {"good", params["good"]},
+                {"ok", params["ok"]},
+                {"bad", params["bad"]},
+                {"drumroll", params["drumroll"]},
+                {"max_combo", params["max_combo"]},
+            },
+            cpr::Payload{
+                {"input_log", map_to_json(input_log)},
+                {"played_at", played_at > 0 ? std::to_string(played_at) : ""},
+                {"modifiers", modifiers_json},
+                {"chara_is_costume", chara_is_costume ? "true" : "false"},
+                {"chara_cos_index", std::to_string(chara_cos_index)},
+            },
+            cpr::Timeout{5000}
+            NETWORK_CA_OPT
+        );
+        if (response.status_code != 200) {
+            spdlog::error("Failed to submit score: HTTP {} - {}", response.status_code, response.text);
+        }
+    }).detach();
 }
 
 void NetworkClient::poll_song_jump(const std::string& access_code) {

--- a/src/libs/network.h
+++ b/src/libs/network.h
@@ -55,6 +55,10 @@ public:
     bool fetch_title_bg(const std::string& access_code, int& title_bg);
 
     bool fetch_costume(const std::string& access_code, int& head_index, int& body_index, int& cos_index, bool& is_costume);
+    // One short synchronous /health round-trip. The boot-time sync fetches each wait
+    // out their 5 s timeout when the server is unreachable (20+ s of black screen
+    // offline); probe once and skip them all instead.
+    bool probe_online();
     void update_costume(const std::string& access_code, int head_index, int body_index, int cos_index, bool is_costume);
 
     void poll_song_jump(const std::string& access_code);


### PR DESCRIPTION
- Boot: a single 1.5 s /health probe decides whether register_user / import check / chara colours run at all. Offline, boot no longer stalls ~20 s on each request timing out in turn.
- Results: submit_score runs its request on a detached thread, so a failing submit (offline) no longer freezes the result screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)