### PR TITLE
hud: per-speed modifier badges on a skin-defined grid

### DIFF
--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -3,6 +3,8 @@
 #include "../../libs/input.h"
 #include "../../libs/scores.h"
 #include <algorithm>
+#include <optional>
+#include <vector>
 #include <cmath>
 
 Player::Player(std::optional<SongParser>& parser_ref, PlayerNum player_num_param, int difficulty_param,
@@ -1535,29 +1537,61 @@ void Player::draw_modifiers(float y) {
         return y + tex.skin_config[SC::SCORE_COUNTER_2P_Y_OFFSET].y
                  + cover_h - icon_h - 2.0f * json_y;
     };
+    auto has = [&](uint32_t id) { return tex.textures.find(id) != tex.textures.end(); };
+
+    // Badge for the current speed: the cabinet has one per value (x1.1 .. x4);
+    // fall back to the three coarse tiers when the skin does not ship them.
+    auto speed_badge = [&]() -> std::optional<uint32_t> {
+        if (modifiers.speed <= 10) return std::nullopt;
+        static const std::pair<int, const char*> labels[] = {
+            {11, "x1_1"}, {12, "x1_2"}, {13, "x1_3"}, {14, "x1_4"}, {15, "x1_5"}, {16, "x1_6"},
+            {17, "x1_7"}, {18, "x1_8"}, {19, "x1_9"}, {20, "x2"},   {25, "x2_5"}, {30, "x3"},
+            {35, "x3_5"}, {40, "x4"}};
+        const char* label = labels[0].second;
+        for (const auto& [v, l] : labels) if (modifiers.speed >= v) label = l;
+        uint32_t id = tex.get_enum(std::string("lane/mod_speed_") + label);
+        if (has(id)) return id;
+        if (modifiers.speed >= 40) return (uint32_t)LANE::MOD_YONBAI;
+        if (modifiers.speed >= 30) return (uint32_t)LANE::MOD_SANBAI;
+        return (uint32_t)LANE::MOD_BAISAKU;
+    };
+
+    // Cabinet order: speed, doron, abekobe, random.
+    std::vector<uint32_t> badges;
+    if (auto sb = speed_badge()) badges.push_back(*sb);
+    if (modifiers.display) badges.push_back(LANE::MOD_DORON);
+    if (modifiers.inverse) badges.push_back(LANE::MOD_ABEKOBE);
+    if (modifiers.random == 2) badges.push_back(LANE::MOD_DETARAME);
+    else if (modifiers.random == 1) badges.push_back(LANE::MOD_KIMAGURE);
+
+    const SkinInfo* grid = tex.skin_entry("mod_badge_grid");
+    if (grid && grid->width > 0) {
+        // Sequential slots on the skin's grid (columns in font_size, default 3).
+        const int cols = grid->font_size > 0 ? grid->font_size : 3;
+        int slot = 0;
+        for (uint32_t id : badges) {
+            if (!has(id)) continue;
+            const float gx = grid->x + (slot % cols) * grid->width;
+            const float gy = grid->y + (slot / cols) * grid->height;
+            float by = y + gy;
+            if (is_2p) {
+                float cover_h = (float)tex.textures[LANE::LANE_SCORE_COVER]->y2[0];
+                float icon_h  = (float)tex.textures[id]->y2[0];
+                by = y + tex.skin_config[SC::SCORE_COUNTER_2P_Y_OFFSET].y + cover_h - icon_h - 2.0f * gy;
+            }
+            tex.draw_texture(id, {.x = gx - (float)tex.textures[id]->x[0], .y = by - (float)tex.textures[id]->y[0]});
+            slot++;
+        }
+        if (score_method == ScoreMethod::SHINUCHI && has(LANE::MOD_SHINUCHI))
+            tex.draw_texture(LANE::MOD_SHINUCHI, {.y = icon_y(LANE::MOD_SHINUCHI)});
+        return;
+    }
 
     if (score_method == ScoreMethod::SHINUCHI) {
         tex.draw_texture(LANE::MOD_SHINUCHI, {.y=icon_y(LANE::MOD_SHINUCHI)});
     }
-
-    if (modifiers.speed >= 40) {
-        tex.draw_texture(LANE::MOD_YONBAI, {.y=icon_y(LANE::MOD_YONBAI)});
-    } else if (modifiers.speed >= 30) {
-        tex.draw_texture(LANE::MOD_SANBAI, {.y=icon_y(LANE::MOD_SANBAI)});
-    } else if (modifiers.speed > 10) {
-        tex.draw_texture(LANE::MOD_BAISAKU, {.y=icon_y(LANE::MOD_BAISAKU)});
-    }
-
-    if (modifiers.display) {
-        tex.draw_texture(LANE::MOD_DORON, {.y=icon_y(LANE::MOD_DORON)});
-    }
-    if (modifiers.inverse) {
-        tex.draw_texture(LANE::MOD_ABEKOBE, {.y=icon_y(LANE::MOD_ABEKOBE)});
-    }
-    if (modifiers.random == 2) {
-        tex.draw_texture(LANE::MOD_DETARAME, {.y=icon_y(LANE::MOD_DETARAME)});
-    } else if (modifiers.random == 1) {
-        tex.draw_texture(LANE::MOD_KIMAGURE, {.y=icon_y(LANE::MOD_KIMAGURE)});
+    for (uint32_t id : badges) {
+        if (has(id)) tex.draw_texture(id, {.y = icon_y(id)});
     }
 }
 


### PR DESCRIPTION
Player::draw_modifiers can lay the active badges out sequentially on a grid the skin declares as skin_config "mod_badge_grid" {x, y, width = column pitch, height = row pitch, font_size = columns}; without the entry the per-texture anchors (the existing look) are used. It also prefers one badge per speed value (lane/mod_speed_x1_1 .. mod_speed_x4) when the skin ships them, falling back to the baisaku / sanbai / yonbai tiers. The Nijiiro skin uses this for its 3 x 2 badge block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)