### PR TITLE
Song select: keep the character still when the skin draws the option panel

### DIFF
--- a/src/objects/song_select/player.cpp
+++ b/src/objects/song_select/player.cpp
@@ -484,6 +484,9 @@ void SongSelectPlayer::draw(SongSelectState state, bool is_half, float diff_fade
             : -offset;
     }
 
+    // a skin that draws the option panel itself keeps the character where it is
+    if (option_panel_by_lua) offset = 0.0f;
+
     if (player_num == PlayerNum::P1) {
         nameplate.draw(tex.skin_config[SC::SONG_SELECT_NAMEPLATE_1P].x, tex.skin_config[SC::SONG_SELECT_NAMEPLATE_1P].y);
         chara->draw(tex.skin_config[SC::SONG_SELECT_CHARA_1P].x, tex.skin_config[SC::SONG_SELECT_CHARA_1P].y + (offset * 0.6f), 1.0f);
@@ -492,7 +495,17 @@ void SongSelectPlayer::draw(SongSelectState state, bool is_half, float diff_fade
         chara->draw(tex.skin_config[SC::SONG_SELECT_CHARA_2P].x, tex.skin_config[SC::SONG_SELECT_CHARA_2P].y + (offset * 0.6f), 1.0f);
     }
 
-    if (neiro_selector.has_value()    && !(script && script->draw_option_panel(this, 2))) neiro_selector->draw();
-    if (modifier_selector.has_value() && !(script && script->draw_option_panel(this, 1))) modifier_selector->draw();
+    bool panel_by_lua = false;
+    if (neiro_selector.has_value()) {
+        bool by_lua = script && script->draw_option_panel(this, 2);
+        if (!by_lua) neiro_selector->draw();
+        panel_by_lua = panel_by_lua || by_lua;
+    }
+    if (modifier_selector.has_value()) {
+        bool by_lua = script && script->draw_option_panel(this, 1);
+        if (!by_lua) modifier_selector->draw();
+        panel_by_lua = panel_by_lua || by_lua;
+    }
+    option_panel_by_lua = panel_by_lua;
     if (ura_switch.has_value()) ura_switch->draw();
 }

--- a/src/objects/song_select/player.h
+++ b/src/objects/song_select/player.h
@@ -42,6 +42,9 @@ public:
 
     SongSelectScript* script = nullptr;
     bool selector_handled_by_lua = false;
+    // set each frame from draw_option_panel: the skin drew the option panel itself, so
+    // the character stays put instead of riding the panel (the cabinet's Don does not move)
+    bool option_panel_by_lua = false;
 
     SongSelectPlayer(PlayerNum player_num);
 


### PR DESCRIPTION
When the modifier / neiro panel opens, `SongSelectPlayer::draw` lifts the player character by the panel's move animation (`offset * 0.6`). A skin that draws the option panel itself through `draw_option_panel` owns that presentation, and the arcade's character does not ride the panel, so this skips the lift whenever the script handled the panel that frame.

- `option_panel_by_lua` is set from the `draw_option_panel` results each frame and zeroes the character offset the next frame (the offset starts at 0 when a panel opens, so the one-frame latency is invisible).
- Skins that leave the panel to the engine (PyTaikoGreen) are unchanged.

Companion of the YataiDONNijiiro option panel work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)