### PR TITLE
song select: the back box (and the screen behind it) take the folder's genre

### DIFF
--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -519,7 +519,7 @@ void Navigator::parse_song_list(const fs::path& path, BoxDef box_def, bool inlin
         auto box = make_song_box(final_path, box_def, SongParser(final_path));
         box->preserve_order = true;
         if (songs_added > 0 && songs_added % 10 == 0)
-            { BoxDef folder = parse_box_def(path.parent_path()); enqueue_inline_box(make_back_box(path.parent_path().parent_path(), &folder)); }
+            enqueue_inline_box(make_back_box(path.parent_path().parent_path(), &inline_back_def));
         if (inline_mode)
             enqueue_inline_box(std::move(box));
         else
@@ -722,7 +722,7 @@ void Navigator::load_collection_new(const fs::path& path, const BoxDef& box_def)
                     last_write - std::filesystem::file_time_type::clock::now());
             if (last_write_sys < two_weeks_ago) continue;
             if (songs_added > 0 && songs_added % 10 == 0)
-                enqueue_inline_box(make_back_box(path.parent_path()));
+                enqueue_inline_box(make_back_box(path.parent_path(), &inline_back_def));
             auto song = make_song_box(entry.path(), box_def, SongParser(entry.path()));
             apply_song_genre(song.get(), sibling_box_def);
             song->fade_in(266);
@@ -774,7 +774,7 @@ void Navigator::load_collection_difficulty(const fs::path& path, const BoxDef& b
     for (const auto& h : hits) {
         if (abort_loading) break;
         if (songs_added > 0 && songs_added % 10 == 0)
-            enqueue_inline_box(make_back_box(path.parent_path()));
+            enqueue_inline_box(make_back_box(path.parent_path(), &inline_back_def));
         SongParser parser(h.path);
         parser.get_metadata();
         auto song = make_song_box(h.path, box_def, parser);
@@ -813,7 +813,7 @@ void Navigator::load_from_song_list(const fs::path& path, const BoxDef& box_def,
             song_path = it->second;
         }
         if (songs_added > 0 && songs_added % 10 == 0)
-            enqueue_inline_box(make_back_box(path.parent_path()));
+            enqueue_inline_box(make_back_box(path.parent_path(), &inline_back_def));
         auto song = make_song_box(song_path, box_def, SongParser(song_path));
         song->preserve_order = true;
         if (mark_favorite) song->is_favorite = true;
@@ -950,7 +950,7 @@ void Navigator::load_collection_search(const fs::path& path, const BoxDef& box_d
         std::transform(title.begin(), title.end(), title.begin(), ::tolower);
         if (title.find(query) == std::string::npos) continue;
         if (songs_added > 0 && songs_added % 10 == 0)
-            enqueue_inline_box(make_back_box(path.parent_path()));
+            enqueue_inline_box(make_back_box(path.parent_path(), &inline_back_def));
         auto song = make_song_box(song_path, box_def, SongParser(song_path));
         fs::path genre_folder = find_box_def_folder(song_path);
         if (!genre_folder.empty())
@@ -977,7 +977,7 @@ void Navigator::load_songs_inline_async(const fs::path path, BoxDef box_def) {
 
     auto add_song = [&](const fs::path& song_path) {
         if (songs_added > 0 && songs_added % 10 == 0)
-            enqueue_inline_box(make_back_box(path.parent_path()));
+            enqueue_inline_box(make_back_box(path.parent_path(), &inline_back_def));
         auto box = make_song_box(song_path, box_def, take_parser(preparsed, song_path));
         box->fade_in(266);
         enqueue_inline_box(std::move(box));
@@ -1455,6 +1455,8 @@ void Navigator::setup_back_box(const fs::path& path, bool has_children, const Ba
         if (from->back_color) folder.back_color = from->back_color;
         if (from->fore_color) folder.fore_color = from->fore_color;
     }
+    // the loaders repeat a back box every ten songs; those wear the same genre
+    inline_back_def = folder;
     if (has_children) {
         if (!reloading_roots) items.clear();
         if (std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end())
@@ -1618,7 +1620,7 @@ bool Navigator::load_gen4_genre_songs(const fs::path& path, const BoxDef& box_de
         std::error_code ec;
         if (!fs::is_directory(song_folder, ec)) continue;
         if (songs_added > 0 && songs_added % 10 == 0)
-            enqueue_inline_box(make_back_box(data_root));
+            enqueue_inline_box(make_back_box(data_root, &inline_back_def));
         auto box = make_song_box(song_folder, def, SongParser(song_folder));
         box->preserve_order = true;
         box->fade_in(266);
@@ -1731,7 +1733,7 @@ bool Navigator::load_gen3_genre_songs(const fs::path& path, const BoxDef& box_de
         std::error_code ec;
         if (!fs::is_directory(song_folder, ec)) continue;
         if (songs_added > 0 && songs_added % 10 == 0)
-            enqueue_inline_box(make_back_box(data_root));
+            enqueue_inline_box(make_back_box(data_root, &inline_back_def));
         auto box = make_song_box(song_folder, def, SongParser(song_folder));
         // The file's own order is the game's order.
         box->preserve_order = true;

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -55,19 +55,15 @@ static SongParser take_parser(std::unordered_map<std::string, std::unique_ptr<So
     return SongParser(path);
 }
 
-// The back box closes a folder, so it wears that folder's genre (colour / board
-// frame) like the cabinet's もどる panel; without a folder def it stays Namco orange.
+// The back box closes a folder, so it carries that folder's genre: the genre
+// background behind the cursor (and a skin's board frame) follow it, like the
+// cabinet's もどる panel.  The box itself keeps its own colour.
 static std::unique_ptr<BackBox> make_back_box(const fs::path& parent_path, const BoxDef* folder = nullptr) {
     BoxDef d;
     d.back_color    = BackBox::COLOR;
     d.fore_color    = BackBox::COLOR;
     d.texture_index = TextureIndex::NONE;
-    d.genre_index   = GenreIndex::NAMCO;
-    if (folder) {
-        d.genre_index = folder->genre_index;
-        if (folder->back_color) d.back_color = folder->back_color;
-        if (folder->fore_color) d.fore_color = folder->fore_color;
-    }
+    d.genre_index   = folder ? folder->genre_index : GenreIndex::NAMCO;
     return std::make_unique<BackBox>(parent_path, d);
 }
 
@@ -1450,11 +1446,7 @@ void Navigator::setup_back_box(const fs::path& path, bool has_children, const Ba
         for (auto& b : items)
             if (b && b->path == path) { from = b.get(); break; }
     BoxDef folder = parse_box_def(path);
-    if (from) {
-        folder.genre_index = from->genre_index;
-        if (from->back_color) folder.back_color = from->back_color;
-        if (from->fore_color) folder.fore_color = from->fore_color;
-    }
+    if (from) folder.genre_index = from->genre_index;
     // the loaders repeat a back box every ten songs; those wear the same genre
     inline_back_def = folder;
     if (has_children) {

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -1404,7 +1404,7 @@ bool Navigator::jump_to_song_path(const fs::path& song_path) {
         pending_inline_folder  = folder_box;
         inline_state           = std::move(state);
 
-        setup_back_box(final_folder, false);
+        setup_back_box(final_folder, false, folder_box);
         genre_bg.emplace(folder_box->text_name, folder_box->back_color, folder_box->texture_index, 1000.0f);
 
         loading_complete = false;
@@ -1442,15 +1442,25 @@ bool Navigator::jump_to_song_path(const fs::path& song_path) {
     return true;
 }
 
-void Navigator::setup_back_box(const fs::path& path, bool has_children) {
+void Navigator::setup_back_box(const fs::path& path, bool has_children, const BaseBox* from) {
+    // The box that opened this folder is the authority on its genre and colours: a
+    // folder without box.def gets them from its name or the gen3/gen4 tables, which
+    // parse_box_def(path) alone does not see.
+    if (!from)
+        for (auto& b : items)
+            if (b && b->path == path) { from = b.get(); break; }
+    BoxDef folder = parse_box_def(path);
+    if (from) {
+        folder.genre_index = from->genre_index;
+        if (from->back_color) folder.back_color = from->back_color;
+        if (from->fore_color) folder.fore_color = from->fore_color;
+    }
     if (has_children) {
         if (!reloading_roots) items.clear();
         if (std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end())
             return;
-        BoxDef folder = parse_box_def(path);
         items.push_back(make_back_box(path.parent_path(), &folder));
     } else {
-        BoxDef folder = parse_box_def(path);
         auto back = make_back_box(path.parent_path(), &folder);
         back->fade_in(266);
         items.erase(items.begin() + open_index);

--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -55,12 +55,19 @@ static SongParser take_parser(std::unordered_map<std::string, std::unique_ptr<So
     return SongParser(path);
 }
 
-static std::unique_ptr<BackBox> make_back_box(const fs::path& parent_path) {
+// The back box closes a folder, so it wears that folder's genre (colour / board
+// frame) like the cabinet's もどる panel; without a folder def it stays Namco orange.
+static std::unique_ptr<BackBox> make_back_box(const fs::path& parent_path, const BoxDef* folder = nullptr) {
     BoxDef d;
     d.back_color    = BackBox::COLOR;
     d.fore_color    = BackBox::COLOR;
     d.texture_index = TextureIndex::NONE;
     d.genre_index   = GenreIndex::NAMCO;
+    if (folder) {
+        d.genre_index = folder->genre_index;
+        if (folder->back_color) d.back_color = folder->back_color;
+        if (folder->fore_color) d.fore_color = folder->fore_color;
+    }
     return std::make_unique<BackBox>(parent_path, d);
 }
 
@@ -512,7 +519,7 @@ void Navigator::parse_song_list(const fs::path& path, BoxDef box_def, bool inlin
         auto box = make_song_box(final_path, box_def, SongParser(final_path));
         box->preserve_order = true;
         if (songs_added > 0 && songs_added % 10 == 0)
-            enqueue_inline_box(make_back_box(path.parent_path().parent_path()));
+            { BoxDef folder = parse_box_def(path.parent_path()); enqueue_inline_box(make_back_box(path.parent_path().parent_path(), &folder)); }
         if (inline_mode)
             enqueue_inline_box(std::move(box));
         else
@@ -1440,9 +1447,11 @@ void Navigator::setup_back_box(const fs::path& path, bool has_children) {
         if (!reloading_roots) items.clear();
         if (std::find(root_paths.begin(), root_paths.end(), path) != root_paths.end())
             return;
-        items.push_back(make_back_box(path.parent_path()));
+        BoxDef folder = parse_box_def(path);
+        items.push_back(make_back_box(path.parent_path(), &folder));
     } else {
-        auto back = make_back_box(path.parent_path());
+        BoxDef folder = parse_box_def(path);
+        auto back = make_back_box(path.parent_path(), &folder);
         back->fade_in(266);
         items.erase(items.begin() + open_index);
         items.insert(items.begin() + open_index, std::move(back));

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -40,6 +40,7 @@ private:
     std::optional<InlineState>  inline_state;
     std::optional<fs::path>     pending_inline_path;
     FolderBox*                  pending_inline_folder = nullptr;
+    BoxDef                      inline_back_def;      // genre/colours for the repeated back boxes of the open folder
     BoxDef                      pending_inline_box_def;
     bool is_inline = false;
 

--- a/src/objects/song_select/file_navigator/navigator.h
+++ b/src/objects/song_select/file_navigator/navigator.h
@@ -95,7 +95,9 @@ private:
     bool load_gen4_genre_songs(const fs::path& genre_path, const BoxDef& box_def);
     bool has_def_file(const std::filesystem::path& path);
     fs::path find_box_def_folder(const fs::path& song_path);
-    void setup_back_box(const fs::path& path, bool has_children);
+    // `from`: the box that opened the folder, when the caller still has it; otherwise the
+    // matching FolderBox is looked up in `items` before they are cleared.
+    void setup_back_box(const fs::path& path, bool has_children, const BaseBox* from = nullptr);
     bool has_child_folders(const fs::path& path);
 
     void wait_for_song_files();


### PR DESCRIPTION
When the cursor sits on a back box (もどる / とじる) the genre background behind it dropped to the Namco orange, because the back box was built with `GenreIndex::NAMCO` regardless of the folder it closes. The box itself is unchanged: it keeps its own colour in the default skin.

- `make_back_box` takes the opening folder's def and carries its `genre_index` only, so the genre background (and a skin's board frame, which reads `genre_frame()`) follow the folder.
- `setup_back_box` looks up the box that opened the folder for the genre, since a folder without box.def gets its genre from its name or the gen3/gen4 tables, which `parse_box_def` alone does not see.
- The back boxes the loaders repeat every ten songs (recent / difficulty / song list / recommended / search / gen3 / gen4 paths) reuse the same resolved def, so they no longer fall back to orange either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)