### PR TITLE
game: let the skin draw the ending banner

### DIFF
--- a/src/objects/game/background.cpp
+++ b/src/objects/game/background.cpp
@@ -36,6 +36,8 @@ Background::Background(PlayerNum player_num, float bpm, const std::string& scene
         fn_handle_song_end = lua_object["handle_song_end"];
         fn_handle_dan      = lua_object["handle_dan"];
         fn_handle_skip     = lua_object["handle_skip"];
+        fn_handle_ending   = lua_object["handle_ending"];
+        fn_draw_ending     = lua_object["draw_ending"];
         fn_draw_back     = lua_object["draw_back"];
         fn_draw_fore     = lua_object["draw_fore"];
         fn_draw_gauge    = lua_object["draw_gauge"];
@@ -126,6 +128,24 @@ void Background::handle_dan(PlayerNum player_num, const sol::table& state) {
     if (!result.valid()) {
         sol::error err = result;
         spdlog::error("Error calling handle_dan: {}", err.what());
+    }
+}
+
+void Background::handle_ending(PlayerNum player_num, const std::string& kind) {
+    if (!fn_handle_ending.valid()) return;
+    auto result = fn_handle_ending(lua_object, static_cast<int>(player_num), kind);
+    if (!result.valid()) {
+        sol::error err = result;
+        spdlog::error("Error calling handle_ending: {}", err.what());
+    }
+}
+
+void Background::draw_ending(PlayerNum player_num) {
+    if (!fn_draw_ending.valid()) return;
+    auto result = fn_draw_ending(lua_object, static_cast<int>(player_num));
+    if (!result.valid()) {
+        sol::error err = result;
+        spdlog::error("Error calling draw_ending: {}", err.what());
     }
 }
 

--- a/src/objects/game/background.h
+++ b/src/objects/game/background.h
@@ -14,6 +14,8 @@ private:
     sol::protected_function fn_handle_song_end;
     sol::protected_function fn_handle_dan;
     sol::protected_function fn_handle_skip;
+    sol::protected_function fn_handle_ending;
+    sol::protected_function fn_draw_ending;
     sol::protected_function fn_draw_back;
     sol::protected_function fn_draw_fore;
     sol::protected_function fn_draw_gauge;
@@ -35,6 +37,12 @@ public:
     bool wants_dan() const { return fn_handle_dan.valid(); }
     void handle_skip(PlayerNum player_num, const sol::table& state);
     bool wants_skip() const { return fn_handle_skip.valid(); }
+    // Ending banner (clear / full combo / donderful / fail): a skin that defines both
+    // handle_ending(player_num, kind) and draw_ending(player_num) draws it itself; the
+    // engine keeps running its own animation for the sounds but skips its drawing.
+    void handle_ending(PlayerNum player_num, const std::string& kind);
+    void draw_ending(PlayerNum player_num);
+    bool wants_ending() const { return fn_handle_ending.valid() && fn_draw_ending.valid(); }
     void draw_back();
     void draw_fore();
 

--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -81,20 +81,27 @@ ResultData Player::get_result_score() {
     return result;
 }
 
-void Player::spawn_ending_anim() {
+void Player::spawn_ending_anim(Background* background) {
+    ending_background = background;
     if (skipped_run) {
         ending_anim.reset();
         return;
     }
     if (!gauge.has_value() && !dan_gauge) return;
     bool is_clear = dan_gauge ? dan_gauge->get_is_clear() : gauge->get_is_clear();
+    const char* kind;
     if (!is_clear) {
         ending_anim = FailAnimation(is_2p);
+        kind = "fail";
     } else if (bad_count == 0) {
         ending_anim = FCAnimation(is_2p, ok_count == 0);
+        kind = (ok_count == 0) ? "donderful" : "full_combo";
     } else {
         ending_anim = ClearAnimation(is_2p);
+        kind = "clear";
     }
+    if (ending_background && ending_background->wants_ending())
+        ending_background->handle_ending(player_num, kind);
 }
 
 void Player::reload_for_dan(std::optional<SongParser>& new_parser, int new_difficulty) {
@@ -1577,7 +1584,10 @@ void Player::draw_lane_cover(float y) {
 void Player::draw_overlays(float y, const ray::Shader& mask_shader) {
     tex.draw_texture(LANE::DRUM, {.y=y});
     if (ending_anim.has_value()) {
-        std::visit([](auto& anim) { anim.draw(); }, ending_anim.value());
+        if (ending_background && ending_background->wants_ending())
+            ending_background->draw_ending(player_num);
+        else
+            std::visit([](auto& anim) { anim.draw(); }, ending_anim.value());
     }
 
     for (auto& anim : draw_drum_hit_list) {

--- a/src/objects/game/player.h
+++ b/src/objects/game/player.h
@@ -92,7 +92,7 @@ public:
 
     void reload_for_dan(std::optional<SongParser>& new_parser, int new_difficulty);
 
-    void spawn_ending_anim();
+    void spawn_ending_anim(Background* background = nullptr);
 
     void seek_to(double resume_time);
 
@@ -168,6 +168,7 @@ private:
     int balloon_index;
 
     std::optional<OutlinedText> current_lyric;
+    Background* ending_background = nullptr;   // skin ending hook target, set by spawn_ending_anim
     bool practice_lyric = false;   // set once draw_practice runs: lyric moves above the practice drums
 
     bool is_branch;

--- a/src/scenes/game.cpp
+++ b/src/scenes/game.cpp
@@ -422,7 +422,7 @@ void GameScreen::end_song() {
         global_data.session_data[(int)players[0]->player_num].result_data = players[0]->get_result_score();
         save_score(global_data.config->general.player_1_id, players[0]->player_num);
         for (auto& player : players) {
-            player->spawn_ending_anim();
+            player->spawn_ending_anim(background.has_value() ? &*background : nullptr);
             if (background.has_value()) {
                 int g = player->get_good(), o = player->get_ok(), b = player->get_bad();
                 background->handle_song_end(player->player_num, g, o, b, g + o + b);

--- a/src/scenes/game_2p.cpp
+++ b/src/scenes/game_2p.cpp
@@ -75,7 +75,7 @@ std::optional<Screens> Game2PScreen::update() {
             save_score(get_player_id(PlayerNum::P1), PlayerNum::P1);
             save_score(get_player_id(PlayerNum::P2), PlayerNum::P2);
             for (int i = 0; i < 2; i++) {
-                players[i]->spawn_ending_anim();
+                players[i]->spawn_ending_anim(background.has_value() ? &*background : nullptr);
             }
             global_data.songs_played += 1;
             score_saved = true;

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -505,7 +505,7 @@ std::optional<Screens> DanGameScreen::update() {
             if (ms_from_start >= players[0]->end_time + 1000 && !score_saved) {
                 check_exam_failures(true, true);
                 save_result_data(false);
-                players[0]->spawn_ending_anim();
+                players[0]->spawn_ending_anim(background.has_value() ? &*background : nullptr);
                 score_saved = true;
             }
             constexpr double SKIP_RESULT_DELAY = 2800.0;


### PR DESCRIPTION
A skin that defines `Background:handle_ending(player_num, kind)` and `Background:draw_ending(player_num)` draws the end-of-song banner itself; `kind` is one of `clear`, `full_combo`, `donderful`, `fail`. The engine keeps its own ending animation running (it still owns the sounds and their timing) but skips its drawing while the skin handles it. Skins without the hooks are unaffected.

`Player::spawn_ending_anim` takes the scene's background so the player can reach the hooks from its overlay draw; the three call sites (game, 2P, dan) pass it.

The Nijiiro skin uses this to replay the arcade's ending clips (banner text, fans, characters) frame by frame instead of a static plate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)