### PR TITLE
song select: expose SongSelectPlayer:difficulty_decided() to Lua

### DIFF
--- a/src/objects/song_select/file_navigator/box_lua_bindings.cpp
+++ b/src/objects/song_select/file_navigator/box_lua_bindings.cpp
@@ -117,6 +117,7 @@ void register_song_select_lua_bindings(sol::state& lua) {
     lua.new_usertype<SongSelectPlayer>("SongSelectPlayer",
         "selected_difficulty", [](SongSelectPlayer& self) { return (int)self.selected_difficulty; },
         "player_num",           [](SongSelectPlayer& self) { return (int)self.player_num; },
+        "difficulty_decided",   [](SongSelectPlayer& self) { return self.difficulty_decided(); },
         "neiro_active",         [](SongSelectPlayer& self) { return self.neiro_selector.has_value(); },
         "modifier_active",      [](SongSelectPlayer& self) { return self.modifier_selector.has_value(); },
         "modifier_offset",      [](SongSelectPlayer& self) -> sol::optional<float> {

--- a/src/objects/song_select/player.h
+++ b/src/objects/song_select/player.h
@@ -47,6 +47,9 @@ public:
 
     void update(double current_time);
     bool is_voice_playing();
+    // true from the moment a course is confirmed (start voice playing or done) until
+    // reset_selection(); the skin swaps the course mark to its decided look on it
+    bool difficulty_decided() const { return selected_difficulty >= Difficulty::EASY && (voice_played || is_ready); }
 
     SongSelectState select_song();
     void sync_ura(bool ura);


### PR DESCRIPTION
Adds one read-only binding, `player:difficulty_decided()`, on `SongSelectPlayer`: true from the moment the player confirms a course (the start voice is playing or has finished) until `reset_selection()` clears it (course back / song change).

The Nijiiro skin uses it to switch the big translucent course mark behind the difficulty board to its decided look with the arcade's short pop animation once the course is locked in; the default skin is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)