### PR TITLE
Song select: the key that opens Song Search is not typed into it; Ctrl+V paste; trimmed query

### DIFF
--- a/src/objects/song_select/player.cpp
+++ b/src/objects/song_select/player.cpp
@@ -200,6 +200,7 @@ SongSelectState SongSelectPlayer::handle_input_browsing(double current_ms) {
         BaseBox* item = navigator.get_current_item();
         if (navigator.is_directory(item) && item->collection == COLLECTIONS[5]) {
             search_guard = true;
+            search_guard_until_ms = ray::GetTime() * 1000.0 + 150.0;
             return SongSelectState::SEARCHING;
         }
         return select_song();
@@ -223,6 +224,25 @@ std::optional<std::pair<int,int>> SongSelectPlayer::handle_input_diff_sort(DiffS
     return std::nullopt;
 }
 
+// Strip leading / trailing blanks: ASCII whitespace and the ideographic space U+3000.
+static std::string trim_search(std::string s) {
+    auto blank_at = [&](size_t i, size_t& len) {
+        unsigned char b = (unsigned char)s[i];
+        if (b == ' ' || b == '\t' || b == '\r' || b == '\n') { len = 1; return true; }
+        if (b == 0xE3 && i + 2 < s.size() && (unsigned char)s[i + 1] == 0x80 && (unsigned char)s[i + 2] == 0x80) { len = 3; return true; }
+        return false;
+    };
+    size_t len = 0;
+    while (!s.empty() && blank_at(0, len)) s.erase(0, len);
+    for (;;) {
+        if (s.empty()) break;
+        if (s.size() >= 3 && blank_at(s.size() - 3, len) && len == 3) { s.resize(s.size() - 3); continue; }
+        if (blank_at(s.size() - 1, len) && len == 1) { s.pop_back(); continue; }
+        break;
+    }
+    return s;
+}
+
 static bool any_don_key_down(PlayerNum player_num) {
     const auto& c = *global_data.config;
     auto down = [](const std::vector<int>& keys) {
@@ -236,10 +256,24 @@ static bool any_don_key_down(PlayerNum player_num) {
 
 std::optional<std::string> SongSelectPlayer::handle_input_search() {
     if (search_guard) {
-        // The don key that opened the box (F/J) arrives as a typed character a frame
-        // later, and repeats while held: swallow everything until every don key is up.
+        // The don press is seen by the input thread a few ms before raylib's own key state
+        // and the typed character catch up, so the opening keystroke (F/J) would land in the
+        // query. Swallow typed input for a short grace period and until every don key is up.
         while (ray::GetCharPressed() > 0) {}
-        if (!any_don_key_down(player_num)) search_guard = false;
+        if (ray::GetTime() * 1000.0 >= search_guard_until_ms && !any_don_key_down(player_num))
+            search_guard = false;
+        return std::nullopt;
+    }
+    // Ctrl+V pastes the clipboard (first line only, UTF-8 as raylib hands it over).
+    if ((ray::IsKeyDown(ray::KEY_LEFT_CONTROL) || ray::IsKeyDown(ray::KEY_RIGHT_CONTROL)) && ray::IsKeyPressed(ray::KEY_V)) {
+        const char* clip = ray::GetClipboardText();
+        if (clip) {
+            std::string s(clip);
+            const size_t eol = s.find_first_of("\r\n");
+            if (eol != std::string::npos) s.resize(eol);
+            search_string += s;
+        }
+        while (ray::GetCharPressed() > 0) {}   // the 'v' itself is not typed
         return std::nullopt;
     }
     if (ray::IsKeyPressed(ray::KEY_BACKSPACE)) {
@@ -250,7 +284,7 @@ std::optional<std::string> SongSelectPlayer::handle_input_search() {
                || is_l_don_pressed(player_num) || is_r_don_pressed(player_num)
 #endif
     ) {
-        std::string result = search_string;
+        std::string result = trim_search(search_string);
         search_string = "";
         clear_input_buffers();
         return result;
@@ -259,7 +293,7 @@ std::optional<std::string> SongSelectPlayer::handle_input_search() {
     int key = ray::GetCharPressed();
     while (key > 0) {
         if (key == '\n' || key == '\r') {
-            std::string result = search_string;
+            std::string result = trim_search(search_string);
             search_string = "";
             clear_input_buffers();
             return result;

--- a/src/objects/song_select/player.cpp
+++ b/src/objects/song_select/player.cpp
@@ -198,8 +198,10 @@ SongSelectState SongSelectPlayer::handle_input_browsing(double current_ms) {
 
     if (!navigated && (l_don || r_don)) {
         BaseBox* item = navigator.get_current_item();
-        if (navigator.is_directory(item) && item->collection == COLLECTIONS[5])
+        if (navigator.is_directory(item) && item->collection == COLLECTIONS[5]) {
+            search_guard = true;
             return SongSelectState::SEARCHING;
+        }
         return select_song();
     }
     return SongSelectState::BROWSING;
@@ -221,7 +223,25 @@ std::optional<std::pair<int,int>> SongSelectPlayer::handle_input_diff_sort(DiffS
     return std::nullopt;
 }
 
+static bool any_don_key_down(PlayerNum player_num) {
+    const auto& c = *global_data.config;
+    auto down = [](const std::vector<int>& keys) {
+        for (int k : keys) if (ray::IsKeyDown(k)) return true;
+        return false;
+    };
+    if (player_num != PlayerNum::P2 && (down(c.keys_1p.left_don) || down(c.keys_1p.right_don))) return true;
+    if (player_num != PlayerNum::P1 && (down(c.keys_2p.left_don) || down(c.keys_2p.right_don))) return true;
+    return false;
+}
+
 std::optional<std::string> SongSelectPlayer::handle_input_search() {
+    if (search_guard) {
+        // The don key that opened the box (F/J) arrives as a typed character a frame
+        // later, and repeats while held: swallow everything until every don key is up.
+        while (ray::GetCharPressed() > 0) {}
+        if (!any_don_key_down(player_num)) search_guard = false;
+        return std::nullopt;
+    }
     if (ray::IsKeyPressed(ray::KEY_BACKSPACE)) {
         if (!search_string.empty())
             search_string.pop_back();

--- a/src/objects/song_select/player.h
+++ b/src/objects/song_select/player.h
@@ -23,6 +23,9 @@ public:
     int ura_toggle;
     bool diff_select_move_right;
     std::string search_string;
+    // Set when a don key opens Song Search: typed characters are dropped until that key
+    // (and any other don key) is released, so the opening keystroke is not typed.
+    bool search_guard = false;
 
     std::optional<NeiroSelector> neiro_selector;
     std::optional<ModifierSelector> modifier_selector;

--- a/src/objects/song_select/player.h
+++ b/src/objects/song_select/player.h
@@ -26,6 +26,7 @@ public:
     // Set when a don key opens Song Search: typed characters are dropped until that key
     // (and any other don key) is released, so the opening keystroke is not typed.
     bool search_guard = false;
+    double search_guard_until_ms = 0.0;
 
     std::optional<NeiroSelector> neiro_selector;
     std::optional<ModifierSelector> modifier_selector;

--- a/src/scenes/song_select.cpp
+++ b/src/scenes/song_select.cpp
@@ -248,6 +248,9 @@ std::optional<Screens> SongSelectScreen::update() {
             diff_select_timer = std::make_unique<Timer>(60, current_time, [this]() { select_song((SongBox*)navigator.get_current_item()); });
         } else if (state == SongSelectState::SEARCHING) {
             search_box.emplace();
+            // The don key that opened the search (F/J) is also a typed character still
+            // queued in raylib's char buffer; drop it so it does not land in the query.
+            while (ray::GetCharPressed() > 0) {}
             android_set_keyboard_visible(true);
         } else if (state == SongSelectState::DAN_SELECTED) {
             dan_transition.emplace();

--- a/src/scenes/song_select_2p.cpp
+++ b/src/scenes/song_select_2p.cpp
@@ -134,6 +134,9 @@ std::optional<Screens> SongSelect2PScreen::update() {
         script->restart_text_fade();
         if (state == SongSelectState::SEARCHING) {
             search_box.emplace();
+            // The don key that opened the search (F/J) is also a typed character still
+            // queued in raylib's char buffer; drop it so it does not land in the query.
+            while (ray::GetCharPressed() > 0) {}
         }
     }
 


### PR DESCRIPTION
Opening the Song Search folder with a keyboard don key (F / J) left that key's character in raylib's char queue, so the search box opened with an `f` or `j` already in the query. The char queue is drained when the box opens (1P and 2P song select).

🤖 Generated with [Claude Code](https://claude.com/claude-code)