### PR TITLE
Dan select: courses grouped by their set folder

### DIFF
--- a/src/scenes/dan_select.cpp
+++ b/src/scenes/dan_select.cpp
@@ -1,4 +1,6 @@
 #include "dan_select.h"
+#include <tuple>
+#include <climits>
 #ifdef SUPPORT_FUMEN
 #include "../libs/optional/gen4.h"
 #include "../libs/optional/gen3.h"
@@ -236,23 +238,25 @@ std::vector<DanBoxData> DanNavigator::scan_all_data(const std::vector<fs::path>&
 void DanNavigator::publish(std::vector<DanBoxData>&& data) {
     boxes.clear();
     selected_index = 0;
+    // Order: courses grouped by the folder they sit in (the dan root's own courses first,
+    // then each version set such as "Nijiiro 2026" as one block), and inside a group by the
+    // leading number of the course folder, then by name. The cabinet lists one version at a
+    // time; here every set is listed, but never interleaved.
+    auto order_key = [](const DanBoxData& d) {
+        const std::string set  = d.json_path.parent_path().parent_path().string();
+        const std::string name = d.json_path.parent_path().filename().string();
+        size_t i = 0;
+        while (i < name.size() && (unsigned char)name[i] >= '0' && (unsigned char)name[i] <= '9') i++;
+        int num = INT_MAX;
+        if (i > 0) { try { num = std::stoi(name.substr(0, i)); } catch (...) {} }
+        return std::make_tuple(set, num, name);
+    };
+    std::stable_sort(data.begin(), data.end(),
+                     [&](const DanBoxData& x, const DanBoxData& y) { return order_key(x) < order_key(y); });
     boxes.reserve(data.size());
     for (const DanBoxData& d : data) boxes.push_back(make_box(d));
 
     if (boxes.empty()) { spdlog::warn("DanNavigator: no dan courses found"); return; }
-
-    auto order_key = [](const DanBox* b) -> std::pair<int, std::string> {
-        const std::string name = b->path.parent_path().filename().string();
-        size_t i = 0;
-        while (i < name.size() && (unsigned char)name[i] >= '0' && (unsigned char)name[i] <= '9') i++;
-        if (i == 0) return {INT_MAX, name};
-        try { return {std::stoi(name.substr(0, i)), name}; }
-        catch (...) { return {INT_MAX, name}; }
-    };
-    std::stable_sort(boxes.begin(), boxes.end(),
-                     [&](const std::unique_ptr<DanBox>& a, const std::unique_ptr<DanBox>& b) {
-                         return order_key(a.get()) < order_key(b.get());
-                     });
 
     set_positions(true, 0);
     boxes[selected_index]->expand_box();


### PR DESCRIPTION
Every `dan.json` under the dan root is still listed, but the order is now: the folder the course sits in first (the root's own courses, then each version set such as `Nijiiro 2026` as one block), then the course folder's leading number, then its name. Sets never interleave regardless of how they are numbered, which lets a converted version set live next to the built-in courses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)