### PR TITLE
Dan: per-song exam borders (value = [[red, gold] per song])

### DIFF
--- a/src/libs/global_data.h
+++ b/src/libs/global_data.h
@@ -56,6 +56,9 @@ struct Exam {
     // songs. Empty for the usual course-wide pair; red/gold above then hold song 1's.
     std::vector<int> song_red;
     std::vector<int> song_gold;
+    // An omitted gold border means "perfect": 0 for a less exam, 100 % gauge, every note
+    // for good / hit / combo. Stored as GOLD_FULL and resolved where the note count is known.
+    static constexpr int GOLD_FULL = -1;
     bool per_song() const { return !song_red.empty(); }
     // The exam as it applies to song i: red/gold swapped for that song's pair.
     Exam for_song(int i) const {

--- a/src/libs/global_data.h
+++ b/src/libs/global_data.h
@@ -51,6 +51,21 @@ struct Exam {
     int gold = 0;
     std::string range;  // "less" or "more"
     bool gothrough = true;
+    // Per-song borders (dan.json value = [[red, gold], ...], one pair per song): the
+    // cabinet's per-song conditions carry a different threshold for each of the three
+    // songs. Empty for the usual course-wide pair; red/gold above then hold song 1's.
+    std::vector<int> song_red;
+    std::vector<int> song_gold;
+    bool per_song() const { return !song_red.empty(); }
+    // The exam as it applies to song i: red/gold swapped for that song's pair.
+    Exam for_song(int i) const {
+        Exam ex = *this;
+        if (per_song() && i >= 0 && i < (int)song_red.size()) {
+            ex.red  = song_red[i];
+            ex.gold = i < (int)song_gold.size() ? song_gold[i] : song_red[i];
+        }
+        return ex;
+    }
 };
 
 inline std::string dan_bar_state(const Exam& exam, int value,

--- a/src/libs/global_data.h
+++ b/src/libs/global_data.h
@@ -67,6 +67,9 @@ struct Exam {
             ex.red  = song_red[i];
             ex.gold = i < (int)song_gold.size() ? song_gold[i] : song_red[i];
         }
+        // the view of one song is a plain pair again (captions print a single number)
+        ex.song_red.clear();
+        ex.song_gold.clear();
         return ex;
     }
 };

--- a/src/objects/game/exam_caption.h
+++ b/src/objects/game/exam_caption.h
@@ -10,7 +10,7 @@
 inline std::string exam_threshold_text(const TextureWrapper& tex,
                                        const std::string& type,
                                        const std::string& range,
-                                       int value,
+                                       const std::string& num,
                                        const std::string& lang) {
     const bool gauge = (type == "gauge");
     const bool less  = (range == "less");
@@ -22,7 +22,6 @@ inline std::string exam_threshold_text(const TextureWrapper& tex,
                     : less  ? "%s \xE6\x9C\xAA\xE6\xBA\x80"                       // "%s 未満"
                             : "%s \xE4\xBB\xA5\xE4\xB8\x8A";                      // "%s 以上"
     std::string fmt = tex.skin_text(key, lang, tex.skin_text(key, "ja", jp));
-    const std::string num = std::to_string(value);
     // Only "%s" is substituted; "%%" is an escaped percent (the en rows use it).
     std::string out;
     for (size_t i = 0; i < fmt.size(); i++) {
@@ -31,6 +30,19 @@ inline std::string exam_threshold_text(const TextureWrapper& tex,
         else out += fmt[i];
     }
     return out;
+}
+
+inline std::string exam_threshold_text(const TextureWrapper& tex, const std::string& type,
+                                       const std::string& range, int value, const std::string& lang) {
+    return exam_threshold_text(tex, type, range, std::to_string(value), lang);
+}
+
+// "154/28/0 以上" for a per-song border, the plain number otherwise.
+inline std::string exam_border_text(const TextureWrapper& tex, const Exam& exam, const std::string& lang) {
+    if (!exam.per_song()) return exam_threshold_text(tex, exam.type, exam.range, exam.red, lang);
+    std::string num;
+    for (size_t i = 0; i < exam.song_red.size(); i++) num += (i ? "/" : "") + std::to_string(exam.song_red[i]);
+    return exam_threshold_text(tex, exam.type, exam.range, num, lang);
 }
 
 class ExamCaptionCache {

--- a/src/objects/song_select/file_navigator/box_dan.cpp
+++ b/src/objects/song_select/file_navigator/box_dan.cpp
@@ -246,8 +246,7 @@ void DanBox::draw_exam_grid() {
         if (!bt) return false;
         const float ol = bt->outline >= 0 ? bt->outline : (3.0f / tex.screen_scale);
         OutlinedText* cap = exam_captions.get(
-            exam_threshold_text(tex, exam.type, exam.range, exam.red,
-                                global_data.config->general.language),
+            exam_border_text(tex, exam, global_data.config->general.language),
             bt->font_size > 0 ? bt->font_size : 28, ol);
         if (!cap) return false;
         const float pad = ExamCaptionCache::pad_for(ol, tex.screen_scale);

--- a/src/scenes/dan_result.cpp
+++ b/src/scenes/dan_result.cpp
@@ -697,7 +697,7 @@ void DanResultScreen::draw_exam_info(double fade, double now, float scale) {
                 if (sbt) {
                     if (sbt->outline >= 0) sbt_ol = sbt->outline;
                     scap = exam_captions.get(
-                        exam_threshold_text(tex, exam.type, exam.range, exam.red,
+                        exam_threshold_text(tex, exam.type, exam.range, exam.for_song(j).red,
                                             global_data.config->general.language),
                         sbt->font_size > 0 ? sbt->font_size : 20, sbt_ol);
                 }
@@ -706,7 +706,7 @@ void DanResultScreen::draw_exam_info(double fade, double now, float scale) {
                     scap->draw({.x = sbt->x + sx - scap->width + pad,
                                 .y = sbt->y - pad + y, .fade = fade});
                 } else {
-                    const std::string bs = std::to_string(exam.red);
+                    const std::string bs = std::to_string(exam.for_song(j).red);
                     const float bx = sx;
                     digits_left(bs, bx, y, border_pitch * sub_border_scale,
                                 border_id, sub_bd_pen, scale * sub_border_scale);
@@ -906,7 +906,8 @@ void DanResultScreen::draw_page2(double fade, double now) {
         bool all_gold   = !any_failed && !rd.exams.empty() && !rd.exam_data.empty();
         if (all_gold) {
             for (int i = 0; i < (int)rd.exams.size() && i < (int)rd.exam_data.size(); i++) {
-                if (rd.exam_data[i].progress < (float)rd.exams[i].gold / (float)(rd.exams[i].red > 0 ? rd.exams[i].red : 1)) {
+                // the verdict tier already folds per-song borders and the less/more sense
+                if (rd.exam_data[i].tier < 2) {
                     all_gold = false; break;
                 }
             }

--- a/src/scenes/dan_select.cpp
+++ b/src/scenes/dan_select.cpp
@@ -43,15 +43,15 @@ Exam DanNavigator::parse_exam(const rapidjson::Value& e) {
         for (auto& pair : e["value"].GetArray()) {
             if (!pair.IsArray() || pair.Size() < 1 || !pair[0].IsInt()) continue;
             const int red  = pair[0].GetInt();
-            const int gold = pair.Size() >= 2 && pair[1].IsInt() ? pair[1].GetInt() : red;
+            const int gold = pair.Size() >= 2 && pair[1].IsInt() ? pair[1].GetInt() : Exam::GOLD_FULL;
             exam.song_red.push_back(red);
             exam.song_gold.push_back(gold);
         }
         if (!exam.song_red.empty()) { exam.red = exam.song_red[0]; exam.gold = exam.song_gold[0]; }
         exam.gothrough = false;   // a per-song border is judged per song by definition
-    } else if (e.HasMember("value") && e["value"].IsArray() && e["value"].Size() >= 2) {
+    } else if (e.HasMember("value") && e["value"].IsArray() && e["value"].Size() >= 1 && e["value"][0].IsInt()) {
         exam.red  = e["value"][0].GetInt();
-        exam.gold = e["value"][1].GetInt();
+        exam.gold = e["value"].Size() >= 2 && e["value"][1].IsInt() ? e["value"][1].GetInt() : Exam::GOLD_FULL;
     }
     if (e.HasMember("gothrough") && e["gothrough"].IsBool())
         exam.gothrough = e["gothrough"].GetBool();

--- a/src/scenes/dan_select.cpp
+++ b/src/scenes/dan_select.cpp
@@ -38,7 +38,18 @@ Exam DanNavigator::parse_exam(const rapidjson::Value& e) {
     Exam exam;
     exam.type  = e["type"].GetString();
     exam.range = e["range"].GetString();
-    if (e.HasMember("value") && e["value"].IsArray() && e["value"].Size() >= 2) {
+    if (e.HasMember("value") && e["value"].IsArray() && e["value"].Size() >= 1 && e["value"][0].IsArray()) {
+        // per-song borders: [[red, gold], [red, gold], [red, gold]] (gold optional)
+        for (auto& pair : e["value"].GetArray()) {
+            if (!pair.IsArray() || pair.Size() < 1 || !pair[0].IsInt()) continue;
+            const int red  = pair[0].GetInt();
+            const int gold = pair.Size() >= 2 && pair[1].IsInt() ? pair[1].GetInt() : red;
+            exam.song_red.push_back(red);
+            exam.song_gold.push_back(gold);
+        }
+        if (!exam.song_red.empty()) { exam.red = exam.song_red[0]; exam.gold = exam.song_gold[0]; }
+        exam.gothrough = false;   // a per-song border is judged per song by definition
+    } else if (e.HasMember("value") && e["value"].IsArray() && e["value"].Size() >= 2) {
         exam.red  = e["value"][0].GetInt();
         exam.gold = e["value"][1].GetInt();
     }

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -45,16 +45,20 @@ void DanGameScreen::init_dan() {
     SessionData& sd = global_data.session_data[(int)global_data.player_num];
 
     total_notes = 0;
+    song_note_counts.clear();
     for (const auto& entry : sd.selected_dan) {
+        int count = 0;
         try {
             SongParser sp(entry.song_path);
             auto [notes, bm, be, bn] = sp.notes_to_position(entry.difficulty);
             for (const Note& n : notes.notes)
-                if (n.type >= NoteType::DON && n.type <= NoteType::KAT_L) total_notes++;
+                if (n.type >= NoteType::DON && n.type <= NoteType::KAT_L) count++;
             for (auto& sec : bm)
                 for (const Note& n : sec.notes)
-                    if (n.type >= NoteType::DON && n.type <= NoteType::KAT_L) total_notes++;
+                    if (n.type >= NoteType::DON && n.type <= NoteType::KAT_L) count++;
         } catch (...) {}
+        song_note_counts.push_back(count);
+        total_notes += count;
     }
     if (total_notes == 0) total_notes = 1;
 
@@ -208,6 +212,23 @@ int DanGameScreen::get_exam_progress_song(const Exam& exam, int song_idx) {
     return get_exam_progress(exam);                 // gauge (course-wide by nature)
 }
 
+Exam DanGameScreen::exam_for(const Exam& exam, int song_idx) const {
+    Exam ex = song_idx >= 0 ? exam.for_song(song_idx) : exam;
+    if (ex.gold != Exam::GOLD_FULL) return ex;
+    if (ex.range == "less") {
+        ex.gold = 1;                                   // gold = none at all (value < 1)
+    } else if (ex.type == "gauge") {
+        ex.gold = 100;
+    } else if (ex.type == "judgeperfect" || ex.type == "hit" || ex.type == "combo") {
+        int notes = total_notes;
+        if (song_idx >= 0 && song_idx < (int)song_note_counts.size()) notes = song_note_counts[song_idx];
+        ex.gold = std::max(ex.red, notes);              // every note
+    } else {
+        ex.gold = ex.red;                               // score / renda: no perfect value, no gold tier
+    }
+    return ex;
+}
+
 DanInfoCache DanGameScreen::calculate_dan_info() {
     DanInfoCache cache;
     Player* p = players[0].get();
@@ -222,7 +243,7 @@ DanInfoCache DanGameScreen::calculate_dan_info() {
         DanExamInfo info;
         info.exam_type  = exam.type;
         info.exam_range = exam.range;
-        info.red_value  = exam.gothrough ? exam.red : exam.for_song(std::min(song_index, 2)).red;
+        info.red_value  = exam.gothrough ? exam.red : exam_for(exam, std::min(song_index, 2)).red;
 
         int val = get_exam_progress(exam);
         float progress = (exam.red > 0) ? (float)val / exam.red : 0.0f;
@@ -242,13 +263,13 @@ DanInfoCache DanGameScreen::calculate_dan_info() {
         if (progress >= 1.0f)        info.bar_texture = "exam_max";
         else if (progress >= 0.5f)   info.bar_texture = "exam_gold";
         else                          info.bar_texture = "exam_red";
-        info.bar_state = dan_bar_state(exam, val, true, near_end, just_before_end);
+        info.bar_state = dan_bar_state(exam_for(exam, -1), val, true, near_end, just_before_end);
 
         info.gothrough  = exam.gothrough;
         info.song_count = std::min(song_index, 3);
         if (!exam.gothrough) {
             for (int j = 0; j < 3 && j <= song_index; j++) {
-                const Exam ex = exam.for_song(j);
+                const Exam ex = exam_for(exam, j);
                 int   sv = get_exam_progress_song(exam, j);
                 float sp = (ex.red > 0) ? (float)sv / ex.red : 0.0f;
                 if (ex.range == "less") { sp = 1.0f - sp; sv = std::max(0, ex.red - sv); }
@@ -279,7 +300,7 @@ void DanGameScreen::check_exam_failures(bool course_finished, bool song_finished
     for (int i = 0; i < (int)exams.size(); i++) {
         if (exam_failed[i]) continue;
         const Exam& base = exams[i];
-        const Exam  exam = base.gothrough ? base : base.for_song(std::min(song_index, 2));
+        const Exam  exam = base.gothrough ? exam_for(base, -1) : exam_for(base, std::min(song_index, 2));
         int val = exam.gothrough ? get_exam_progress(exam)
                                   : get_exam_progress_song(exam, song_index);
         bool at_boundary = exam.gothrough ? course_finished
@@ -360,17 +381,17 @@ void DanGameScreen::save_result_data(bool all_failed) {
                 if (all_failed) {
                     re.tier = 0;
                 } else if (exam.gothrough) {
-                    re.tier = exam_tier(exam, get_exam_progress(exam));
+                    re.tier = exam_tier(exam_for(exam, -1), get_exam_progress(exam));
                 } else {
                     re.tier = 2;
                     for (int j = 0; j < course_songs; j++)
-                        re.tier = std::min(re.tier, exam_tier(exam.for_song(j), get_exam_progress_song(exam, j)));
+                        re.tier = std::min(re.tier, exam_tier(exam_for(exam, j), get_exam_progress_song(exam, j)));
                 }
                 if (re.tier == 0) re.failed = true;
-                re.bar_state = dan_bar_state(exam, get_exam_progress(exam));
+                re.bar_state = dan_bar_state(exam_for(exam, -1), get_exam_progress(exam));
                 if (!exam.gothrough)
                     for (int j = 0; j < course_songs; j++)
-                        re.song_state[j] = dan_bar_state(exam.for_song(j), get_exam_progress_song(exam, j));
+                        re.song_state[j] = dan_bar_state(exam_for(exam, j), get_exam_progress_song(exam, j));
             }
             check = std::min(check, re.tier);
             sd.dan_result_data.exam_data.push_back(re);
@@ -586,12 +607,12 @@ void DanGameScreen::push_dan_state() {
         row["type"]     = info.exam_type;
         row["range"]    = info.exam_range;
         row["red"]      = info.red_value;
-        row["gold"]     = (i < (int)exams.size()) ? exams[i].gold : 0;
+        row["gold"]     = (i < (int)exams.size()) ? exam_for(exams[i], exams[i].gothrough ? -1 : std::min(song_index, 2)).gold : 0;
         if (i < (int)exams.size() && exams[i].per_song()) {
             sol::table sr = lua.create_table(), sg = lua.create_table();
             for (int j = 0; j < (int)exams[i].song_red.size(); j++) {
                 sr[j + 1] = exams[i].song_red[j];
-                sg[j + 1] = exams[i].for_song(j).gold;
+                sg[j + 1] = exam_for(exams[i], j).gold;
             }
             row["song_red"]  = sr;
             row["song_gold"] = sg;

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -222,7 +222,7 @@ DanInfoCache DanGameScreen::calculate_dan_info() {
         DanExamInfo info;
         info.exam_type  = exam.type;
         info.exam_range = exam.range;
-        info.red_value  = exam.red;
+        info.red_value  = exam.gothrough ? exam.red : exam.for_song(std::min(song_index, 2)).red;
 
         int val = get_exam_progress(exam);
         float progress = (exam.red > 0) ? (float)val / exam.red : 0.0f;
@@ -248,13 +248,14 @@ DanInfoCache DanGameScreen::calculate_dan_info() {
         info.song_count = std::min(song_index, 3);
         if (!exam.gothrough) {
             for (int j = 0; j < 3 && j <= song_index; j++) {
+                const Exam ex = exam.for_song(j);
                 int   sv = get_exam_progress_song(exam, j);
-                float sp = (exam.red > 0) ? (float)sv / exam.red : 0.0f;
-                if (exam.range == "less") { sp = 1.0f - sp; sv = std::max(0, exam.red - sv); }
+                float sp = (ex.red > 0) ? (float)sv / ex.red : 0.0f;
+                if (ex.range == "less") { sp = 1.0f - sp; sv = std::max(0, ex.red - sv); }
                 info.song_value[j]    = std::max(0, sv);
                 info.song_progress[j] = std::max(0.0f, std::min(1.0f, sp));
                 const bool live_j = (j == song_index);
-                info.song_state[j]    = dan_bar_state(exam, get_exam_progress_song(exam, j),
+                info.song_state[j]    = dan_bar_state(ex, get_exam_progress_song(exam, j),
                                                       live_j, near_end, just_before_end);
             }
             int cur = std::min(song_index, 2);
@@ -277,7 +278,8 @@ void DanGameScreen::check_exam_failures(bool course_finished, bool song_finished
     const auto& exams = global_data.session_data[(int)global_data.player_num].selected_dan_exam;
     for (int i = 0; i < (int)exams.size(); i++) {
         if (exam_failed[i]) continue;
-        const Exam& exam = exams[i];
+        const Exam& base = exams[i];
+        const Exam  exam = base.gothrough ? base : base.for_song(std::min(song_index, 2));
         int val = exam.gothrough ? get_exam_progress(exam)
                                   : get_exam_progress_song(exam, song_index);
         bool at_boundary = exam.gothrough ? course_finished
@@ -362,13 +364,13 @@ void DanGameScreen::save_result_data(bool all_failed) {
                 } else {
                     re.tier = 2;
                     for (int j = 0; j < course_songs; j++)
-                        re.tier = std::min(re.tier, exam_tier(exam, get_exam_progress_song(exam, j)));
+                        re.tier = std::min(re.tier, exam_tier(exam.for_song(j), get_exam_progress_song(exam, j)));
                 }
                 if (re.tier == 0) re.failed = true;
                 re.bar_state = dan_bar_state(exam, get_exam_progress(exam));
                 if (!exam.gothrough)
                     for (int j = 0; j < course_songs; j++)
-                        re.song_state[j] = dan_bar_state(exam, get_exam_progress_song(exam, j));
+                        re.song_state[j] = dan_bar_state(exam.for_song(j), get_exam_progress_song(exam, j));
             }
             check = std::min(check, re.tier);
             sd.dan_result_data.exam_data.push_back(re);
@@ -585,6 +587,15 @@ void DanGameScreen::push_dan_state() {
         row["range"]    = info.exam_range;
         row["red"]      = info.red_value;
         row["gold"]     = (i < (int)exams.size()) ? exams[i].gold : 0;
+        if (i < (int)exams.size() && exams[i].per_song()) {
+            sol::table sr = lua.create_table(), sg = lua.create_table();
+            for (int j = 0; j < (int)exams[i].song_red.size(); j++) {
+                sr[j + 1] = exams[i].song_red[j];
+                sg[j + 1] = exams[i].for_song(j).gold;
+            }
+            row["song_red"]  = sr;
+            row["song_gold"] = sg;
+        }
         row["value"]    = info.counter_value;
         row["progress"] = info.progress;
         row["bar"]      = info.bar_texture;

--- a/src/scenes/game_dan.h
+++ b/src/scenes/game_dan.h
@@ -59,6 +59,10 @@ private:
     int prev_score = 0;
     struct SongStats { int good = 0, ok = 0, bad = 0, drumroll = 0, score = 0, max_combo = 0; };
     std::vector<SongStats> song_stats;
+    std::vector<int> song_note_counts;   // notes per course song, for the "perfect" gold border
+    // exam as judged for song_idx (-1 = course-wide): per-song pair applied and an omitted
+    // gold border resolved to the perfect value
+    Exam exam_for(const Exam& exam, int song_idx) const;
     int song_max_combo = 0;
     std::string current_song_title;
 


### PR DESCRIPTION
The cabinet's per-song dan conditions (e.g. 連打 on 六段以上, 可 on 十段) carry a different red/gold threshold for each of the three songs. `dan.json` could only hold one pair per exam, so those courses could not be written down.

An exam's `value` may now be a list of `[red, gold]` pairs, one per song. The shape of `value` decides how the exam is judged: one pair = the whole course, one pair per song = each song on its own (the old `gothrough` key is no longer read; no shipped file used it). `gold` may be omitted (`[red]`), meaning *perfect*: 0 for a less exam, 100 % gauge, every note for good / hit / combo; score and renda keep no gold tier.

```json
{ "type": "renda", "range": "more", "value": [[154, 165], [28, 30], [0, 0]] }
{ "type": "judgebad", "range": "less", "value": [6] }
```

Per-song pairs apply everywhere the threshold matters: HUD progress / counter, fail checks, verdict tiers, result-screen per-song rows, and the select-board caption / grid segments. The Lua dan state rows gain `song_red` / `song_gold` arrays. The gold verdict on the result screen uses the per-exam tier instead of recomputing `progress >= gold/red`, which was wrong for `less` exams. Course-wide exams (`value: [red, gold]`) are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)