### PR TITLE
practice: keep the lyric at its normal position, drawn over the large drums

### DIFF
--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -1634,22 +1634,17 @@ void Player::draw_overlays(float y, const ray::Shader& mask_shader) {
     for (ScoreCounterAnimation& anim : base_score_list) {
         anim.draw(y);
     }
-    if (current_lyric.has_value()) {
-        const SkinInfo* lyric_cfg = tex.skin_entry("lyric");
-        float lyric_y = (lyric_cfg && lyric_cfg->y > 0) ? lyric_cfg->y
-                                                        : static_cast<float>(tex.screen_height - (int)(current_lyric->height*1.5));
-        if (practice_lyric) {
-            const SkinInfo* pcfg = tex.skin_entry("lyric_practice");
-            if (pcfg && pcfg->y > 0) {
-                lyric_y = pcfg->y;
-            } else {
-                auto drum = tex.textures.find((uint32_t)PRACTICE::LARGE_DRUM);
-                if (drum != tex.textures.end() && !drum->second->y.empty())
-                    lyric_y = drum->second->y[0] - current_lyric->height - 8.0f * tex.screen_scale;
-            }
-        }
-        current_lyric->draw({.x=(int)(tex.screen_width/2) - current_lyric->width/2, .y=lyric_y});
-    }
+    // Practice mode draws the lyric itself, after the large drums, so it is not hidden.
+    if (!practice_lyric) draw_lyric(y);
+}
+
+void Player::draw_lyric(float y) {
+    (void)y;
+    if (!current_lyric.has_value()) return;
+    const SkinInfo* lyric_cfg = tex.skin_entry("lyric");
+    float lyric_y = (lyric_cfg && lyric_cfg->y > 0) ? lyric_cfg->y
+                                                    : static_cast<float>(tex.screen_height - (int)(current_lyric->height*1.5));
+    current_lyric->draw({.x=(int)(tex.screen_width/2) - current_lyric->width/2, .y=lyric_y});
 }
 
 void Player::seek_to(double resume_time) {

--- a/src/objects/game/player.h
+++ b/src/objects/game/player.h
@@ -102,6 +102,8 @@ public:
 
     void draw_practice(double ms_from_start, float x, float y, ray::Shader& mask_shader, bool draw_notes_on);
 
+    void draw_lyric(float y);   // practice scene draws it after the large drums
+
     void draw_overlays(float y, const ray::Shader& mask_shader);
     void draw_lane_cover(float y);
 
@@ -168,7 +170,7 @@ private:
     int balloon_index;
 
     std::optional<OutlinedText> current_lyric;
-    bool practice_lyric = false;   // set once draw_practice runs: lyric moves above the practice drums
+    bool practice_lyric = false;   // set once draw_practice runs: the practice scene draws the lyric itself (over the drums)
 
     bool is_branch;
     std::tuple<float, float, double> curr_branch_reqs;

--- a/src/scenes/game_practice.cpp
+++ b/src/scenes/game_practice.cpp
@@ -495,6 +495,8 @@ void PracticeGameScreen::draw() {
     if (!paused) {
         tex.draw_texture(PRACTICE::PLAYING, {.fade = 0.5, .index = (int)global_data.player_num - 1});
     }
+    // lyric stays at its normal position but on top of the large drums
+    if (!players.empty()) players[0]->draw_lyric(184 * tex.screen_scale);
 
     // Progress bar
     tex.draw_texture(PRACTICE::PROGRESS_BAR_BG, {});


### PR DESCRIPTION
Follow-up to #151: rather than moving the lyric above the practice drums, keep it exactly where it sits in normal play and let the practice scene draw it after the large drums, so it is on top of them instead of hidden. Player::draw_lyric() is the shared draw; the practice scene calls it after its PLAYING plate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)