### PR TITLE
game: report the running score to the skin

### DIFF
--- a/src/objects/game/background.cpp
+++ b/src/objects/game/background.cpp
@@ -36,6 +36,7 @@ Background::Background(PlayerNum player_num, float bpm, const std::string& scene
         fn_handle_song_end = lua_object["handle_song_end"];
         fn_handle_dan      = lua_object["handle_dan"];
         fn_handle_skip     = lua_object["handle_skip"];
+        fn_handle_score    = lua_object["handle_score"];
         fn_draw_back     = lua_object["draw_back"];
         fn_draw_fore     = lua_object["draw_fore"];
         fn_draw_gauge    = lua_object["draw_gauge"];
@@ -126,6 +127,15 @@ void Background::handle_dan(PlayerNum player_num, const sol::table& state) {
     if (!result.valid()) {
         sol::error err = result;
         spdlog::error("Error calling handle_dan: {}", err.what());
+    }
+}
+
+void Background::handle_score(PlayerNum player_num, int score) {
+    if (!fn_handle_score.valid()) return;
+    auto result = fn_handle_score(lua_object, static_cast<int>(player_num), score);
+    if (!result.valid()) {
+        sol::error err = result;
+        spdlog::error("Error calling handle_score: {}", err.what());
     }
 }
 

--- a/src/objects/game/background.h
+++ b/src/objects/game/background.h
@@ -14,6 +14,7 @@ private:
     sol::protected_function fn_handle_song_end;
     sol::protected_function fn_handle_dan;
     sol::protected_function fn_handle_skip;
+    sol::protected_function fn_handle_score;
     sol::protected_function fn_draw_back;
     sol::protected_function fn_draw_fore;
     sol::protected_function fn_draw_gauge;
@@ -35,6 +36,9 @@ public:
     bool wants_dan() const { return fn_handle_dan.valid(); }
     void handle_skip(PlayerNum player_num, const sol::table& state);
     bool wants_skip() const { return fn_handle_skip.valid(); }
+    // Optional: the running score, sent whenever it changes (skins draw the
+    // score-rank badge from it).
+    void handle_score(PlayerNum player_num, int score);
     void draw_back();
     void draw_fore();
 

--- a/src/objects/game/player.cpp
+++ b/src/objects/game/player.cpp
@@ -403,6 +403,10 @@ void Player::update(double ms_from_start, double current_ms, std::optional<Backg
         gauge->update(current_ms);
         if (background.has_value()) {
             background->handle_gauge(player_num, gauge->get_length() / 100.0f, gauge->get_is_clear(), gauge->get_is_rainbow());
+            if (score != last_reported_score) {
+                last_reported_score = score;
+                background->handle_score(player_num, score);
+            }
         }
         bool gauge_full_now = gauge->get_is_rainbow();
         if (gauge_full_now && !was_gauge_full) {

--- a/src/objects/game/player.h
+++ b/src/objects/game/player.h
@@ -128,6 +128,7 @@ private:
     int bad_count;
     int combo;
     int score;
+    int last_reported_score = -1;   // last value sent to Background::handle_score
     int max_combo;
     int total_drumroll;
 


### PR DESCRIPTION
`Background:handle_score(player_num, score)` is called whenever a player's score changes (checked once per update, next to the gauge report), so a skin can show the arcade's score-rank badge (粋 / 雅 / 極) as the rank lines are crossed. Skins without the hook are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)