### PR TITLE
Dan: classic HUD layout for skins without the newer art; board hides the gauge row at 4+ conditions

### DIFF
--- a/src/objects/song_select/file_navigator/box_dan.cpp
+++ b/src/objects/song_select/file_navigator/box_dan.cpp
@@ -1,4 +1,5 @@
 #include "box_dan.h"
+TexID exam_icon_id(TexID preferred, const char* folder);
 #include "../../../libs/song_parser.h"
 #include "../../../libs/scores.h"
 #include <algorithm>
@@ -355,7 +356,7 @@ void DanBox::draw_exam_box() {
         };
         auto icon_it = exam_icons.find(exam.type);
         if (icon_it != exam_icons.end())
-            tex.draw_texture(icon_it->second, {.y=y, .fade=f});
+            tex.draw_texture(exam_icon_id(icon_it->second, "yellow_box"), {.y=y, .fade=f});
 
         float x_offset = 0;
         if (exam.type == "gauge") {

--- a/src/objects/song_select/file_navigator/box_dan.cpp
+++ b/src/objects/song_select/file_navigator/box_dan.cpp
@@ -302,10 +302,11 @@ void DanBox::draw_exam_grid() {
                 const int frame = exam.gothrough ? 0 : (k + 1);
                 draw_abs("yellow_box/exam_seg_label",
                          BX + seg_x + seg_dx * k, BY + seg_y, f, frame);
-                if (!draw_value_text(exam, seg_bt,
+                const Exam seg_exam = exam.for_song(k);   // per-song borders: this song's pair
+                if (!draw_value_text(seg_exam, seg_bt,
                                      BX + (seg_bt ? seg_bt->x : 0.0f) + seg_dx * k,
                                      BY + (seg_bt ? seg_bt->y : 0.0f)))
-                    draw_value(exam, BX + val_x + seg_dx * k, BY + val_y);
+                    draw_value(seg_exam, BX + val_x + seg_dx * k, BY + val_y);
             }
         }
         if (!left) right_row++;
@@ -330,8 +331,14 @@ void DanBox::draw_exam_box() {
     float offset_y = tex.skin_config[SC::DAN_EXAM_INFO].y;
     float margin   = tex.skin_config[SC::EXAM_COUNTER_MARGIN].x;
 
-    for (int i = 0; i < (int)exams.size(); i++) {
-        const Exam& exam = exams[i];
+    // Four or more conditions do not fit the board: drop the soul-gauge row (it is the
+    // one condition every course carries and the gauge itself shows it in game).
+    std::vector<const Exam*> shown;
+    for (const Exam& e : exams)
+        if (!(exams.size() >= 4 && e.type == "gauge")) shown.push_back(&e);
+    if ((int)shown.size() > 3) shown.resize(3);
+    for (int i = 0; i < (int)shown.size(); i++) {
+        const Exam& exam = *shown[i];
         float y = i * offset_y;
         tex.draw_texture(YELLOW_BOX::JUDGE_BOX, {.y=y, .fade=f});
 

--- a/src/scenes/dan_result.cpp
+++ b/src/scenes/dan_result.cpp
@@ -1,4 +1,5 @@
 #include "dan_result.h"
+TexID exam_icon_id(TexID preferred, const char* folder);
 #include <cmath>
 #include "../libs/input.h"
 #include "../libs/scores.h"
@@ -739,7 +740,7 @@ void DanResultScreen::draw_exam_info(double fade, double now, float scale) {
         };
         auto icon_it = icon_ids.find(exam.type);
         if (icon_it != icon_ids.end())
-            tex.draw_texture(icon_it->second, {.scale=scale, .y=y, .fade=fade});
+            tex.draw_texture(exam_icon_id(icon_it->second, "exam_info"), {.scale=scale, .y=y, .fade=fade});
 
         if (exam.gothrough || tamashii_row) {
         const std::string red_str = std::to_string(exam.red);

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -610,6 +610,57 @@ void DanGameScreen::draw_exam_row(const DanExamInfo& info, const Exam& exam, int
     const SkinInfo* vm = tex.skin_entry("dan_value_counter_margin");
     float value_margin = vm ? vm->x : border_margin;
 
+    auto have_tex = [&](TexID id) { return tex.textures.find((uint32_t)id) != tex.textures.end(); };
+    if (!have_tex(DAN_INFO::EXAM_BORDER_COUNTER)) {
+        // Classic HUD (PyTaikoGreen and other skins made before the Nijiiro rework): the
+        // row as it was drawn then - background, overlay 1, one bar picked by progress
+        // (exam_red / exam_gold / exam_max), icon shifted left of the border digits, the
+        // border digits and 以上/未満 mark, overlay 2, the live value on value_counter index 1.
+        const float score_margin = tex.skin_config[SC::DAN_SCORE_BOX_MARGIN].x;
+        tex.draw_texture(DAN_INFO::EXAM_BG,        {.y = y});
+        tex.draw_texture(DAN_INFO::EXAM_OVERLAY_1, {.y = y});
+        static const std::unordered_map<std::string, TexID> classic_bars = {
+            {"exam_red",  DAN_INFO::EXAM_RED},
+            {"exam_gold", DAN_INFO::EXAM_GOLD},
+            {"exam_max",  DAN_INFO::EXAM_MAX},
+        };
+        auto bar_it = classic_bars.find(info.bar_texture);
+        if (exam_failed[index])
+            tex.draw_texture(DAN_INFO::EXAM_FAIL, {.y = y, .x2 = info.bar_width});
+        else if (bar_it != classic_bars.end())
+            tex.draw_texture(bar_it->second, {.y = y, .x2 = info.bar_width});
+        static const std::unordered_map<std::string, TexID> classic_icons = {
+            {"gauge",        DAN_INFO::EXAM_GAUGE},
+            {"combo",        DAN_INFO::EXAM_COMBO},
+            {"hit",          DAN_INFO::EXAM_HIT},
+            {"judgebad",     DAN_INFO::EXAM_JUDGEBAD},
+            {"judgegood",    DAN_INFO::EXAM_JUDGEGOOD},
+            {"judgeperfect", DAN_INFO::EXAM_JUDGEPERFECT},
+            {"score",        DAN_INFO::EXAM_SCORE},
+            {"renda",        DAN_INFO::EXAM_ROLL},
+        };
+        const std::string red_str = std::to_string(info.red_value);
+        const float type_x = -(float)red_str.size() * 20.0f * tex.screen_scale;
+        auto ic = classic_icons.find(info.exam_type);
+        if (ic != classic_icons.end())
+            tex.draw_texture(ic->second, {.x = type_x, .y = y});
+        const float gauge_shift = (info.exam_type == "gauge") ? -score_margin : 0.0f;
+        draw_digit_counter(red_str, score_margin, DAN_INFO::VALUE_COUNTER, 0, y, gauge_shift);
+        if (info.exam_range == "less")      tex.draw_texture(DAN_INFO::EXAM_LESS, {.y = y});
+        else if (info.exam_range == "more") tex.draw_texture(DAN_INFO::EXAM_MORE, {.y = y});
+        tex.draw_texture(DAN_INFO::EXAM_OVERLAY_2, {.y = y});
+        if (exam_failed[index]) {
+            tex.draw_texture(DAN_INFO::EXAM_FAILED, {.y = y});
+        } else {
+            draw_digit_counter(std::to_string(info.counter_value), score_margin, DAN_INFO::VALUE_COUNTER, 1, y);
+            if (info.exam_type == "gauge") {
+                tex.draw_texture(DAN_INFO::EXAM_PERCENT, {.y = y, .index = 0});
+                tex.draw_texture(DAN_INFO::EXAM_PERCENT, {.y = y, .index = 1});
+            }
+        }
+        return;
+    }
+
     tex.draw_texture(DAN_INFO::EXAM_BG, {.y = y});
     tex.draw_texture(DAN_INFO::EXAM_BADGE,
                      {.frame = info.gothrough ? 0 : 1 + std::min(song_index, 2), .y = y});
@@ -679,31 +730,6 @@ void DanGameScreen::draw_exam_row(const DanExamInfo& info, const Exam& exam, int
         {"renda",        DAN_INFO::EXAM_ROLL},
     };
     auto icon_it = exam_ids.find(info.exam_type);
-    const bool classic = !have(DAN_INFO::EXAM_BORDER_COUNTER);
-    if (classic) {
-        // Classic HUD (PyTaikoGreen): the border digits share value_counter (index 0) and
-        // sit left of the 以上/未満 mark, the icon shifts left to make room, and the live
-        // value uses value_counter index 1. Same layout as before the Nijiiro rework.
-        const float score_margin = tex.skin_config[SC::DAN_SCORE_BOX_MARGIN].x;
-        const std::string red_str = std::to_string(info.red_value);
-        const float type_x = -(float)red_str.size() * 20.0f * tex.screen_scale;
-        if (icon_it != exam_ids.end())
-            tex.draw_texture(icon_it->second, {.x = type_x, .y = y});
-        const float gauge_shift = (info.exam_type == "gauge") ? -score_margin : 0.0f;
-        draw_digit_counter(red_str, score_margin, DAN_INFO::VALUE_COUNTER, 0, y, gauge_shift);
-        if (info.exam_range == "less")      tex.draw_texture(DAN_INFO::EXAM_LESS, {.y = y});
-        else if (info.exam_range == "more") tex.draw_texture(DAN_INFO::EXAM_MORE, {.y = y});
-        if (exam_failed[index]) {
-            tex.draw_texture(DAN_INFO::EXAM_FAILED, {.y = y});
-        } else {
-            draw_digit_counter(std::to_string(info.counter_value), score_margin, DAN_INFO::VALUE_COUNTER, 1, y);
-            if (info.exam_type == "gauge") {
-                tex.draw_texture(DAN_INFO::EXAM_PERCENT, {.y = y, .index = 0});
-                tex.draw_texture(DAN_INFO::EXAM_PERCENT, {.y = y, .index = 1});
-            }
-        }
-        return;
-    }
     if (icon_it != exam_ids.end())
         tex.draw_texture(icon_it->second, {.y = y});
 

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -679,6 +679,31 @@ void DanGameScreen::draw_exam_row(const DanExamInfo& info, const Exam& exam, int
         {"renda",        DAN_INFO::EXAM_ROLL},
     };
     auto icon_it = exam_ids.find(info.exam_type);
+    const bool classic = !have(DAN_INFO::EXAM_BORDER_COUNTER);
+    if (classic) {
+        // Classic HUD (PyTaikoGreen): the border digits share value_counter (index 0) and
+        // sit left of the 以上/未満 mark, the icon shifts left to make room, and the live
+        // value uses value_counter index 1. Same layout as before the Nijiiro rework.
+        const float score_margin = tex.skin_config[SC::DAN_SCORE_BOX_MARGIN].x;
+        const std::string red_str = std::to_string(info.red_value);
+        const float type_x = -(float)red_str.size() * 20.0f * tex.screen_scale;
+        if (icon_it != exam_ids.end())
+            tex.draw_texture(icon_it->second, {.x = type_x, .y = y});
+        const float gauge_shift = (info.exam_type == "gauge") ? -score_margin : 0.0f;
+        draw_digit_counter(red_str, score_margin, DAN_INFO::VALUE_COUNTER, 0, y, gauge_shift);
+        if (info.exam_range == "less")      tex.draw_texture(DAN_INFO::EXAM_LESS, {.y = y});
+        else if (info.exam_range == "more") tex.draw_texture(DAN_INFO::EXAM_MORE, {.y = y});
+        if (exam_failed[index]) {
+            tex.draw_texture(DAN_INFO::EXAM_FAILED, {.y = y});
+        } else {
+            draw_digit_counter(std::to_string(info.counter_value), score_margin, DAN_INFO::VALUE_COUNTER, 1, y);
+            if (info.exam_type == "gauge") {
+                tex.draw_texture(DAN_INFO::EXAM_PERCENT, {.y = y, .index = 0});
+                tex.draw_texture(DAN_INFO::EXAM_PERCENT, {.y = y, .index = 1});
+            }
+        }
+        return;
+    }
     if (icon_it != exam_ids.end())
         tex.draw_texture(icon_it->second, {.y = y});
 
@@ -763,6 +788,13 @@ void DanGameScreen::draw_dan_info() {
     const SessionData& sd = global_data.session_data[(int)global_data.player_num];
 
     tex.draw_texture(DAN_INFO::TOTAL_NOTES, {});
+    // Skins built around the classic HUD (no exam_border_counter art, no Lua dan panel)
+    // still get the remaining-notes counter from the engine.
+    if (tex.textures.find((uint32_t)DAN_INFO::EXAM_BORDER_COUNTER) == tex.textures.end() &&
+        tex.textures.find((uint32_t)DAN_INFO::TOTAL_NOTES_COUNTER) != tex.textures.end()) {
+        draw_digit_counter(std::to_string(cache.remaining_notes), tex.skin_config[SC::DAN_TOTAL_NOTES_MARGIN].x,
+                           DAN_INFO::TOTAL_NOTES_COUNTER, 0, 0);
+    }
 
     float offset_y = dan_exam_info().y;
     const auto& exams = sd.selected_dan_exam;

--- a/src/scenes/game_dan.cpp
+++ b/src/scenes/game_dan.cpp
@@ -41,6 +41,15 @@ void DanGameScreen::on_screen_start() {
     allnet_indicator  = AllNetIcon();
 }
 
+// The drumroll condition icon is `exam_roll` in newer skins and `exam_drumroll` in older
+// ones; use whichever the active skin carries.
+TexID exam_icon_id(TexID preferred, const char* folder) {
+    if (tex.textures.find((uint32_t)preferred) != tex.textures.end()) return preferred;
+    const std::string alt = std::string(folder) + "/exam_drumroll";
+    if (tex.has_texture(alt)) return tex.get_enum(alt);
+    return preferred;
+}
+
 void DanGameScreen::init_dan() {
     SessionData& sd = global_data.session_data[(int)global_data.player_num];
 
@@ -643,7 +652,7 @@ void DanGameScreen::draw_exam_row(const DanExamInfo& info, const Exam& exam, int
         const float type_x = -(float)red_str.size() * 20.0f * tex.screen_scale;
         auto ic = classic_icons.find(info.exam_type);
         if (ic != classic_icons.end())
-            tex.draw_texture(ic->second, {.x = type_x, .y = y});
+            tex.draw_texture(exam_icon_id(ic->second, "dan_info"), {.x = type_x, .y = y});
         const float gauge_shift = (info.exam_type == "gauge") ? -score_margin : 0.0f;
         draw_digit_counter(red_str, score_margin, DAN_INFO::VALUE_COUNTER, 0, y, gauge_shift);
         if (info.exam_range == "less")      tex.draw_texture(DAN_INFO::EXAM_LESS, {.y = y});
@@ -731,7 +740,7 @@ void DanGameScreen::draw_exam_row(const DanExamInfo& info, const Exam& exam, int
     };
     auto icon_it = exam_ids.find(info.exam_type);
     if (icon_it != exam_ids.end())
-        tex.draw_texture(icon_it->second, {.y = y});
+        tex.draw_texture(exam_icon_id(icon_it->second, "dan_info"), {.y = y});
 
     const SkinInfo* bt = tex.skin_entry("dan_game_exam_border_text");
     OutlinedText* cap = nullptr;


### PR DESCRIPTION
Two dan display fixes:

**Classic HUD (PyTaikoGreen).** The Nijiiro HUD rework moved the border digits to a new `exam_border_counter` texture and the live value to `value_counter` index 0, and left the remaining-notes counter to the skin's Lua. Skins that do not carry that art (PyTaikoGreen) ended up with no border digits, the live value overlapping the 以上/未満 mark, and no remaining-notes counter. When `exam_border_counter` is absent the engine now draws the layout those skins were made for: border digits on `value_counter` index 0 left of the mark, icon shifted left, live value on index 1, remaining notes from the engine.

**Select board.** With four or more conditions the vertical list overflowed the board; the soul-gauge row is dropped in that case (every course has it and the gauge shows it in game), so the three meaningful conditions fit. On the grid board each per-song segment now shows that song's own border.

🤖 Generated with [Claude Code](https://claude.com/claude-code)