### PR TITLE
Song select: leave the lower boxes in place at folder open when the skin draws the wheel

### DIFF
--- a/src/objects/song_select/file_navigator/navigator.cpp
+++ b/src/objects/song_select/file_navigator/navigator.cpp
@@ -1222,6 +1222,11 @@ void Navigator::begin_inline_load() {
     genre_bg.emplace(items[open_index]->text_name, items[open_index]->back_color,
                      items[open_index]->texture_index, approx_items * 100);
     is_processing = true;
+    // The boxes below the opened folder slide out of the way for the inline list.
+    // A skin that draws the wheel itself animates them on its own (the cabinet
+    // flies them out on the decide clip); the slide would take them off screen at
+    // once, before that animation can play, so leave their positions to the swap.
+    if (script && script->has_draw_box()) return;
     for (int i = 0; i < (int)items.size(); i++) {
         if (items[i]->position > items[open_index]->position)
             items[i]->move_box(tex.screen_width + 150, 600);

--- a/src/objects/song_select/song_select_script.h
+++ b/src/objects/song_select/song_select_script.h
@@ -31,6 +31,7 @@ public:
     void draw_top(float dan_progress);
 
     bool draw_box(BaseBox* box);
+    bool has_draw_box() const { return fn_draw_box.valid(); }   // the skin draws the wheel itself
     bool draw_box_bg(BaseBox* box);
     bool has_box_bg() const { return fn_draw_box_bg.valid(); }
     bool draw_background(Navigator* nav);


### PR DESCRIPTION
`Navigator::begin_inline_load` slides every box below the opened folder out of the way for the inline list. A skin that draws the wheel itself (has `draw_box`) animates those boxes on its own -- the cabinet flies them out on the decide clip -- and the engine's slide took them off screen at once, before that animation could play.

With a wheel-drawing skin their positions are now left alone until the content swap (`set_positions` on `loading_complete`) repositions everything. Skins without `draw_box` (PyTaikoGreen) keep the slide unchanged.

Adds `SongSelectScript::has_draw_box()`.

Companion of YataiDONNijiiro PR 22 (folder-open animation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)